### PR TITLE
feat(ui): practice pool opt-in toggle + source badge + EU AI Act disclosure

### DIFF
--- a/quiz-app/src/components/PracticeOptInDialog/PracticeOptInDialog.css
+++ b/quiz-app/src/components/PracticeOptInDialog/PracticeOptInDialog.css
@@ -1,0 +1,56 @@
+/* PracticeOptInDialog 樣式 */
+
+.optin-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.55);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  padding: var(--spacing-md);
+}
+
+.optin-dialog {
+  background: var(--color-surface);
+  color: var(--color-text-primary);
+  border-radius: var(--radius-lg);
+  padding: var(--spacing-lg);
+  max-width: 560px;
+  width: 100%;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+}
+
+.optin-dialog h2 {
+  margin-top: 0;
+  margin-bottom: var(--spacing-md);
+}
+
+.optin-dialog p,
+.optin-dialog ul {
+  font-size: var(--font-size-sm);
+  line-height: 1.6;
+  margin: var(--spacing-sm) 0;
+}
+
+.optin-dialog ul {
+  padding-left: 1.25em;
+}
+
+.optin-dialog li {
+  margin-bottom: var(--spacing-xs);
+}
+
+.optin-note {
+  font-size: var(--font-size-xs);
+  color: var(--color-text-secondary);
+  border-top: 1px solid var(--color-border, rgba(0, 0, 0, 0.1));
+  padding-top: var(--spacing-sm);
+}
+
+.optin-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--spacing-sm);
+  margin-top: var(--spacing-md);
+}

