### PR TITLE
test: unit tests for audit corrections + practice-pool util

### DIFF
--- a/quiz-app/src/data/audit-corrections.test.ts
+++ b/quiz-app/src/data/audit-corrections.test.ts
@@ -1,0 +1,121 @@
+// 稽核修正回歸測試
+// 鎖定 c2-190、c2-006、c2-132 等審核過的答案，避免被誤改回去
+import { describe, it, expect } from 'vitest';
+import questionsRaw from './questions.json';
+import datasetRaw from './integrated_dataset.json';
+
+interface RawQ {
+  id: string;
+  question: string;
+  options: Record<string, string>;
+  answer: string;
+  explanation?: string;
+  metadata?: { sources?: string[]; sources_verified_date?: string };
+}
+
+interface DatasetItem {
+  index: number;
+  stem: string;
+  answer: string;
+  options: { key: string; text: string }[];
+  metadata?: { original_id?: string; sources?: string[] };
+  explanation?: string;
+}
+
+const Q1 = questionsRaw as unknown as RawQ[];
+const DS = datasetRaw as unknown as { gist_items: DatasetItem[] };
+
+const byId = (id: string) => Q1.find((q) => q.id === id);
+const byIndex = (idx: number) => DS.gist_items.find((g) => g.index === idx);
+
+describe('audit corrections regression', () => {
+  describe('c2-190 一級數據佔上游排放（discussion #1）', () => {
+    const q = byId('c2-190');
+    it('answer should be B (10%, not 20%)', () => {
+      expect(q?.answer).toBe('B');
+    });
+    it('option B 文字含 10', () => {
+      expect(q?.options.B).toContain('10');
+    });
+    it('explanation includes 10%', () => {
+      expect(q?.explanation).toContain('10%');
+    });
+    it('explanation does NOT contain "原環境部" anachronism', () => {
+      expect(q?.explanation).not.toContain('（原環境部）');
+    });
+    it('metadata.sources includes vocus citation', () => {
+      const sources = q?.metadata?.sources ?? [];
+      expect(sources.some((u) => u.includes('vocus.cc'))).toBe(true);
+    });
+  });
+
+  describe('c2-006 溫管辦法主導查驗員', () => {
+    const q = byId('c2-006');
+    it('answer should be C (6 years)', () => {
+      expect(q?.answer).toBe('C');
+    });
+    it('explanation cites §8 (not §14)', () => {
+      // §8 第 2 項第 2 款 — should appear; §14 should not be the answer reference
+      expect(q?.explanation).toContain('第 8 條');
+    });
+  });
+
+  describe('c2-132 CDP 揭露範疇', () => {
+    const q = byId('c2-132');
+    it('answer should be A (土壤, not 塑膠)', () => {
+      expect(q?.answer).toBe('A');
+    });
+    it('option A is 土壤', () => {
+      expect(q?.options.A).toBe('土壤');
+    });
+  });
+
+  describe('CBAM Omnibus dates (Reg 2025/2083)', () => {
+    it('c1-038 surrender deadline option C → 9 月 30 日', () => {
+      expect(byId('c1-038')?.options.C).toBe('9 月 30 日');
+    });
+    it('c1-040 first submission option B → 2027 年 9 月 30 日', () => {
+      expect(byId('c1-040')?.options.B).toBe('2027 年 9 月 30 日');
+    });
+  });
+
+  describe('NDC 3.0 update', () => {
+    it('c2-086 option B → 28 % ± 2 %', () => {
+      expect(byId('c2-086')?.options.B).toBe('28 % ± 2 %');
+    });
+  });
+
+  describe('SF6 GWP AR5 (23,500)', () => {
+    const sf6_50 = byIndex(480);
+    const sf6_60 = byIndex(494);
+    it('gist[480] 50kg SF6 answer D = 1,175 tCO2e', () => {
+      const optD = sf6_50?.options.find((o) => o.key === 'D')?.text;
+      expect(optD).toBe('1,175 tCO2e');
+    });
+    it('gist[494] 60kg SF6 answer D = 1,410 tCO2e', () => {
+      const optD = sf6_60?.options.find((o) => o.key === 'D')?.text;
+      expect(optD).toBe('1,410 tCO2e');
+    });
+  });
+
+  describe('Cat 4/5 stem fix', () => {
+    const q = byIndex(179);
+    it('gist[179] stem mentions Category 5 (not 4) for use phase', () => {
+      expect(q?.stem).toContain('Category 5');
+    });
+  });
+
+  describe('threshold law source correction', () => {
+    const q = byIndex(150);
+    it('gist[150] explanation cites 公告 (not §5)', () => {
+      expect(q?.explanation).toContain('1139101260');
+    });
+  });
+
+  describe('c2-006 / gist[88] citation accuracy', () => {
+    const q = byIndex(89);
+    it('gist[89] explanation cites §56 (1500 元 cap)', () => {
+      expect(q?.explanation).toContain('第 56 條');
+    });
+  });
+});

