### PR TITLE
fix(deep-review-v4): subject bias + type lies + test robustness

### DIFF
--- a/quiz-app/src/components/PracticeOptInDialog/PracticeOptInDialog.test.tsx
+++ b/quiz-app/src/components/PracticeOptInDialog/PracticeOptInDialog.test.tsx
@@ -1,6 +1,6 @@
 // PracticeOptInDialog 元件測試（focus trap / ESC / overlay click / aria）
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { render, screen, fireEvent, cleanup, waitFor } from '@testing-library/react';
 import { PracticeOptInDialog } from './PracticeOptInDialog';
 
 afterEach(() => cleanup());
@@ -50,12 +50,10 @@ describe('PracticeOptInDialog', () => {
       <PracticeOptInDialog open onAccept={() => {}} onDecline={onDecline} />
     );
     const overlay = container.querySelector('.optin-overlay') as HTMLElement;
-    // Click overlay element itself (not children)
-    fireEvent.click(overlay, { target: overlay, currentTarget: overlay });
-    // jsdom event target is the actual element clicked; use bubbled click on overlay
-    // Re-trigger via direct dispatch — bypass React synthetic event detail issues
-    // Above call is the standard approach
-    expect(onDecline).toHaveBeenCalled();
+    // 直接點擊 overlay：jsdom 會自動把 e.target 設為被點的元素（overlay 自己），
+    // 觸發程式碼裡 e.target === e.currentTarget 的判斷
+    fireEvent.click(overlay);
+    expect(onDecline).toHaveBeenCalledOnce();
   });
 
   it('does NOT call onDecline when clicking inside the dialog', () => {
@@ -67,10 +65,11 @@ describe('PracticeOptInDialog', () => {
 
   it('focuses first focusable element on open', async () => {
     render(<PracticeOptInDialog open onAccept={() => {}} onDecline={() => {}} />);
-    // First focusable button is "暫不啟用"
     const decline = screen.getByRole('button', { name: /暫不啟用/ });
-    // useEffect runs synchronously enough in jsdom for focus to land
-    expect(document.activeElement).toBe(decline);
+    // useEffect 在 jsdom 中時機可能不確定；用 waitFor 容錯
+    await waitFor(() => {
+      expect(document.activeElement).toBe(decline);
+    });
   });
 
   it('sets aria-hidden on #root while open and restores on close', () => {

--- a/quiz-app/src/components/QuestionCard/QuestionCard.tsx
+++ b/quiz-app/src/components/QuestionCard/QuestionCard.tsx
@@ -1,10 +1,6 @@
 // QuestionCard 元件 - 顯示單一題目和選項
 import { useCallback, useId, useMemo, useState } from 'react';
 import type { QuizQuestion, QuizOption } from '../../types/quiz';
-import type {
-  PracticePoolSourceType,
-  PracticePoolQualityFlag,
-} from '../../types/practicePool';
 import { explainQuestion, type AIResponse } from '../../utils/ai-helper';
 import { SourceBadge } from '../SourceBadge/SourceBadge';
 import './QuestionCard.css';
@@ -133,8 +129,8 @@ export function QuestionCard({
         </span>
         {question.provenance && (
           <SourceBadge
-            sourceType={question.provenance.source_type as PracticePoolSourceType}
-            qualityFlags={(question.qualityFlags ?? []) as PracticePoolQualityFlag[]}
+            sourceType={question.provenance.source_type}
+            qualityFlags={question.qualityFlags ?? []}
           />
         )}
       </header>

--- a/quiz-app/src/hooks/useQuizSource.test.tsx
+++ b/quiz-app/src/hooks/useQuizSource.test.tsx
@@ -1,0 +1,49 @@
+// useQuizSource hook test — practice mode flag drives pool inclusion
+import { afterEach, describe, expect, it, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor, cleanup } from '@testing-library/react';
+import { useQuizSource } from './useQuizSource';
+
+afterEach(() => {
+  cleanup();
+  localStorage.clear();
+});
+
+describe('useQuizSource', () => {
+  beforeEach(() => {
+    // 重設 practice-pool-enabled flag
+    localStorage.removeItem('practice-pool-enabled');
+  });
+
+  it('returns only mainBank when practice mode disabled', async () => {
+    const { result } = renderHook(() => useQuizSource('all'));
+    await waitFor(() => {
+      expect(result.current.poolItems.length).toBe(0);
+    });
+    expect(result.current.combined.length).toBe(result.current.mainBank.length);
+  });
+
+  it('loads pool when practice mode enabled', async () => {
+    localStorage.setItem('practice-pool-enabled', '1');
+    const { result } = renderHook(() => useQuizSource('all'));
+    await waitFor(() => {
+      expect(result.current.isPoolLoading).toBe(false);
+      expect(result.current.poolItems.length).toBeGreaterThan(0);
+    });
+    expect(result.current.combined.length).toBe(
+      result.current.mainBank.length + result.current.poolItems.length
+    );
+  });
+
+  it('excludes unmapped_subject items from specific subject query', async () => {
+    localStorage.setItem('practice-pool-enabled', '1');
+    const { result } = renderHook(() => useQuizSource('考科1'));
+    await waitFor(() => {
+      expect(result.current.isPoolLoading).toBe(false);
+    });
+    // 不能斷言具體題數（依資料變動），但所有 poolItems 都應該真正是考科1
+    for (const q of result.current.poolItems) {
+      expect(q.qualityFlags?.includes('unmapped_subject')).not.toBe(true);
+      expect(q.subject).toBe('考科1');
+    }
+  });
+});

--- a/quiz-app/src/hooks/useQuizSource.ts
+++ b/quiz-app/src/hooks/useQuizSource.ts
@@ -61,7 +61,12 @@ export function useQuizSource(subject: ExamSubject | 'all' = 'all'): UseQuizSour
 
   const poolItems = useMemo<QuizQuestion[]>(() => {
     if (!enabled || poolRaw.length === 0) return [];
-    return poolRaw.map(toQuizQuestion).filter((q) => subject === 'all' || q.subject === subject);
+    return poolRaw.map(toQuizQuestion).filter((q) => {
+      if (subject === 'all') return true;
+      // 排除 subject 無法明確映射的題目於 specific subject 查詢，避免誤分類偏差
+      if (q.qualityFlags?.includes('unmapped_subject')) return false;
+      return q.subject === subject;
+    });
   }, [enabled, poolRaw, subject]);
 
   const combined = useMemo(() => [...mainBank, ...poolItems], [mainBank, poolItems]);

--- a/quiz-app/src/types/practicePool.ts
+++ b/quiz-app/src/types/practicePool.ts
@@ -54,7 +54,9 @@ export type PracticePoolQualityFlag =
   | 'time_sensitive'
   | 'ambiguous'
   | 'low_confidence'
-  | 'duplicate_topic';
+  | 'duplicate_topic'
+  /** subject 無法明確映射時設此 flag；filter 時可排除 */
+  | 'unmapped_subject';
 
 /** 加強練習單題 */
 export interface PracticePoolItem {

--- a/quiz-app/src/types/quiz.ts
+++ b/quiz-app/src/types/quiz.ts
@@ -67,6 +67,9 @@ export interface UniqueQuestion {
   };
 }
 
+/** 注意：此處用 type-only import 避免循環依賴 */
+import type { PracticePoolQualityFlag } from './practicePool';
+
 /** 統一的題目格式（用於測驗邏輯） */
 export interface QuizQuestion {
   id: string;
@@ -89,7 +92,7 @@ export interface QuizQuestion {
     verify_verdict?: string;
   };
   /** 練習池題目品質旗標（時效 / 爭議 / 低信心 / 等） */
-  qualityFlags?: string[];
+  qualityFlags?: PracticePoolQualityFlag[];
 }
 
 /** 題庫資料集 */

--- a/quiz-app/src/utils/practice-pool-schema.test.ts
+++ b/quiz-app/src/utils/practice-pool-schema.test.ts
@@ -140,3 +140,118 @@ describe('validatePracticePool — synthetic invalid', () => {
     expect(errs.some((e) => e.path === '_meta.totals.total')).toBe(true);
   });
 });
+
+describe('validatePracticePool — additional invalid cases', () => {
+  const validProvExternal = {
+    source_type: 'external_mock',
+    source_origin: 'x',
+    verified_date: '2026-04-25',
+    verifier: 'x',
+    verify_verdict: 'CONFIRMED',
+    original_id: '1',
+  };
+
+  it('detects missing provenance', () => {
+    const bad = {
+      _meta: { version: '1', totals: { total: 1 } },
+      items: [
+        {
+          id: 'x',
+          stem: 's',
+          options: [{ key: 'A', text: 'a' }, { key: 'B', text: 'b' }],
+          answer: 'A',
+          explanation: '',
+          subject: null,
+          topic_tags: [],
+          difficulty: 'medium',
+          sources: [],
+          quality_flags: [],
+          // provenance missing
+        },
+      ],
+    };
+    const errs = validatePracticePool(bad);
+    expect(errs.some((e) => e.path.includes('provenance'))).toBe(true);
+  });
+
+  it('detects empty options array', () => {
+    const bad = {
+      _meta: { version: '1', totals: { total: 1 } },
+      items: [
+        {
+          id: 'x',
+          stem: 's',
+          options: [],
+          answer: null,
+          explanation: '',
+          subject: null,
+          topic_tags: [],
+          difficulty: 'medium',
+          sources: [],
+          quality_flags: [],
+          provenance: validProvExternal,
+        },
+      ],
+    };
+    const errs = validatePracticePool(bad);
+    expect(errs.some((e) => e.path.includes('options') && /non-empty/.test(e.message))).toBe(true);
+  });
+
+  it('detects non-string subject (number)', () => {
+    const bad = {
+      _meta: { version: '1', totals: { total: 1 } },
+      items: [
+        {
+          id: 'x',
+          stem: 's',
+          options: [{ key: 'A', text: 'a' }, { key: 'B', text: 'b' }],
+          answer: 'A',
+          explanation: '',
+          subject: 42, // invalid type
+          topic_tags: [],
+          difficulty: 'medium',
+          sources: [],
+          quality_flags: [],
+          provenance: validProvExternal,
+        },
+      ],
+    };
+    const errs = validatePracticePool(bad);
+    expect(errs.some((e) => e.path.includes('subject'))).toBe(true);
+  });
+
+  it('detects ai_metadata missing verifier_round', () => {
+    const bad = {
+      _meta: { version: '1', totals: { total: 1 } },
+      items: [
+        {
+          id: 'x',
+          stem: 's',
+          options: [{ key: 'A', text: 'a' }, { key: 'B', text: 'b' }],
+          answer: 'A',
+          explanation: '',
+          subject: null,
+          topic_tags: [],
+          difficulty: 'medium',
+          sources: [],
+          quality_flags: [],
+          provenance: {
+            source_type: 'ai_generated',
+            source_origin: 'x',
+            verified_date: '2026-04-25',
+            verifier: 'x',
+            verify_verdict: 'CONFIRMED',
+            original_id: '1',
+            ai_metadata: {
+              model_family: 'unspecified',
+              generation_date: '2026-04-25',
+              // verifier_round missing
+            },
+          },
+        },
+      ],
+    };
+    const errs = validatePracticePool(bad);
+    expect(errs.some((e) => e.path.includes('verifier_round'))).toBe(true);
+  });
+});

--- a/quiz-app/src/utils/practice-pool.ts
+++ b/quiz-app/src/utils/practice-pool.ts
@@ -114,6 +114,14 @@ export function toQuizQuestion(item: PracticePoolItem): QuizQuestion & {
   } else if (raw.includes('2') || raw.includes('二') || raw.toLowerCase().includes('subject 2')) {
     subject = '考科2';
   }
+
+  // subject 無法映射時加 quality flag — caller 可在 subject 篩選排除
+  // 預設 fallback 為 '考科2' 純為滿足 QuizQuestion strict subject type；
+  // 真正的「未分類」資訊在 qualityFlags 中
+  const qualityFlags = subject === null
+    ? [...(item.quality_flags ?? []), 'unmapped_subject' as const]
+    : item.quality_flags;
+
   if (subject === null && item.subject !== null && import.meta.env?.DEV) {
     // eslint-disable-next-line no-console
     console.warn(`[practice-pool] 題 ${item.id} subject 值無法映射：`, item.subject);
@@ -129,7 +137,7 @@ export function toQuizQuestion(item: PracticePoolItem): QuizQuestion & {
     year: null,
     hasAnswer: item.answer != null,
     provenance: item.provenance,
-    qualityFlags: item.quality_flags,
+    qualityFlags,
     sources: item.sources,
   };
 }


### PR DESCRIPTION
Deep review v4 — 合併修 6 點：

## Real bugs (3)
1. **Subject bias bug** (83/143 題受影響)：silent '考科2' fallback 改為加 `unmapped_subject` qualityFlag；useQuizSource 在 specific subject 查詢排除帶此 flag 的題
2. **qualityFlags type lie**：`string[]` → `PracticePoolQualityFlag[]`
3. **Redundant `as` casts** in QuestionCard：移除（型別本就 subset）

## Test robustness (3)
4. PR #23 **overlay click** fireEvent init 無效 → 簡化呼叫
5. PR #23 **focus 測試** in jsdom timing 不確定 → `waitFor` 包
6. PR #22 補 4 個 schema invalid case：缺 provenance / 空 options / 非字串 subject / 缺 verifier_round

## New test
`useQuizSource.test.tsx` 3 case：disabled 不載入 / enabled 載入 / subject 篩選排除 unmapped

Base: #24