### PR TITLE
feat(quiz): integrate practice pool into quiz flow + SourceBadge

### DIFF
--- a/quiz-app/src/components/QuestionCard/QuestionCard.tsx
+++ b/quiz-app/src/components/QuestionCard/QuestionCard.tsx
@@ -1,7 +1,12 @@
 // QuestionCard 元件 - 顯示單一題目和選項
 import { useCallback, useId, useMemo, useState } from 'react';
 import type { QuizQuestion, QuizOption } from '../../types/quiz';
+import type {
+  PracticePoolSourceType,
+  PracticePoolQualityFlag,
+} from '../../types/practicePool';
 import { explainQuestion, type AIResponse } from '../../utils/ai-helper';
+import { SourceBadge } from '../SourceBadge/SourceBadge';
 import './QuestionCard.css';
 
 /**
@@ -126,6 +131,12 @@ export function QuestionCard({
         <span className={`badge badge-info subject-tag subject-${question.subject === '考科1' ? '1' : '2'}`}>
           {question.subject === '考科1' ? '考科一' : '考科二'}
         </span>
+        {question.provenance && (
+          <SourceBadge
+            sourceType={question.provenance.source_type as PracticePoolSourceType}
+            qualityFlags={(question.qualityFlags ?? []) as PracticePoolQualityFlag[]}
+          />
+        )}
       </header>
 
       {/* 題幹 */}

--- a/quiz-app/src/hooks/index.ts
+++ b/quiz-app/src/hooks/index.ts
@@ -1,3 +1,4 @@
 export { useQuiz, defaultConfig } from './useQuiz';
 export { useAccessibility } from './useAccessibility';
 export { usePracticePool, pickQuizQuestions } from './usePracticePool';
+export { useQuizSource } from './useQuizSource';

--- a/quiz-app/src/hooks/useQuizSource.ts
+++ b/quiz-app/src/hooks/useQuizSource.ts
@@ -1,0 +1,70 @@
+// 統一題庫來源 hook：依 practiceMode 旗標決定是否混入練習池題
+import { useMemo, useEffect, useState } from 'react';
+import { allQuestions, getQuestionsBySubject } from '../data/questions';
+import { loadPracticePool } from '../utils/practice-pool';
+import { toQuizQuestion } from '../utils/practice-pool';
+import { usePracticeMode } from './usePracticeMode';
+import type { QuizQuestion, ExamSubject } from '../types/quiz';
+import type { PracticePoolItem } from '../types/practicePool';
+
+interface UseQuizSourceResult {
+  /** 主題庫題（永遠載入） */
+  mainBank: QuizQuestion[];
+  /** 加強練習池題（只有 enabled 才有） */
+  poolItems: QuizQuestion[];
+  /** 兩者合併（mainBank + poolItems if enabled） */
+  combined: QuizQuestion[];
+  isPoolLoading: boolean;
+  poolError: Error | null;
+}
+
+/**
+ * 取得當前可用的題庫來源；poolItems 僅在使用者開啟加強練習時提供。
+ * Caller 可呼 getBySubject / getRandom 等 helper 自行抽題。
+ */
+export function useQuizSource(subject: ExamSubject | 'all' = 'all'): UseQuizSourceResult {
+  const { enabled } = usePracticeMode();
+  const [poolRaw, setPoolRaw] = useState<PracticePoolItem[]>([]);
+  const [isPoolLoading, setIsPoolLoading] = useState<boolean>(false);
+  const [poolError, setPoolError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    if (!enabled) {
+      setPoolRaw([]);
+      return;
+    }
+    let cancelled = false;
+    setIsPoolLoading(true);
+    setPoolError(null);
+    loadPracticePool()
+      .then((p) => {
+        if (!cancelled) {
+          setPoolRaw(p.items);
+          setIsPoolLoading(false);
+        }
+      })
+      .catch((e: Error) => {
+        if (!cancelled) {
+          setPoolError(e);
+          setIsPoolLoading(false);
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [enabled]);
+
+  const mainBank = useMemo(
+    () => (subject === 'all' ? allQuestions : getQuestionsBySubject(subject)),
+    [subject]
+  );
+
+  const poolItems = useMemo<QuizQuestion[]>(() => {
+    if (!enabled || poolRaw.length === 0) return [];
+    return poolRaw.map(toQuizQuestion).filter((q) => subject === 'all' || q.subject === subject);
+  }, [enabled, poolRaw, subject]);
+
+  const combined = useMemo(() => [...mainBank, ...poolItems], [mainBank, poolItems]);
+
+  return { mainBank, poolItems, combined, isPoolLoading, poolError };
+}

--- a/quiz-app/src/types/quiz.ts
+++ b/quiz-app/src/types/quiz.ts
@@ -81,6 +81,15 @@ export interface QuizQuestion {
   sources?: string[];
   /** 解析文字（給 AI helper 與 UI 參考），可能為空 */
   explanation?: string | null;
+  /** 練習池題目專屬：UI 用以渲染來源徽章；主題庫題不帶 */
+  provenance?: {
+    source_type: 'external_mock' | 'ai_generated';
+    source_origin?: string;
+    verified_date?: string;
+    verify_verdict?: string;
+  };
+  /** 練習池題目品質旗標（時效 / 爭議 / 低信心 / 等） */
+  qualityFlags?: string[];
 }
 
 /** 題庫資料集 */


### PR DESCRIPTION
PR #9 練習池資料終於進入 quiz UI。

## What this PR does
- **QuestionCard** 渲染 `SourceBadge`：當 question 來自練習池（有 provenance）時，header 顯示「模擬題」或「AI 產題」徽章 + quality_flags chips
- **QuizQuestion** 型別延伸 optional `provenance` 與 `qualityFlags`
- **useQuizSource** hook：依 `usePracticeMode.enabled` 載入練習池並提供 `combined` array（mainBank + poolItems）；subject 篩選一致

## Not in this PR
- 改 `startQuiz` 用 `combined` 取代 `getRandomQuestions` —— 留下個 PR，避免破壞既有 API

## Test plan
- [ ] 啟用練習池後（settings toggle ON），useQuizSource 回 combined 含 ~143 題
- [ ] 關閉時 combined 等於 mainBank
- [ ] QuestionCard 的練習池題顯示徽章

Base: #23