### PR TITLE
chore: add /audit/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ build/
 /docs/
 /scripts/
 /data/
+/audit/
 PROGRESS_DASHBOARD.md
 *.jsonl
 


### PR DESCRIPTION
## Summary
- Adds `/audit/` to `.gitignore` so稽核過程檔（bucket_*、reverify_*、verify_new_*、new_questions_*、research_practice_pool_ux 等）不會進主倉庫。

## Why
這些是多代理稽核過程中產出的中間檔，只在本地分析用途；不屬於 production 資料。

## Stacked PRs that depend on this
- #TBD fix/c2-190-tier1-data-10-percent
- #TBD feat/visitor-counter-reliable-backend
- #TBD fix/quiz-data-audit-corrections
- #TBD chore/header-link-and-ai-model

## Test plan
- [ ] `git status` 在本地產生 audit/ 時，檔案不出現在未追蹤清單