### PR TITLE
feat(loader): add practice pool util + usePracticePool hook

### DIFF
--- a/quiz-app/src/hooks/index.ts
+++ b/quiz-app/src/hooks/index.ts
@@ -1,2 +1,3 @@
 export { useQuiz, defaultConfig } from './useQuiz';
 export { useAccessibility } from './useAccessibility';
+export { usePracticePool, pickQuizQuestions } from './usePracticePool';

--- a/quiz-app/src/hooks/usePracticePool.ts
+++ b/quiz-app/src/hooks/usePracticePool.ts
@@ -1,0 +1,33 @@
+// 加強練習池 React hook：依過濾條件回傳題目陣列。
+// 內部不做網路請求 — 練習池為 static import；hook 僅作 memoized filter / sample。
+
+import { useMemo } from 'react';
+import {
+  filterPool,
+  getPracticePool,
+  pickQuizQuestions,
+  type PoolFilterOptions,
+} from '../utils/practice-pool';
+import type { PracticePool, PracticePoolItem } from '../types/practicePool';
+
+interface UsePracticePoolResult {
+  pool: PracticePool;
+  items: PracticePoolItem[];
+  totalCount: number;
+}
+
+/**
+ * 取得練習池內容並依條件過濾。
+ * - 不抽樣（保留原順序）；如需隨機，請呼叫 pickQuizQuestions util。
+ */
+export function usePracticePool(opts: PoolFilterOptions = {}): UsePracticePoolResult {
+  const pool = useMemo(() => getPracticePool(), []);
+  const items = useMemo(() => filterPool(pool.items, opts), [pool.items, opts]);
+  return {
+    pool,
+    items,
+    totalCount: items.length,
+  };
+}
+
+export { pickQuizQuestions };

