### PR TITLE
feat(ui): render verified source URLs on QuestionCard

### DIFF
--- a/quiz-app/src/components/QuestionCard/QuestionCard.css
+++ b/quiz-app/src/components/QuestionCard/QuestionCard.css
@@ -304,3 +304,47 @@
     font-size: var(--font-size-sm);
   }
 }
+
+/* 參考來源區塊 */
+.question-sources {
+  margin-top: var(--spacing-md);
+  padding: var(--spacing-sm) var(--spacing-md);
+  background: var(--color-surface-variant);
+  border-radius: var(--radius-md);
+  border-left: 3px solid var(--color-info-fg, #0369a1);
+}
+
+.question-sources-header {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+  font-size: var(--font-size-sm);
+  font-weight: 600;
+  color: var(--color-text-secondary);
+  margin-bottom: var(--spacing-xs);
+}
+
+.question-sources-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-xs) var(--spacing-md);
+}
+
+.source-link {
+  font-size: var(--font-size-xs);
+  color: var(--color-text-primary);
+  text-decoration: none;
+  border-bottom: 1px dashed currentColor;
+  transition: color 0.15s ease;
+}
+.source-link:hover {
+  color: var(--color-info-fg, #0369a1);
+}
+
+[data-theme="dark"] .question-sources {
+  background: rgba(59, 130, 246, 0.08);
+  border-left-color: #93c5fd;
+}

--- a/quiz-app/src/components/QuestionCard/QuestionCard.tsx
+++ b/quiz-app/src/components/QuestionCard/QuestionCard.tsx
@@ -204,10 +204,69 @@ export function QuestionCard({
               )}
             </div>
           )}
+
+          {question.sources && question.sources.length > 0 && (
+            <div className="question-sources" aria-label="參考來源">
+              <div className="question-sources-header">
+                <span className="material-icons sm">menu_book</span>
+                <span>參考來源</span>
+              </div>
+              <ul className="question-sources-list">
+                {question.sources.map((url) => (
+                  <li key={url}>
+                    <a
+                      href={url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="source-link"
+                    >
+                      {prettifySourceUrl(url)}
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
         </div>
       )}
     </article>
   );
+}
+
+/** 將 URL 轉成短而可讀的標籤（host + 路徑摘要） */
+function prettifySourceUrl(url: string): string {
+  try {
+    const u = new URL(url);
+    if (u.hostname.includes('law.moj.gov.tw')) {
+      const pcode = u.searchParams.get('pcode');
+      const flno = u.searchParams.get('flno');
+      const pcodeLabel: Record<string, string> = {
+        O0020098: '氣候變遷因應法',
+        O0020102: '溫管辦法',
+        O0020139: '碳費收費辦法',
+        O0020137: '自願減量專案管理辦法',
+        O0020140: '自主減量計畫管理辦法',
+      };
+      const name = pcode && pcodeLabel[pcode] ? pcodeLabel[pcode] : '法規';
+      return flno ? `${name} §${flno}` : name;
+    }
+    if (u.hostname.includes('eur-lex.europa.eu')) {
+      const celex = u.searchParams.get('uri') || '';
+      const m = celex.match(/3?(\d{4})R(\d+)/);
+      return m ? `EU Reg ${m[1]}/${m[2]}` : 'EUR-Lex';
+    }
+    if (u.hostname.includes('ipcc.ch')) return 'IPCC';
+    if (u.hostname.includes('iso.org')) return 'ISO';
+    if (u.hostname.includes('cca.gov.tw')) return '環境部 氣候變遷署';
+    if (u.hostname.includes('moenv.gov.tw')) return '環境部';
+    if (u.hostname.includes('greentrade.org.tw')) return '綠色貿易資訊網';
+    if (u.hostname.includes('cdp.net')) return 'CDP';
+    if (u.hostname.includes('vocus.cc')) return 'vocus 文章';
+    if (u.hostname.includes('github.com')) return 'GitHub Discussion';
+    return u.hostname.replace(/^www\./, '');
+  } catch {
+    return url;
+  }
 }
 
 // 選項按鈕子元件

--- a/quiz-app/src/data/questions.ts
+++ b/quiz-app/src/data/questions.ts
@@ -39,6 +39,8 @@ function convertGistQuestion(q: GistQuestion): QuizQuestion {
     sourceType: 'gist',
     year: null,
     hasAnswer: q.answer !== null,
+    sources: q.metadata?.sources,
+    explanation: q.explanation,
   };
 }
 
@@ -55,6 +57,8 @@ function convertUniqueQuestion(q: UniqueQuestion): QuizQuestion {
     sourceType: 'unique',
     year: q.year,
     hasAnswer: q.answer !== null,
+    sources: q.metadata?.sources,
+    explanation: q.explanation ?? undefined,
   };
 }
 

--- a/quiz-app/src/types/quiz.ts
+++ b/quiz-app/src/types/quiz.ts
@@ -32,6 +32,12 @@ export interface GistQuestion {
   source: string;
   original_section: string;
   exam_subject: ExamSubject;
+  explanation?: string;
+  metadata?: {
+    sources?: string[];
+    sources_verified_date?: string;
+    [k: string]: unknown;
+  };
 }
 
 /** 補充題目格式 */
@@ -54,6 +60,11 @@ export interface UniqueQuestion {
   exam_subject: ExamSubject;
   subject_confidence?: number;
   _quality_score?: number;
+  metadata?: {
+    sources?: string[];
+    sources_verified_date?: string;
+    [k: string]: unknown;
+  };
 }
 
 /** 統一的題目格式（用於測驗邏輯） */
@@ -66,6 +77,10 @@ export interface QuizQuestion {
   sourceType: 'gist' | 'unique' | 'practice_pool';
   year?: number | null;
   hasAnswer: boolean;
+  /** Curl 實測通過的引用 URL（來自 metadata.sources），UI 渲染為「參考來源」 */
+  sources?: string[];
+  /** 解析文字（給 AI helper 與 UI 參考），可能為空 */
+  explanation?: string | null;
 }
 
 /** 題庫資料集 */


### PR DESCRIPTION
Deep review M2 follow-up：

PR #8 已將 source URLs 寫入 `metadata.sources`，但 UI **從未渲染**給使用者看。此 PR 補上：

- types extend：`QuizQuestion.sources?: string[]` + `explanation?`
- questions.ts converter 把 `metadata.sources` 帶過去
- QuestionCard 在 AI 解析後加「參考來源」list
- `prettifySourceUrl()` 把 URL 轉人讀標籤（「氣候變遷因應法 §56」、「EU Reg 2025/2083」等），底層仍是原 URL

僅在 `question.sources` 非空時顯示。

## Screenshot example
- 「參考來源」標題後，列出 inline chips：氣候變遷因應法 §56 ｜ 環境部 氣候變遷署
- 點擊跳到原始連結（target="_blank" rel="noopener noreferrer"）

Base: #19