### PR TITLE
chore(visitor-counter): add AbortController + isMounted guard

### DIFF
--- a/quiz-app/src/components/VisitorCounter/VisitorCounter.tsx
+++ b/quiz-app/src/components/VisitorCounter/VisitorCounter.tsx
@@ -1,6 +1,6 @@
 // 訪客計數器元件
 // 以 Abacus (jasoncameron.dev) 為主，counterapi.dev 為備援；皆失敗時不顯示。
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import './VisitorCounter.css';
 
 interface VisitorCounterProps {
@@ -17,14 +17,19 @@ interface ProviderResult {
   provider: Provider;
 }
 
-async function fromAbacus(ns: string, key: string, bump: boolean): Promise<ProviderResult> {
+async function fromAbacus(
+  ns: string,
+  key: string,
+  bump: boolean,
+  signal: AbortSignal
+): Promise<ProviderResult> {
   const endpoint = bump ? 'hit' : 'get';
   const url = `https://abacus.jasoncameron.dev/${endpoint}/${encodeURIComponent(ns)}/${encodeURIComponent(key)}`;
-  const res = await fetch(url);
+  const res = await fetch(url, { signal });
   if (!res.ok) {
     // 首次呼叫 get 會是 404，改用 hit 建立並遞增
     if (endpoint === 'get' && res.status === 404) {
-      return fromAbacus(ns, key, true);
+      return fromAbacus(ns, key, true, signal);
     }
     throw new Error(`abacus ${res.status}`);
   }
@@ -33,10 +38,15 @@ async function fromAbacus(ns: string, key: string, bump: boolean): Promise<Provi
   return { count: data.value, provider: 'abacus' };
 }
 
-async function fromCounterApi(ns: string, key: string, bump: boolean): Promise<ProviderResult> {
+async function fromCounterApi(
+  ns: string,
+  key: string,
+  bump: boolean,
+  signal: AbortSignal
+): Promise<ProviderResult> {
   const endpoint = bump ? 'up' : 'get';
   const url = `https://api.counterapi.dev/v1/${encodeURIComponent(ns)}/${encodeURIComponent(key)}/${endpoint}`;
-  const res = await fetch(url);
+  const res = await fetch(url, { signal });
   if (!res.ok) throw new Error(`counterapi ${res.status}`);
   const data = (await res.json()) as { count?: number };
   if (typeof data.count !== 'number') throw new Error('counterapi malformed');
@@ -49,29 +59,41 @@ export function VisitorCounter({
 }: VisitorCounterProps) {
   const [count, setCount] = useState<number | null>(null);
   const [isLoading, setIsLoading] = useState(true);
+  const isMountedRef = useRef(true);
 
   useEffect(() => {
+    isMountedRef.current = true;
     const sessionKey = `visited-${namespace}-${counterKey}`;
     const visitedThisSession = sessionStorage.getItem(sessionKey) === 'true';
     const shouldBump = !visitedThisSession;
+    const ac = new AbortController();
 
     const run = async () => {
       try {
-        const result = await fromAbacus(namespace, counterKey, shouldBump).catch(() =>
-          fromCounterApi(namespace, counterKey, shouldBump)
+        const result = await fromAbacus(namespace, counterKey, shouldBump, ac.signal).catch(
+          (err) => {
+            if (err?.name === 'AbortError') throw err;
+            return fromCounterApi(namespace, counterKey, shouldBump, ac.signal);
+          }
         );
+        if (!isMountedRef.current) return;
         setCount(result.count);
         if (shouldBump) sessionStorage.setItem(sessionKey, 'true');
-      } catch {
+      } catch (err: unknown) {
+        if ((err as { name?: string })?.name === 'AbortError') return;
         // 所有計數服務皆失敗：不顯示假數字，直接隱藏元件
-        setCount(null);
+        if (isMountedRef.current) setCount(null);
       } finally {
-        setIsLoading(false);
+        if (isMountedRef.current) setIsLoading(false);
       }
     };
 
     const timer = setTimeout(run, 100);
-    return () => clearTimeout(timer);
+    return () => {
+      isMountedRef.current = false;
+      clearTimeout(timer);
+      ac.abort();
+    };
   }, [namespace, counterKey]);
 
   if (isLoading) {


### PR DESCRIPTION
## Summary
PR #5 follow-up：補上 `AbortController` 與 `isMountedRef`，避免：
1. fetch 進行中元件 unmount → `setState` 在 unmounted 觸發（React 18 strict-mode 警告）
2. 重複 mount 觸發競態條件

## Why follow-up not amend
直接 amend PR #5 會強制 rebase 4 個下游 stacked PRs（#6/#7/#8/#9），對 reviewer 干擾大。改採追加 PR。

## Test plan
- [ ] dev 環境 strict mode 開啟，確認無 warning
- [ ] 手動快速進出含 VisitorCounter 的頁面，無 setState-on-unmounted

Base: #9 (feat/practice-pool-data)