--- a/quiz-app/src/utils/practice-pool.ts
+++ b/quiz-app/src/utils/practice-pool.ts
@@ -1,0 +1,129 @@
+// 加強練習池工具：載入、過濾、normalize、轉換為 QuizQuestion
+// 不直接依賴 React；可在 hook 與其他 utils 共用。
+
+import practicePoolJson from '../data/practice_pool.json';
+import type {
+  PracticePool,
+  PracticePoolItem,
+  PracticePoolSourceType,
+  PracticePoolDifficulty,
+} from '../types/practicePool';
+import type { QuizQuestion } from '../types/quiz';
+
+// 直接強型別轉型（Vite/TS 對 JSON import 預設為 any-ish）
+const POOL: PracticePool = practicePoolJson as unknown as PracticePool;
+
+/** 取得整個練習池（含 _meta） */
+export function getPracticePool(): PracticePool {
+  return POOL;
+}
+
+/** 過濾條件 */
+export interface PoolFilterOptions {
+  sourceTypes?: PracticePoolSourceType[];
+  topicTags?: string[];
+  subjects?: Array<string | null>;
+  difficulties?: PracticePoolDifficulty[];
+  excludeFlags?: string[];
+}
+
+/** 將不同代理寫法的 topic tag 正規化（lowercased、移除空白與標點） */
+export function normalizeTopicTag(tag: string): string {
+  return tag
+    .toLowerCase()
+    .replace(/\s+/g, '')
+    .replace(/[　-〿＀-￯()（）「」『』、，。\.\-_/]/g, '');
+}
+
+/**
+ * 根據條件過濾練習池。
+ * - 任何 array 為空或 undefined 視為「不過濾此維度」
+ * - excludeFlags 用於排除帶特定 quality_flag 的題（如 'time_sensitive'）
+ */
+export function filterPool(
+  items: PracticePoolItem[],
+  opts: PoolFilterOptions = {}
+): PracticePoolItem[] {
+  const sourceSet = opts.sourceTypes && new Set(opts.sourceTypes);
+  const tagSet = opts.topicTags && new Set(opts.topicTags.map(normalizeTopicTag));
+  const subjectSet = opts.subjects && new Set(opts.subjects);
+  const diffSet = opts.difficulties && new Set(opts.difficulties);
+  const excludeFlagSet = opts.excludeFlags && new Set(opts.excludeFlags);
+
+  return items.filter((it) => {
+    if (sourceSet && !sourceSet.has(it.provenance.source_type)) return false;
+    if (subjectSet && !subjectSet.has(it.subject ?? null)) return false;
+    if (diffSet && !diffSet.has(it.difficulty)) return false;
+    if (tagSet) {
+      const itemTags = it.topic_tags.map(normalizeTopicTag);
+      if (!itemTags.some((t) => tagSet.has(t))) return false;
+    }
+    if (excludeFlagSet) {
+      if (it.quality_flags.some((f) => excludeFlagSet.has(f))) return false;
+    }
+    return true;
+  });
+}
+
+/**
+ * Fisher-Yates shuffle in-place clone。確定性可選 seed（測試用）。
+ */
+export function shuffle<T>(arr: T[], rng: () => number = Math.random): T[] {
+  const a = [...arr];
+  for (let i = a.length - 1; i > 0; i--) {
+    const j = Math.floor(rng() * (i + 1));
+    [a[i], a[j]] = [a[j], a[i]];
+  }
+  return a;
+}
+
+/** 隨機抽樣 n 題（不重複）。若 items 不足 n，回傳全部。 */
+export function randomSample<T>(items: T[], n: number, rng?: () => number): T[] {
+  if (items.length <= n) return [...items];
+  return shuffle(items, rng).slice(0, n);
+}
+
+/**
+ * 把 PracticePoolItem 轉成現有 quiz 流程吃的 QuizQuestion 形狀。
+ * UI 仍能透過 item.provenance / item.quality_flags 額外渲染來源徽章。
+ */
+export function toQuizQuestion(item: PracticePoolItem): QuizQuestion & {
+  provenance: PracticePoolItem['provenance'];
+  qualityFlags: PracticePoolItem['quality_flags'];
+  sources: string[];
+} {
+  // subject 在練習池可能是中文「考科一/考科二」或 null；映射到既有 ExamSubject。
+  let subject: QuizQuestion['subject'];
+  const raw = item.subject ?? '';
+  if (typeof raw === 'string' && raw.includes('1')) subject = '考科1';
+  else if (typeof raw === 'string' && (raw.includes('一') || raw.toLowerCase().includes('subject 1')))
+    subject = '考科1';
+  else if (typeof raw === 'string' && raw.includes('2')) subject = '考科2';
+  else if (typeof raw === 'string' && (raw.includes('二') || raw.toLowerCase().includes('subject 2')))
+    subject = '考科2';
+  else subject = '考科2'; // 大宗 fallback
+
+  return {
+    id: item.id,
+    stem: item.stem,
+    options: item.options,
+    answer: item.answer,
+    subject,
+    sourceType: 'unique',
+    year: null,
+    hasAnswer: item.answer != null,
+    provenance: item.provenance,
+    qualityFlags: item.quality_flags,
+    sources: item.sources,
+  };
+}
+
+/** Convenience：依條件抽 n 題並轉換為 QuizQuestion 形狀 */
+export function pickQuizQuestions(
+  count: number,
+  opts: PoolFilterOptions = {},
+  rng?: () => number
+): ReturnType<typeof toQuizQuestion>[] {
+  const filtered = filterPool(POOL.items, opts);
+  return randomSample(filtered, count, rng).map(toQuizQuestion);
+}


### PR DESCRIPTION
## Summary
PR #11 follow-up：練習池資料層完成 — util 模組 + React hook。

## What this PR adds
- `src/utils/practice-pool.ts` — pure functions
  - `getPracticePool()`、`filterPool()`、`shuffle()`、`randomSample()`
  - `normalizeTopicTag()` — 處理「CBAM / cbam / 碳邊境調整機制」這種跨代理產出的 tag 不一致
  - `toQuizQuestion()` — 把 PracticePoolItem 映射為現有 QuizQuestion 形狀（保留 provenance/qualityFlags/sources 給 UI 渲染徽章）
  - `pickQuizQuestions()` — filter + sample + convert 一次完成
- `src/hooks/usePracticePool.ts` — `useMemo` 包裝過濾結果

## Why this design
- **無網路**：練習池是 static JSON import，Vite/TS 處理。Tree-shaking + bundle 一次完成
- **可測**：filter / shuffle 接 `rng` 參數可注入；後續可用 deterministic seed 寫單元測試
- **不破壞主流程**：`toQuizQuestion` 把練習池題映射為主題庫題的形狀；既有 `useQuiz` / `QuestionCard` 都能直接吃，只是多帶 `provenance/qualityFlags/sources` 三欄

## Not in this PR
- UI 入口（settings 頁切換、source badge 元件、opt-in 對話框）— 另開 PR
- 整合進 `useQuiz` 流程 — 另開 PR

## Test plan
- [ ] `tsc --noEmit` 通過
- [ ] 在 dev console 跑 `getPracticePool().items.length === 143`
- [ ] 跑 `pickQuizQuestions(5, { sourceTypes: ['external_mock'] })` 取 5 題

Base: #11 (feat/practice-pool-types)