### PR TITLE
chore: point Header icon to discussions, switch AI model

### DIFF
--- a/quiz-app/src/components/Header/Header.tsx
+++ b/quiz-app/src/components/Header/Header.tsx
@@ -47,14 +47,14 @@ export function Header({ onOpenSettings, onGoHome, accessibility }: HeaderProps)
             <span className="material-icons">settings</span>
           </button>
 
-          {/* GitHub 連結 */}
+          {/* 社群討論 / 回報題目 */}
           <a
-            href="https://github.com/thc1006/ipas-net-zero-quiz"
+            href="https://github.com/thc1006/ipas-net-zero-quiz/discussions/1"
             target="_blank"
             rel="noopener noreferrer"
             className="btn btn-text icon-btn"
-            aria-label="GitHub 專案"
-            title="GitHub"
+            aria-label="社群討論 / 回報題目"
+            title="社群討論"
           >
             <svg
               viewBox="0 0 24 24"

--- a/quiz-app/src/utils/ai-helper.ts
+++ b/quiz-app/src/utils/ai-helper.ts
@@ -18,9 +18,8 @@ declare global {
   }
 }
 
-// AI 模型設定 - 使用 OpenAI GPT-5.2（目前最強模型）
-// 其他可用選項：'gpt-4o', 'o1', 'o3'
-const AI_MODEL = 'gpt-5.2-chat';
+// AI 模型設定 - 使用 OpenAI GPT-5.4（透過 Puter.js）
+const AI_MODEL = 'openai/gpt-5.4';
 const CONFIDENCE_THRESHOLD = 0.7;
 
 // 系統提示詞（中文）


### PR DESCRIPTION
## Summary
兩件小型 UX/config 變更：

1. **Header**：章魚貓 icon href 由 repo 根改指 [discussion #1](https://github.com/thc1006/ipas-net-zero-quiz/discussions/1)（社群討論 / 回報題目）；`aria-label` 與 `title` 同步更新；SVG 保留做 GitHub 識別
2. **AI 模型**：`AI_MODEL` 由 `'gpt-5.2-chat'` 改為 `'openai/gpt-5.4'`（透過 Puter.js）

## Why
- Header icon：目前 Footer 與 SettingsPage 都已有「GitHub 原始碼」入口指 repo 根。將 Header icon 轉為社群討論入口，可分流（原始碼 vs 回報題目），提升回報可見度。
- AI 模型升級（用戶要求）。

## Test plan
- [ ] 點 Header 章魚貓 icon → 跳到 discussion #1
- [ ] Footer「GitHub」與 SettingsPage「GitHub 原始碼」仍指 repo 根
- [ ] AI 解題功能以 `openai/gpt-5.4` 呼叫 Puter.js（console 檢查 request payload）

Base: #6 (fix/quiz-data-audit-corrections)