### PR TITLE
fix(deep-review-v3): 3 critical findings + a11y aria-describedby + prettify tests

### DIFF
--- a/quiz-app/src/components/PracticeOptInDialog/PracticeOptInDialog.tsx
+++ b/quiz-app/src/components/PracticeOptInDialog/PracticeOptInDialog.tsx
@@ -14,17 +14,14 @@ const FOCUSABLE_SELECTOR =
 
 export function PracticeOptInDialog({ open, onAccept, onDecline }: PracticeOptInDialogProps) {
   const dialogRef = useRef<HTMLDivElement>(null);
-  const firstFocusableRef = useRef<HTMLElement | null>(null);
 
   useEffect(() => {
     if (!open) return;
     const previouslyFocused = document.activeElement as HTMLElement | null;
 
-    // Move focus into dialog
+    // Move focus into the first focusable element inside dialog
     const focusables = dialogRef.current?.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR);
-    const first = focusables?.[0] ?? null;
-    firstFocusableRef.current = first;
-    first?.focus();
+    focusables?.[0]?.focus();
 
     // aria-hide everything OUTSIDE the dialog so SR not reading both
     const root = document.getElementById('root');
@@ -68,6 +65,7 @@ export function PracticeOptInDialog({ open, onAccept, onDecline }: PracticeOptIn
       role="dialog"
       aria-modal="true"
       aria-labelledby="optin-title"
+      aria-describedby="optin-desc"
       onClick={(e) => {
         // 點擊 overlay 外圍視為 decline（保留 dialog 內點擊）
         if (e.target === e.currentTarget) onDecline();
@@ -75,7 +73,7 @@ export function PracticeOptInDialog({ open, onAccept, onDecline }: PracticeOptIn
     >
       <div className="optin-dialog" ref={dialogRef} tabIndex={-1}>
         <h2 id="optin-title">啟用加強練習池</h2>
-        <p>
+        <p id="optin-desc">
           加強練習池是<strong>獨立於主題庫的補充題目</strong>，總計 143 題。題目來自兩種來源：
         </p>
         <ul>

--- a/quiz-app/src/components/QuestionCard/QuestionCard.tsx
+++ b/quiz-app/src/components/QuestionCard/QuestionCard.tsx
@@ -1,5 +1,5 @@
 // QuestionCard 元件 - 顯示單一題目和選項
-import { useCallback, useId, useState } from 'react';
+import { useCallback, useId, useMemo, useState } from 'react';
 import type { QuizQuestion, QuizOption } from '../../types/quiz';
 import { explainQuestion, type AIResponse } from '../../utils/ai-helper';
 import './QuestionCard.css';
@@ -52,6 +52,11 @@ export function QuestionCard({
 }: QuestionCardProps) {
   const labelId = useId();
   const [aiResponse, setAiResponse] = useState<AIResponse | null>(null);
+  const sourceLabels = useMemo(
+    () =>
+      (question.sources ?? []).map((url) => ({ url, label: prettifySourceUrl(url) })),
+    [question.sources]
+  );
   const [isLoadingAI, setIsLoadingAI] = useState(false);
 
   const getOptionStatus = useCallback(
@@ -212,7 +217,7 @@ export function QuestionCard({
                 <span>參考來源</span>
               </div>
               <ul className="question-sources-list">
-                {question.sources.map((url) => (
+                {sourceLabels.map(({ url, label }) => (
                   <li key={url}>
                     <a
                       href={url}
@@ -220,7 +225,7 @@ export function QuestionCard({
                       rel="noopener noreferrer"
                       className="source-link"
                     >
-                      {prettifySourceUrl(url)}
+                      {label}
                     </a>
                   </li>
                 ))}
@@ -233,11 +238,12 @@ export function QuestionCard({
   );
 }
 
-/** 將 URL 轉成短而可讀的標籤（host + 路徑摘要） */
-function prettifySourceUrl(url: string): string {
+/** 將 URL 轉成短而可讀的標籤；export 供測試使用 */
+export function prettifySourceUrl(url: string): string {
   try {
     const u = new URL(url);
-    if (u.hostname.includes('law.moj.gov.tw')) {
+    const host = u.hostname;
+    if (host.includes('law.moj.gov.tw')) {
       const pcode = u.searchParams.get('pcode');
       const flno = u.searchParams.get('flno');
       const pcodeLabel: Record<string, string> = {
@@ -250,20 +256,32 @@ function prettifySourceUrl(url: string): string {
       const name = pcode && pcodeLabel[pcode] ? pcodeLabel[pcode] : '法規';
       return flno ? `${name} §${flno}` : name;
     }
-    if (u.hostname.includes('eur-lex.europa.eu')) {
+    if (host.includes('eur-lex.europa.eu')) {
       const celex = u.searchParams.get('uri') || '';
-      const m = celex.match(/3?(\d{4})R(\d+)/);
-      return m ? `EU Reg ${m[1]}/${m[2]}` : 'EUR-Lex';
+      // CELEX 格式：3{year}R{number}，第一碼 3=legal acts；strip leading zeros from number
+      const m = celex.match(/3(\d{4})R(\d+)/);
+      if (m) {
+        const year = m[1];
+        const num = m[2].replace(/^0+/, '') || '0';
+        return `EU Reg ${year}/${num}`;
+      }
+      return 'EUR-Lex';
     }
-    if (u.hostname.includes('ipcc.ch')) return 'IPCC';
-    if (u.hostname.includes('iso.org')) return 'ISO';
-    if (u.hostname.includes('cca.gov.tw')) return '環境部 氣候變遷署';
-    if (u.hostname.includes('moenv.gov.tw')) return '環境部';
-    if (u.hostname.includes('greentrade.org.tw')) return '綠色貿易資訊網';
-    if (u.hostname.includes('cdp.net')) return 'CDP';
-    if (u.hostname.includes('vocus.cc')) return 'vocus 文章';
-    if (u.hostname.includes('github.com')) return 'GitHub Discussion';
-    return u.hostname.replace(/^www\./, '');
+    if (host.includes('ipcc.ch')) return 'IPCC';
+    if (host.includes('iso.org')) return 'ISO';
+    if (host.includes('cca.gov.tw')) return '環境部 氣候變遷署';
+    if (host.includes('moenv.gov.tw')) return '環境部';
+    if (host.includes('greentrade.org.tw')) return '綠色貿易資訊網';
+    if (host.includes('cdp.net')) return 'CDP';
+    if (host.includes('vocus.cc')) return 'vocus 文章';
+    if (host.includes('github.com')) {
+      // 細分 path：discussions / issues / pulls / 其他
+      if (u.pathname.includes('/discussions/')) return 'GitHub Discussion';
+      if (u.pathname.includes('/issues/')) return 'GitHub Issue';
+      if (u.pathname.includes('/pull/')) return 'GitHub PR';
+      return 'GitHub';
+    }
+    return host.replace(/^www\./, '');
   } catch {
     return url;
   }

--- a/quiz-app/src/components/QuestionCard/prettifySourceUrl.test.ts
+++ b/quiz-app/src/components/QuestionCard/prettifySourceUrl.test.ts
@@ -1,0 +1,53 @@
+// prettifySourceUrl 單元測試
+import { describe, it, expect } from 'vitest';
+import { prettifySourceUrl } from './QuestionCard';
+
+describe('prettifySourceUrl', () => {
+  it('law.moj 全條與單條', () => {
+    expect(
+      prettifySourceUrl('https://law.moj.gov.tw/LawClass/LawAll.aspx?pcode=O0020098')
+    ).toBe('氣候變遷因應法');
+    expect(
+      prettifySourceUrl('https://law.moj.gov.tw/LawClass/LawSingle.aspx?pcode=O0020098&flno=56')
+    ).toBe('氣候變遷因應法 §56');
+  });
+
+  it('EUR-Lex CELEX strips leading zeros', () => {
+    expect(
+      prettifySourceUrl('https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32023R0956')
+    ).toBe('EU Reg 2023/956');
+    expect(
+      prettifySourceUrl('https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32025R2083')
+    ).toBe('EU Reg 2025/2083');
+  });
+
+  it('GitHub path differentiation', () => {
+    expect(
+      prettifySourceUrl('https://github.com/thc1006/ipas-net-zero-quiz/discussions/1')
+    ).toBe('GitHub Discussion');
+    expect(
+      prettifySourceUrl('https://github.com/thc1006/ipas-net-zero-quiz/issues/42')
+    ).toBe('GitHub Issue');
+    expect(
+      prettifySourceUrl('https://github.com/thc1006/ipas-net-zero-quiz/pull/3')
+    ).toBe('GitHub PR');
+    expect(prettifySourceUrl('https://github.com/thc1006/ipas-net-zero-quiz')).toBe(
+      'GitHub'
+    );
+  });
+
+  it('known agency hosts', () => {
+    expect(prettifySourceUrl('https://www.ipcc.ch/report/ar5/wg1/')).toBe('IPCC');
+    expect(prettifySourceUrl('https://www.iso.org/standard/66453.html')).toBe('ISO');
+    expect(prettifySourceUrl('https://www.cca.gov.tw/')).toBe('環境部 氣候變遷署');
+    expect(prettifySourceUrl('https://www.cdp.net/en')).toBe('CDP');
+  });
+
+  it('unknown host falls back to bare host', () => {
+    expect(prettifySourceUrl('https://www.example.com/foo')).toBe('example.com');
+  });
+
+  it('malformed URL returns original string', () => {
+    expect(prettifySourceUrl('not a url')).toBe('not a url');
+  });
+});

--- a/quiz-app/src/hooks/usePracticePool.ts
+++ b/quiz-app/src/hooks/usePracticePool.ts
@@ -1,7 +1,7 @@
 // 加強練習池 React hook：依過濾條件回傳題目陣列。
 // 內部用 dynamic import 懶載入（170 KB JSON 不進 main bundle）
 
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import {
   filterPool,
   loadPracticePool,
@@ -18,7 +18,7 @@ interface UsePracticePoolResult {
   error: Error | null;
 }
 
-/** 對 opts 做淺比較，避免 caller 傳 literal 物件導致 useMemo 每次失效 */
+/** 對 opts 做穩定 key，避免 caller 傳 literal 物件導致 useMemo 每次失效 */
 function stableKey(opts: PoolFilterOptions): string {
   return JSON.stringify({
     sourceTypes: opts.sourceTypes ?? null,
@@ -29,14 +29,34 @@ function stableKey(opts: PoolFilterOptions): string {
   });
 }
 
+/** 從 stableKey 還原 opts（避免 render-time mutate ref 違反 React 18 純粹原則） */
+function parseStableKey(key: string): PoolFilterOptions {
+  try {
+    const o = JSON.parse(key) as PoolFilterOptions & {
+      sourceTypes: PoolFilterOptions['sourceTypes'] | null;
+      topicTags: PoolFilterOptions['topicTags'] | null;
+      subjects: PoolFilterOptions['subjects'] | null;
+      difficulties: PoolFilterOptions['difficulties'] | null;
+      excludeFlags: PoolFilterOptions['excludeFlags'] | null;
+    };
+    return {
+      sourceTypes: o.sourceTypes ?? undefined,
+      topicTags: o.topicTags ?? undefined,
+      subjects: o.subjects ?? undefined,
+      difficulties: o.difficulties ?? undefined,
+      excludeFlags: o.excludeFlags ?? undefined,
+    };
+  } catch {
+    return {};
+  }
+}
+
 export function usePracticePool(opts: PoolFilterOptions = {}): UsePracticePoolResult {
   const [pool, setPool] = useState<PracticePool | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
 
   const key = stableKey(opts);
-  const optsRef = useRef(opts);
-  optsRef.current = opts;
 
   useEffect(() => {
     let cancelled = false;
@@ -60,9 +80,9 @@ export function usePracticePool(opts: PoolFilterOptions = {}): UsePracticePoolRe
     };
   }, []);
 
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+  // 純由 stable key 決定 — 避免 ref 在 render 期間 mutate
   const items = useMemo(
-    () => (pool ? filterPool(pool.items, optsRef.current) : []),
+    () => (pool ? filterPool(pool.items, parseStableKey(key)) : []),
     [pool, key]
   );
 

--- a/quiz-app/src/utils/practice-pool.ts
+++ b/quiz-app/src/utils/practice-pool.ts
@@ -12,27 +12,28 @@ import type { QuizQuestion } from '../types/quiz';
 // Lazy load: 使用 dynamic import 避免 170 KB 常駐於 main bundle
 // Vite 會自動拆 chunk；僅在第一次 callers 呼叫 loadPracticePool 時載入
 let poolPromise: Promise<PracticePool> | null = null;
+/** 同步 cache：透過 loadPracticePool 與 prefetchPracticePool 都會寫入 */
+let poolCached: PracticePool | null = null;
 
 export function loadPracticePool(): Promise<PracticePool> {
   if (!poolPromise) {
-    poolPromise = import('../data/practice_pool.json').then(
-      (m) => m.default as unknown as PracticePool
-    );
+    poolPromise = import('../data/practice_pool.json').then((m) => {
+      const pool = m.default as unknown as PracticePool;
+      poolCached = pool;
+      return pool;
+    });
   }
   return poolPromise;
 }
 
 /** 供同步 caller（已確認 pool 載入完成）存取已快取的 pool */
-let poolCached: PracticePool | null = null;
 export function getPracticePoolSync(): PracticePool | null {
   return poolCached;
 }
 
 /** 預載入（UI 可於 opt-in 時呼叫，讓 quiz 啟動前 chunk 已進快取） */
 export async function prefetchPracticePool(): Promise<PracticePool> {
-  const p = await loadPracticePool();
-  poolCached = p;
-  return p;
+  return loadPracticePool();
 }
 
 /** 過濾條件 */
@@ -146,6 +147,9 @@ export async function pickQuizQuestions(
 
 /** 測試專用：重置 lazy-loaded promise cache（勿於 production 使用） */
 export function __resetPracticePoolCacheForTesting(): void {
+  // 僅供測試環境（vitest）；production build 呼叫會 no-op
+  const env = (import.meta as ImportMeta).env;
+  if (env?.PROD) return;
   poolPromise = null;
   poolCached = null;
 }


### PR DESCRIPTION
Deep review v3 找到 3 個 critical 與數個 medium，本 PR 統一修：

## 修正
- **PR #15** `optsRef.current = opts` 在 render body 違反 React 18 純粹原則 → 改用 stableKey + parseStableKey
- **PR #15** `loadPracticePool` 同步寫 `poolCached`；`__resetPracticePoolCacheForTesting` 加 PROD guard
- **PR #17** 移除死碼 `firstFocusableRef`；加 `aria-describedby` 讓 SR 讀到對話框內容說明
- **PR #20** `prettifySourceUrl` regex bug（CELEX leading zero `2023/0956` → `2023/956`）+ GitHub host 細分 path（issues/pulls/discussions）
- **PR #20** 用 `useMemo` 包 sourceLabels 避免每 render 重跑 `new URL()`

## 新測試
- `prettifySourceUrl.test.ts` 涵蓋 law.moj、EUR-Lex CELEX、GitHub path、known hosts、unknown host fallback、malformed URL

Base: #20