### PR TITLE
feat: replace broken visitor counter backend

### DIFF
--- a/quiz-app/src/components/VisitorCounter/VisitorCounter.tsx
+++ b/quiz-app/src/components/VisitorCounter/VisitorCounter.tsx
@@ -1,5 +1,5 @@
 // 訪客計數器元件
-// 使用 CountAPI 替代服務進行真實計數
+// 以 Abacus (jasoncameron.dev) 為主，counterapi.dev 為備援；皆失敗時不顯示。
 import { useEffect, useState } from 'react';
 import './VisitorCounter.css';
 
@@ -10,71 +10,67 @@ interface VisitorCounterProps {
   counterKey?: string;
 }
 
-/**
- * 訪客計數器
- * 使用 api.counterapi.dev 進行真實計數
- */
+type Provider = 'abacus' | 'counterapi';
+
+interface ProviderResult {
+  count: number;
+  provider: Provider;
+}
+
+async function fromAbacus(ns: string, key: string, bump: boolean): Promise<ProviderResult> {
+  const endpoint = bump ? 'hit' : 'get';
+  const url = `https://abacus.jasoncameron.dev/${endpoint}/${encodeURIComponent(ns)}/${encodeURIComponent(key)}`;
+  const res = await fetch(url);
+  if (!res.ok) {
+    // 首次呼叫 get 會是 404，改用 hit 建立並遞增
+    if (endpoint === 'get' && res.status === 404) {
+      return fromAbacus(ns, key, true);
+    }
+    throw new Error(`abacus ${res.status}`);
+  }
+  const data = (await res.json()) as { value?: number };
+  if (typeof data.value !== 'number') throw new Error('abacus malformed');
+  return { count: data.value, provider: 'abacus' };
+}
+
+async function fromCounterApi(ns: string, key: string, bump: boolean): Promise<ProviderResult> {
+  const endpoint = bump ? 'up' : 'get';
+  const url = `https://api.counterapi.dev/v1/${encodeURIComponent(ns)}/${encodeURIComponent(key)}/${endpoint}`;
+  const res = await fetch(url);
+  if (!res.ok) throw new Error(`counterapi ${res.status}`);
+  const data = (await res.json()) as { count?: number };
+  if (typeof data.count !== 'number') throw new Error('counterapi malformed');
+  return { count: data.count, provider: 'counterapi' };
+}
+
 export function VisitorCounter({
   namespace = 'thc1006-ipas-nz',
   counterKey = 'visits',
 }: VisitorCounterProps) {
   const [count, setCount] = useState<number | null>(null);
   const [isLoading, setIsLoading] = useState(true);
-  const [error, setError] = useState(false);
 
   useEffect(() => {
     const sessionKey = `visited-${namespace}-${counterKey}`;
-    const hasVisitedThisSession = sessionStorage.getItem(sessionKey);
+    const visitedThisSession = sessionStorage.getItem(sessionKey) === 'true';
+    const shouldBump = !visitedThisSession;
 
-    const fetchCount = async () => {
+    const run = async () => {
       try {
-        // 使用 counterapi.dev (CountAPI 的替代服務)
-        const endpoint = hasVisitedThisSession ? 'get' : 'up';
-        const url = `https://api.counterapi.dev/v1/${namespace}/${counterKey}/${endpoint}`;
-
-        const response = await fetch(url);
-        if (!response.ok) {
-          throw new Error('Counter API error');
-        }
-
-        const data = await response.json();
-        setCount(data.count);
-
-        // 標記本次 session 已訪問，避免重複計數
-        if (!hasVisitedThisSession) {
-          sessionStorage.setItem(sessionKey, 'true');
-        }
+        const result = await fromAbacus(namespace, counterKey, shouldBump).catch(() =>
+          fromCounterApi(namespace, counterKey, shouldBump)
+        );
+        setCount(result.count);
+        if (shouldBump) sessionStorage.setItem(sessionKey, 'true');
       } catch {
-        // API 失敗時使用備用方案（localStorage 模擬）
-        console.warn('Counter API unavailable, using local fallback');
-        setError(true);
-        fallbackCount();
+        // 所有計數服務皆失敗：不顯示假數字，直接隱藏元件
+        setCount(null);
       } finally {
         setIsLoading(false);
       }
     };
 
-    // localStorage 備用計數
-    const fallbackCount = () => {
-      try {
-        const storageKey = `visitor-count-${namespace}`;
-        const currentCount = parseInt(localStorage.getItem(storageKey) || '1000', 10);
-
-        if (!hasVisitedThisSession) {
-          const newCount = currentCount + 1;
-          localStorage.setItem(storageKey, String(newCount));
-          sessionStorage.setItem(sessionKey, 'true');
-          setCount(newCount);
-        } else {
-          setCount(currentCount);
-        }
-      } catch {
-        setCount(null);
-      }
-    };
-
-    // 稍微延遲避免閃爍
-    const timer = setTimeout(fetchCount, 100);
+    const timer = setTimeout(run, 100);
     return () => clearTimeout(timer);
   }, [namespace, counterKey]);
 
@@ -87,16 +83,10 @@ export function VisitorCounter({
     );
   }
 
-  if (count === null) {
-    return null;
-  }
+  if (count === null) return null;
 
   return (
-    <span
-      className={`visitor-counter ${error ? 'fallback' : ''}`}
-      aria-label={`訪客人次：${count}`}
-      title={error ? '計數器服務暫時無法連線' : undefined}
-    >
+    <span className="visitor-counter" aria-label={`訪客人次：${count}`}>
       <span className="counter-icon">👥</span>
       <span className="count">{count.toLocaleString()}</span>
       <span className="label">人次</span>


### PR DESCRIPTION
## Summary
- 訪客計數器改用 Abacus (jasoncameron.dev) 為主、counterapi.dev 為備援
- 移除 localStorage `seed=1000` 的偽計數（先前症狀：每個新裝置從 1001 開始）
- 兩服務皆失敗時 component 回 null 隱藏，不再顯示誤導的假數字

## Why
前版 `api.counterapi.dev` 實測不穩定（多半 403/unreachable），fallback 的 localStorage seed=1000 使每個新瀏覽器/清快取都從 1001 開始，非真正訪客累計。用戶在 [discussion #1](https://github.com/thc1006/ipas-net-zero-quiz/discussions/1) 詢問此現象，確認為設計缺陷。

## Implementation
- 主：`GET https://abacus.jasoncameron.dev/hit/<ns>/<key>` → `{value:N}`，CORS wildcard、首次呼叫自動建立 key
- 備：`GET https://api.counterapi.dev/v1/<ns>/<key>/up` → `{count:N}`
- Session dedup：`sessionStorage` 避免同一 tab 重複 +1

## Test plan
- [ ] 首次開啟頁面，計數器顯示數字（Abacus 回傳）
- [ ] Abacus 斷線時，備援仍能顯示
- [ ] 兩者都斷線時，計數器不顯示（不給假數字）

Base: #TBD (fix/c2-190-tier1-data-10-percent)