--- a/quiz-app/src/utils/practice-pool.test.ts
+++ b/quiz-app/src/utils/practice-pool.test.ts
@@ -1,0 +1,178 @@
+// practice-pool util 單元測試
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  filterPool,
+  normalizeTopicTag,
+  shuffle,
+  randomSample,
+  toQuizQuestion,
+  loadPracticePool,
+  __resetPracticePoolCacheForTesting,
+} from './practice-pool';
+import type { PracticePoolItem } from '../types/practicePool';
+
+const baseItem = (over: Partial<PracticePoolItem> = {}): PracticePoolItem => ({
+  id: 'pool-test-001',
+  stem: 'Sample stem',
+  options: [
+    { key: 'A', text: 'a' },
+    { key: 'B', text: 'b' },
+  ],
+  answer: 'A',
+  explanation: '',
+  subject: '考科2',
+  topic_tags: ['CBAM'],
+  difficulty: 'medium',
+  provenance: {
+    source_type: 'external_mock',
+    source_origin: 'test',
+    verified_date: '2026-04-25',
+    verifier: 'test',
+    verify_verdict: 'CONFIRMED',
+    original_id: '1',
+  },
+  sources: [],
+  quality_flags: [],
+  ...over,
+});
+
+describe('normalizeTopicTag', () => {
+  it('lowercases', () => {
+    expect(normalizeTopicTag('CBAM')).toBe('cbam');
+  });
+  it('removes whitespace', () => {
+    expect(normalizeTopicTag('CO 2 排放')).toBe('co2排放');
+  });
+  it('removes punctuation (full + half width)', () => {
+    expect(normalizeTopicTag('碳邊境-CBAM')).toBe('碳邊境cbam');
+    expect(normalizeTopicTag('A,B;C')).toBe('abc');
+    expect(normalizeTopicTag('（淨零）')).toBe('淨零');
+  });
+});
+
+describe('filterPool', () => {
+  const items: PracticePoolItem[] = [
+    baseItem({ id: 'a', provenance: { ...baseItem().provenance, source_type: 'external_mock' } }),
+    baseItem({
+      id: 'b',
+      provenance: {
+        source_type: 'ai_generated',
+        source_origin: 'test',
+        verified_date: '2026-04-25',
+        verifier: 'test',
+        verify_verdict: 'CONFIRMED',
+        original_id: '2',
+        ai_metadata: { model_family: 'unspecified', generation_date: '2026-04-25', verifier_round: 1 },
+      },
+    }),
+    baseItem({ id: 'c', topic_tags: ['NDC'] }),
+    baseItem({ id: 'd', quality_flags: ['time_sensitive'] }),
+  ];
+
+  it('no opts returns all', () => {
+    expect(filterPool(items)).toHaveLength(4);
+  });
+  it('sourceTypes filter', () => {
+    expect(filterPool(items, { sourceTypes: ['ai_generated'] }).map((x) => x.id)).toEqual(['b']);
+  });
+  it('topicTags normalized match', () => {
+    expect(
+      filterPool(items, { topicTags: ['cbam'] }).map((x) => x.id).sort()
+    ).toEqual(['a', 'b', 'd'].sort());
+  });
+  it('excludeFlags filter', () => {
+    const out = filterPool(items, { excludeFlags: ['time_sensitive'] });
+    expect(out.find((x) => x.id === 'd')).toBeUndefined();
+    expect(out).toHaveLength(3);
+  });
+});
+
+describe('shuffle', () => {
+  it('keeps same length & elements', () => {
+    const arr = [1, 2, 3, 4, 5];
+    const out = shuffle(arr);
+    expect(out).toHaveLength(arr.length);
+    expect(new Set(out)).toEqual(new Set(arr));
+  });
+  it('does not mutate input', () => {
+    const arr = [1, 2, 3];
+    shuffle(arr);
+    expect(arr).toEqual([1, 2, 3]);
+  });
+  it('deterministic with seeded rng', () => {
+    let i = 0;
+    const seq = [0.1, 0.5, 0.9, 0.2, 0.4];
+    const rng = () => seq[i++ % seq.length];
+    const a = shuffle([1, 2, 3, 4, 5], rng);
+    i = 0;
+    const b = shuffle([1, 2, 3, 4, 5], rng);
+    expect(a).toEqual(b);
+  });
+});
+
+describe('randomSample', () => {
+  it('returns all when n >= length', () => {
+    expect(randomSample([1, 2, 3], 5)).toHaveLength(3);
+  });
+  it('returns n distinct items', () => {
+    const out = randomSample([1, 2, 3, 4, 5], 3);
+    expect(out).toHaveLength(3);
+    expect(new Set(out).size).toBe(3);
+  });
+});
+
+describe('toQuizQuestion', () => {
+  it('sets sourceType to practice_pool (not unique)', () => {
+    const q = toQuizQuestion(baseItem());
+    expect(q.sourceType).toBe('practice_pool');
+  });
+  it('maps subject "考科一" → 考科1', () => {
+    const q = toQuizQuestion(baseItem({ subject: '考科一' }));
+    expect(q.subject).toBe('考科1');
+  });
+  it('maps "考科2" → 考科2', () => {
+    const q = toQuizQuestion(baseItem({ subject: '考科2' }));
+    expect(q.subject).toBe('考科2');
+  });
+  it('passes through provenance + qualityFlags + sources', () => {
+    const item = baseItem({
+      sources: ['https://example.org'],
+      quality_flags: ['ambiguous'],
+    });
+    const q = toQuizQuestion(item);
+    expect(q.provenance.source_type).toBe('external_mock');
+    expect(q.qualityFlags).toContain('ambiguous');
+    expect(q.sources).toContain('https://example.org');
+  });
+  it('hasAnswer reflects answer presence', () => {
+    expect(toQuizQuestion(baseItem({ answer: null })).hasAnswer).toBe(false);
+    expect(toQuizQuestion(baseItem({ answer: 'A' })).hasAnswer).toBe(true);
+  });
+});
+
+describe('loadPracticePool (lazy)', () => {
+  beforeEach(() => __resetPracticePoolCacheForTesting());
+  it('returns same promise on subsequent calls (cached)', async () => {
+    const p1 = loadPracticePool();
+    const p2 = loadPracticePool();
+    expect(p1).toBe(p2);
+    const pool = await p1;
+    expect(Array.isArray(pool.items)).toBe(true);
+    expect(pool.items.length).toBeGreaterThan(0);
+  });
+  it('items have valid provenance.source_type', async () => {
+    const pool = await loadPracticePool();
+    for (const item of pool.items) {
+      expect(['external_mock', 'ai_generated']).toContain(item.provenance.source_type);
+    }
+  });
+  it('every ai_generated item has ai_metadata (discriminated union)', async () => {
+    const pool = await loadPracticePool();
+    for (const item of pool.items) {
+      if (item.provenance.source_type === 'ai_generated') {
+        expect(item.provenance.ai_metadata).toBeDefined();
+        expect(item.provenance.ai_metadata.model_family).toBeTypeOf('string');
+      }
+    }
+  });
+});


### PR DESCRIPTION
Deep review 提到「11 PR 零測試」— 此 PR 補足回歸測試：

- `audit-corrections.test.ts` 鎖 c2-190、c2-006、c2-132、CBAM Omnibus 日期、NDC 3.0、SF6 AR5、Cat 5 stem、2.5 萬噸公告、§56 罰鍰等
- `practice-pool.test.ts` 覆 normalizeTopicTag、filterPool、shuffle、randomSample、toQuizQuestion、loadPracticePool 各路徑

未涵蓋（後續 PR）：VisitorCounter（需 mock fetch）、PracticeOptInDialog（需 testing-library/react）、usePracticeMode（需 mock localStorage）

Base: #18