--- a/quiz-app/src/components/PracticeOptInDialog/PracticeOptInDialog.tsx
+++ b/quiz-app/src/components/PracticeOptInDialog/PracticeOptInDialog.tsx
@@ -1,0 +1,48 @@
+// 加強練習池 opt-in 對話框：首次啟用時揭露 AI 產題與第三方模擬題之來源
+// 對應 EU AI Act Art.50（2026-08-02 起）對 AI 生成文字之揭露義務
+import './PracticeOptInDialog.css';
+
+interface PracticeOptInDialogProps {
+  open: boolean;
+  onAccept: () => void;
+  onDecline: () => void;
+}
+
+export function PracticeOptInDialog({ open, onAccept, onDecline }: PracticeOptInDialogProps) {
+  if (!open) return null;
+  return (
+    <div className="optin-overlay" role="dialog" aria-modal="true" aria-labelledby="optin-title">
+      <div className="optin-dialog">
+        <h2 id="optin-title">啟用加強練習池</h2>
+        <p>
+          加強練習池是<strong>獨立於主題庫的補充題目</strong>，總計 143 題。題目來自兩種來源：
+        </p>
+        <ul>
+          <li>
+            <strong>模擬題（54 題）</strong>：取自 vocus 講師、HackMD、yamol 等公開模擬題，
+            非官方歷屆試題（iPAS 不公開歷屆）。
+          </li>
+          <li>
+            <strong>AI 產題（89 題）</strong>：由語言模型依環境部、CBAM、ISO 等法規與標準
+            產生，並經獨立驗證代理逐題以權威來源（law.moj.gov.tw、EUR-Lex、IPCC、ISO 等）
+            交叉比對通過。
+          </li>
+        </ul>
+        <p className="optin-note">
+          每題皆顯示來源徽章。AI 產題答案雖經驗證，仍以官方教材為最終依據。
+          本揭露依 EU AI Act Art. 50（2026-08-02 起對 AI 生成文字強制揭露）。
+        </p>
+        <div className="optin-actions">
+          <button className="btn btn-secondary" onClick={onDecline}>
+            暫不啟用
+          </button>
+          <button className="btn btn-primary" onClick={onAccept}>
+            我已了解，啟用加強練習
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default PracticeOptInDialog;

--- a/quiz-app/src/components/SourceBadge/SourceBadge.css
+++ b/quiz-app/src/components/SourceBadge/SourceBadge.css
@@ -1,0 +1,52 @@
+/* SourceBadge 樣式 */
+
+.source-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+  padding: 2px 8px;
+  border-radius: var(--radius-full);
+  font-size: var(--font-size-xs);
+  font-weight: 500;
+  line-height: 1.4;
+  vertical-align: middle;
+}
+
+.source-badge .badge-text {
+  white-space: nowrap;
+}
+
+.source-badge.tone-mock {
+  background: var(--color-info-bg, #e0f2fe);
+  color: var(--color-info-fg, #0369a1);
+}
+
+.source-badge.tone-ai {
+  background: var(--color-warning-bg, #fef3c7);
+  color: var(--color-warning-fg, #92400e);
+  border: 1px solid var(--color-warning-fg, #92400e);
+}
+
+@media (prefers-color-scheme: dark) {
+  .source-badge.tone-mock {
+    background: rgba(59, 130, 246, 0.15);
+    color: #93c5fd;
+  }
+  .source-badge.tone-ai {
+    background: rgba(245, 158, 11, 0.15);
+    color: #fbbf24;
+    border-color: rgba(245, 158, 11, 0.4);
+  }
+}
+
+.flag-chip {
+  display: inline-block;
+  padding: 0 6px;
+  border-radius: var(--radius-sm, 4px);
+  font-size: 0.85em;
+  background: rgba(0, 0, 0, 0.08);
+}
+
+.flag-time_sensitive { background: rgba(239, 68, 68, 0.15); color: #b91c1c; }
+.flag-ambiguous     { background: rgba(168, 85, 247, 0.15); color: #6b21a8; }
+.flag-low_confidence{ background: rgba(107, 114, 128, 0.15); color: #4b5563; }

--- a/quiz-app/src/components/SourceBadge/SourceBadge.tsx
+++ b/quiz-app/src/components/SourceBadge/SourceBadge.tsx
@@ -1,0 +1,48 @@
+// 練習池題目來源徽章。
+// 對 ai_generated 題顯示「AI 產題」並符合 EU AI Act Art.50（2026-08-02 起）揭露要求。
+import './SourceBadge.css';
+import type { PracticePoolSourceType, PracticePoolQualityFlag } from '../../types/practicePool';
+
+interface SourceBadgeProps {
+  sourceType: PracticePoolSourceType;
+  qualityFlags?: PracticePoolQualityFlag[];
+  /** 顯示完整描述 vs 縮寫 */
+  compact?: boolean;
+}
+
+const SOURCE_LABEL: Record<PracticePoolSourceType, { text: string; icon: string; tone: string }> = {
+  external_mock: { text: '模擬題', icon: 'menu_book', tone: 'mock' },
+  ai_generated: { text: 'AI 產題', icon: 'auto_awesome', tone: 'ai' },
+};
+
+const FLAG_LABEL: Partial<Record<PracticePoolQualityFlag, string>> = {
+  time_sensitive: '時效',
+  ambiguous: '爭議',
+  low_confidence: '低信心',
+};
+
+export function SourceBadge({ sourceType, qualityFlags = [], compact = false }: SourceBadgeProps) {
+  const meta = SOURCE_LABEL[sourceType];
+  const isAI = sourceType === 'ai_generated';
+  const title = isAI
+    ? 'AI 產題：本題由語言模型基於法規與標準產生，已通過獨立驗證。依 EU AI Act Art.50 揭露。'
+    : '模擬題：來自第三方公開模擬題（vocus / HackMD / yamol 等），非官方歷屆試題。';
+
+  return (
+    <span className={`source-badge tone-${meta.tone}`} title={title} aria-label={title}>
+      <span className="material-icons sm" aria-hidden="true">
+        {meta.icon}
+      </span>
+      {!compact && <span className="badge-text">{meta.text}</span>}
+      {qualityFlags
+        .filter((f): f is keyof typeof FLAG_LABEL => f in FLAG_LABEL)
+        .map((f) => (
+          <span key={f} className={`flag-chip flag-${f}`}>
+            {FLAG_LABEL[f]}
+          </span>
+        ))}
+    </span>
+  );
+}
+
+export default SourceBadge;

--- a/quiz-app/src/hooks/usePracticeMode.ts
+++ b/quiz-app/src/hooks/usePracticeMode.ts
@@ -1,0 +1,78 @@
+// 加強練習模式狀態：以 localStorage 持久化是否啟用、是否已 opt-in 揭露
+// 依 EU AI Act Art.50（2026-08-02 起）：使用 AI 產題前須揭露給使用者
+import { useCallback, useEffect, useState } from 'react';
+
+const ENABLED_KEY = 'practice-pool-enabled';
+const OPTED_IN_KEY = 'practice-pool-ai-opt-in';
+
+function readBool(key: string): boolean {
+  if (typeof window === 'undefined') return false;
+  try {
+    return window.localStorage.getItem(key) === '1';
+  } catch {
+    return false;
+  }
+}
+
+function writeBool(key: string, value: boolean) {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(key, value ? '1' : '0');
+  } catch {
+    /* quota or disabled — silently ignore */
+  }
+}
+
+export interface UsePracticeModeResult {
+  /** 使用者是否啟用加強練習池 */
+  enabled: boolean;
+  /** 使用者是否已確認 AI 產題揭露聲明 */
+  hasOptedIn: boolean;
+  /** 啟用時須先 opt-in；若尚未 opt-in 則需先呼 acceptOptIn */
+  enable: () => void;
+  /** 關閉加強練習 */
+  disable: () => void;
+  /** 確認 AI 揭露聲明（同步觸發 enable） */
+  acceptOptIn: () => void;
+  /** 重置 opt-in（之後啟用時會再彈一次揭露） */
+  resetOptIn: () => void;
+}
+
+export function usePracticeMode(): UsePracticeModeResult {
+  const [enabled, setEnabled] = useState<boolean>(() => readBool(ENABLED_KEY));
+  const [hasOptedIn, setHasOptedIn] = useState<boolean>(() => readBool(OPTED_IN_KEY));
+
+  // sync if storage changes from another tab
+  useEffect(() => {
+    const onStorage = (e: StorageEvent) => {
+      if (e.key === ENABLED_KEY) setEnabled(readBool(ENABLED_KEY));
+      if (e.key === OPTED_IN_KEY) setHasOptedIn(readBool(OPTED_IN_KEY));
+    };
+    window.addEventListener('storage', onStorage);
+    return () => window.removeEventListener('storage', onStorage);
+  }, []);
+
+  const enable = useCallback(() => {
+    setEnabled(true);
+    writeBool(ENABLED_KEY, true);
+  }, []);
+
+  const disable = useCallback(() => {
+    setEnabled(false);
+    writeBool(ENABLED_KEY, false);
+  }, []);
+
+  const acceptOptIn = useCallback(() => {
+    setHasOptedIn(true);
+    writeBool(OPTED_IN_KEY, true);
+    setEnabled(true);
+    writeBool(ENABLED_KEY, true);
+  }, []);
+
+  const resetOptIn = useCallback(() => {
+    setHasOptedIn(false);
+    writeBool(OPTED_IN_KEY, false);
+  }, []);
+
+  return { enabled, hasOptedIn, enable, disable, acceptOptIn, resetOptIn };
+}

--- a/quiz-app/src/pages/SettingsPage.tsx
+++ b/quiz-app/src/pages/SettingsPage.tsx
@@ -1,5 +1,9 @@
 // 設定頁面元件
+import { useState } from 'react';
 import type { useAccessibility } from '../hooks/useAccessibility';
+import { usePracticeMode } from '../hooks/usePracticeMode';
+import { usePracticePool } from '../hooks/usePracticePool';
+import { PracticeOptInDialog } from '../components/PracticeOptInDialog/PracticeOptInDialog';
 import './SettingsPage.css';
 
 interface SettingsPageProps {
@@ -16,6 +20,20 @@ export function SettingsPage({ accessibility, onClose }: SettingsPageProps) {
     setFontSize,
     resetToDefault,
   } = accessibility;
+
+  const practiceMode = usePracticeMode();
+  const { pool } = usePracticePool();
+  const [optInOpen, setOptInOpen] = useState(false);
+
+  const onTogglePractice = () => {
+    if (practiceMode.enabled) {
+      practiceMode.disable();
+    } else if (practiceMode.hasOptedIn) {
+      practiceMode.enable();
+    } else {
+      setOptInOpen(true);
+    }
+  };
 
   return (
     <div className="settings-page animate-fade-in">
@@ -120,6 +138,41 @@ export function SettingsPage({ accessibility, onClose }: SettingsPageProps) {
           </select>
         </div>
       </section>
+
+      {/* 加強練習池 */}
+      <section className="settings-section card">
+        <h2>加強練習池</h2>
+        <div className="setting-item">
+          <div className="setting-info">
+            <span className="material-icons">auto_awesome</span>
+            <div>
+              <p className="setting-title">啟用加強練習</p>
+              <p className="setting-desc">
+                {pool._meta.totals.total} 題補充題（{pool._meta.totals.external_mock} 題模擬題、
+                {pool._meta.totals.ai_generated} 題 AI 產題）；獨立於主題庫，每題附來源徽章。
+              </p>
+            </div>
+          </div>
+          <label className="toggle-switch">
+            <input
+              type="checkbox"
+              checked={practiceMode.enabled}
+              onChange={onTogglePractice}
+              aria-label="啟用加強練習池"
+            />
+            <span className="toggle-slider"></span>
+          </label>
+        </div>
+      </section>
+
+      <PracticeOptInDialog
+        open={optInOpen}
+        onAccept={() => {
+          practiceMode.acceptOptIn();
+          setOptInOpen(false);
+        }}
+        onDecline={() => setOptInOpen(false)}
+      />
 
       {/* 重置 */}
       <section className="settings-section">


### PR DESCRIPTION
## Summary
PR #12 follow-up：練習池最小可用 UI — settings 頁 toggle、opt-in dialog、source badge 元件。

## What this PR adds

| File | Purpose |
|---|---|
| `components/SourceBadge/` | 顯示「模擬題 / AI 產題」徽章 + quality_flags chips |
| `components/PracticeOptInDialog/` | 首次啟用揭露對話框（含 EU AI Act Art.50 聲明）|
| `hooks/usePracticeMode.ts` | localStorage 持久化 enabled / hasOptedIn |
| `pages/SettingsPage.tsx` | 新增「加強練習池」section + toggle |

## EU AI Act Art.50 compliance
2026-08-02 起，AI 生成的文字必須對使用者揭露。本 PR 設計：
1. AI 產題在 SourceBadge 用警示色 + 邊框 + icon 標示
2. 首次啟用透過 opt-in dialog 完整揭露
3. usePracticeMode 將 `hasOptedIn` 存 localStorage

## Not in this PR (future)
- 整合進主 Quiz flow（讓 QuizPage 真的會抽到練習池題目）
- QuestionCard 顯示 SourceBadge
- 來源 URL 渲染（讓使用者點擊看到引文）

## Test plan
- [ ] Settings 頁出現「加強練習池」section
- [ ] 第一次點 toggle 彈出 opt-in dialog；接受後 toggle 開啟
- [ ] 第二次點 toggle 直接開關（不再彈窗）
- [ ] localStorage 跨 tab 同步
- [ ] Dark mode 下徽章顏色 OK

Base: #12 (feat/practice-pool-loader)