### PR TITLE
test: VisitorCounter + PracticeOptInDialog (RTL + fetch mock)

### DIFF
--- a/quiz-app/src/components/PracticeOptInDialog/PracticeOptInDialog.test.tsx
+++ b/quiz-app/src/components/PracticeOptInDialog/PracticeOptInDialog.test.tsx
@@ -1,0 +1,92 @@
+// PracticeOptInDialog 元件測試（focus trap / ESC / overlay click / aria）
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { PracticeOptInDialog } from './PracticeOptInDialog';
+
+afterEach(() => cleanup());
+
+describe('PracticeOptInDialog', () => {
+  it('renders nothing when not open', () => {
+    const { container } = render(
+      <PracticeOptInDialog open={false} onAccept={() => {}} onDecline={() => {}} />
+    );
+    expect(container.querySelector('.optin-dialog')).toBeNull();
+  });
+
+  it('renders dialog with role and aria-labelledby/-describedby', () => {
+    render(<PracticeOptInDialog open onAccept={() => {}} onDecline={() => {}} />);
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toHaveAttribute('aria-modal', 'true');
+    expect(dialog).toHaveAttribute('aria-labelledby', 'optin-title');
+    expect(dialog).toHaveAttribute('aria-describedby', 'optin-desc');
+    expect(document.getElementById('optin-title')).toHaveTextContent('啟用加強練習池');
+    expect(document.getElementById('optin-desc')).toBeInTheDocument();
+  });
+
+  it('calls onAccept when accept button clicked', () => {
+    const onAccept = vi.fn();
+    render(<PracticeOptInDialog open onAccept={onAccept} onDecline={() => {}} />);
+    fireEvent.click(screen.getByRole('button', { name: /我已了解/ }));
+    expect(onAccept).toHaveBeenCalledOnce();
+  });
+
+  it('calls onDecline when decline button clicked', () => {
+    const onDecline = vi.fn();
+    render(<PracticeOptInDialog open onAccept={() => {}} onDecline={onDecline} />);
+    fireEvent.click(screen.getByRole('button', { name: /暫不啟用/ }));
+    expect(onDecline).toHaveBeenCalledOnce();
+  });
+
+  it('calls onDecline when ESC pressed', () => {
+    const onDecline = vi.fn();
+    render(<PracticeOptInDialog open onAccept={() => {}} onDecline={onDecline} />);
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(onDecline).toHaveBeenCalledOnce();
+  });
+
+  it('calls onDecline when overlay (not dialog) clicked', () => {
+    const onDecline = vi.fn();
+    const { container } = render(
+      <PracticeOptInDialog open onAccept={() => {}} onDecline={onDecline} />
+    );
+    const overlay = container.querySelector('.optin-overlay') as HTMLElement;
+    // Click overlay element itself (not children)
+    fireEvent.click(overlay, { target: overlay, currentTarget: overlay });
+    // jsdom event target is the actual element clicked; use bubbled click on overlay
+    // Re-trigger via direct dispatch — bypass React synthetic event detail issues
+    // Above call is the standard approach
+    expect(onDecline).toHaveBeenCalled();
+  });
+
+  it('does NOT call onDecline when clicking inside the dialog', () => {
+    const onDecline = vi.fn();
+    render(<PracticeOptInDialog open onAccept={() => {}} onDecline={onDecline} />);
+    fireEvent.click(screen.getByText(/iPAS 不公開歷屆/));
+    expect(onDecline).not.toHaveBeenCalled();
+  });
+
+  it('focuses first focusable element on open', async () => {
+    render(<PracticeOptInDialog open onAccept={() => {}} onDecline={() => {}} />);
+    // First focusable button is "暫不啟用"
+    const decline = screen.getByRole('button', { name: /暫不啟用/ });
+    // useEffect runs synchronously enough in jsdom for focus to land
+    expect(document.activeElement).toBe(decline);
+  });
+
+  it('sets aria-hidden on #root while open and restores on close', () => {
+    // create #root
+    const root = document.createElement('div');
+    root.id = 'root';
+    document.body.appendChild(root);
+
+    const { rerender } = render(
+      <PracticeOptInDialog open onAccept={() => {}} onDecline={() => {}} />
+    );
+    expect(root.getAttribute('aria-hidden')).toBe('true');
+
+    rerender(<PracticeOptInDialog open={false} onAccept={() => {}} onDecline={() => {}} />);
+    expect(root.getAttribute('aria-hidden')).toBeNull();
+
+    document.body.removeChild(root);
+  });
+});

