### PR TITLE
chore(startup): assert practice_pool schema in dev mode

### DIFF
--- a/quiz-app/src/main.tsx
+++ b/quiz-app/src/main.tsx
@@ -10,6 +10,22 @@ if (!rootElement) {
   throw new Error('找不到 root 元素');
 }
 
+// Dev 模式啟動時驗證練習池 schema — 失敗會 throw 醒目錯誤
+// Production 模式不執行此驗證（節省 bundle / 啟動時間）
+if (import.meta.env.DEV) {
+  void Promise.all([
+    import('./data/practice_pool.json'),
+    import('./utils/practice-pool-schema'),
+  ])
+    .then(([poolModule, schemaModule]) => {
+      schemaModule.assertPracticePoolValid(poolModule.default);
+    })
+    .catch((err) => {
+      // eslint-disable-next-line no-console
+      console.error('[startup] practice_pool schema validation failed:', err);
+    });
+}
+
 createRoot(rootElement).render(
   <StrictMode>
     <App />


### PR DESCRIPTION
PR #22 加入的 `assertPracticePoolValid` 終於接到啟動：

- `main.tsx` DEV 模式 dynamic import + assert
- Production 完全 tree-shake 不執行
- 不阻塞 React render；async fire-and-forget

Base: #25