--- a/quiz-app/src/components/VisitorCounter/VisitorCounter.test.tsx
+++ b/quiz-app/src/components/VisitorCounter/VisitorCounter.test.tsx
@@ -1,0 +1,99 @@
+// VisitorCounter 元件測試
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor, cleanup } from '@testing-library/react';
+import { VisitorCounter } from './VisitorCounter';
+
+const ABACUS_URL = /abacus\.jasoncameron\.dev/;
+const COUNTERAPI_URL = /api\.counterapi\.dev/;
+
+function mockFetchAbacusOk(value = 42) {
+  return vi.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    json: async () => ({ value }),
+  });
+}
+
+function mockFetchAbacusFailThenCounterapiOk(count = 99) {
+  return vi.fn().mockImplementation((url: string) => {
+    if (ABACUS_URL.test(url)) {
+      return Promise.resolve({ ok: false, status: 500 });
+    }
+    if (COUNTERAPI_URL.test(url)) {
+      return Promise.resolve({ ok: true, status: 200, json: async () => ({ count }) });
+    }
+    return Promise.reject(new Error('unexpected url'));
+  });
+}
+
+function mockFetchAllFail() {
+  return vi.fn().mockResolvedValue({ ok: false, status: 503 });
+}
+
+describe('VisitorCounter', () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('shows loading then count when Abacus succeeds', async () => {
+    vi.stubGlobal('fetch', mockFetchAbacusOk(42));
+    render(<VisitorCounter namespace="test-ns" counterKey="visits" />);
+    expect(screen.getByLabelText('載入中')).toBeInTheDocument();
+    await vi.runAllTimersAsync();
+    await waitFor(() => {
+      expect(screen.getByLabelText(/訪客人次：42/)).toBeInTheDocument();
+    });
+  });
+
+  it('falls back to counterapi.dev when Abacus 5xx', async () => {
+    vi.stubGlobal('fetch', mockFetchAbacusFailThenCounterapiOk(99));
+    render(<VisitorCounter namespace="test-ns2" counterKey="visits" />);
+    await vi.runAllTimersAsync();
+    await waitFor(() => {
+      expect(screen.getByLabelText(/訪客人次：99/)).toBeInTheDocument();
+    });
+  });
+
+  it('renders nothing when both providers fail', async () => {
+    vi.stubGlobal('fetch', mockFetchAllFail());
+    const { container } = render(
+      <VisitorCounter namespace="test-ns3" counterKey="visits" />
+    );
+    await vi.runAllTimersAsync();
+    await waitFor(() => {
+      // After loading completes, container should be empty (returns null)
+      expect(container.querySelector('.visitor-counter')).toBeNull();
+    });
+  });
+
+  it('uses GET endpoint when sessionStorage marks visited', async () => {
+    sessionStorage.setItem('visited-test-ns4-visits', 'true');
+    const fetchMock = mockFetchAbacusOk(7);
+    vi.stubGlobal('fetch', fetchMock);
+    render(<VisitorCounter namespace="test-ns4" counterKey="visits" />);
+    await vi.runAllTimersAsync();
+    await waitFor(() => {
+      expect(screen.getByLabelText(/訪客人次：7/)).toBeInTheDocument();
+    });
+    // Abacus URL path should contain '/get/' not '/hit/'
+    const calledUrl = fetchMock.mock.calls[0]?.[0] as string;
+    expect(calledUrl).toMatch(/\/get\//);
+  });
+
+  it('encodes namespace and key', async () => {
+    const fetchMock = mockFetchAbacusOk(1);
+    vi.stubGlobal('fetch', fetchMock);
+    render(<VisitorCounter namespace="ns/with slash" counterKey="key#hash" />);
+    await vi.runAllTimersAsync();
+    const url = fetchMock.mock.calls[0]?.[0] as string;
+    expect(url).toContain('ns%2Fwith%20slash');
+    expect(url).toContain('key%23hash');
+  });
+});


### PR DESCRIPTION
Deep review medium follow-up：補互動 UI 元件測試。

## VisitorCounter
- Loading 狀態 → 數字渲染
- Abacus 500 → counterapi fallback
- 兩者都失敗 → 元件不渲染
- sessionStorage 已標訪問 → `/get`（不 bump）
- URL encode for namespace/key

## PracticeOptInDialog
- role/dialog + aria-modal/labelledby/describedby
- 按鈕 onAccept/onDecline
- ESC 觸發 onDecline
- 點擊 overlay 觸發 onDecline，點擊 dialog 內部不觸發
- 自動 focus 第一個 focusable
- #root aria-hidden 開關還原

CI `pnpm test:coverage` 自動跑。

Base: #22