### PR TITLE
feat(quiz): startQuizWithPool async — mix practice pool when opted in

### DIFF
--- a/quiz-app/src/data/questions.ts
+++ b/quiz-app/src/data/questions.ts
@@ -113,6 +113,25 @@ export function getRandomQuestions(
 
   return shuffled.slice(0, Math.min(count, shuffled.length));
 }
+/**
+ * 從自訂題庫池中隨機抽題（用於混合主題庫 + 練習池等情境）
+ */
+export function getRandomQuestionsFromPool(
+  pool: QuizQuestion[],
+  count: number,
+  subject: ExamSubject | 'all' = 'all',
+  onlyWithAnswer = false
+): QuizQuestion[] {
+  let filtered = subject === 'all' ? pool : pool.filter((q) => q.subject === subject);
+  if (onlyWithAnswer) filtered = filtered.filter((q) => q.hasAnswer);
+  const shuffled = [...filtered];
+  for (let i = shuffled.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
+  }
+  return shuffled.slice(0, Math.min(count, shuffled.length));
+}
+
 
 /**
  * 依據 ID 取得題目

--- a/quiz-app/src/hooks/useQuiz.ts
+++ b/quiz-app/src/hooks/useQuiz.ts
@@ -6,7 +6,13 @@ import type {
   AnswerRecord,
   QuizResult,
 } from '../types/quiz';
-import { getRandomQuestions, getQuestionsBySubject } from '../data/questions';
+import {
+  getRandomQuestions,
+  getQuestionsBySubject,
+  getRandomQuestionsFromPool,
+  allQuestions,
+} from '../data/questions';
+import { loadPracticePool, toQuizQuestion } from '../utils/practice-pool';
 
 /** 測驗狀態 */
 export interface QuizState {
@@ -62,6 +68,64 @@ export function useQuiz() {
     }
 
     // 如果需要打亂選項順序
+    if (config.shuffleOptions) {
+      questions = questions.map((q) => ({
+        ...q,
+        options: shuffleArray([...q.options]),
+      }));
+    }
+
+    setState({
+      isActive: true,
+      questions,
+      currentIndex: 0,
+      answers: [],
+      startTime: Date.now(),
+      config,
+    });
+    setQuestionStartTime(Date.now());
+  }, []);
+
+  /**
+   * 開始測驗（async 版本）：當 config.includePracticePool 為 true 時，
+   * 動態載入練習池並混入抽題範圍；否則行為等同 startQuiz。
+   * 練習池僅在使用者於 settings 啟用後才應傳入 includePracticePool=true。
+   */
+  const startQuizWithPool = useCallback(async (config: QuizConfig) => {
+    let questions: QuizQuestion[];
+
+    if (config.includePracticePool) {
+      const pool = await loadPracticePool();
+      const poolItems = pool.items
+        .map(toQuizQuestion)
+        .filter((q) => {
+          // 只在 'all' 或明確映射 subject 一致時納入；排除 unmapped_subject
+          if (config.subject === 'all') return true;
+          if (q.qualityFlags?.includes('unmapped_subject')) return false;
+          return q.subject === config.subject;
+        });
+      const combined: QuizQuestion[] = [...allQuestions, ...poolItems];
+
+      questions = config.shuffleQuestions
+        ? getRandomQuestionsFromPool(
+            combined,
+            config.questionCount,
+            config.subject,
+            config.mode === 'exam'
+          )
+        : (config.subject === 'all' ? combined : combined.filter((q) => q.subject === config.subject))
+            .slice(0, config.questionCount);
+    } else {
+      // 不混練習池 — fallback 到 startQuiz 邏輯
+      questions = config.shuffleQuestions
+        ? getRandomQuestions(
+            config.questionCount,
+            config.subject,
+            config.mode === 'exam'
+          )
+        : getQuestionsBySubject(config.subject).slice(0, config.questionCount);
+    }
+
     if (config.shuffleOptions) {
       questions = questions.map((q) => ({
         ...q,

--- a/quiz-app/src/types/quiz.ts
+++ b/quiz-app/src/types/quiz.ts
@@ -125,6 +125,8 @@ export interface QuizConfig {
   questionCount: number;
   shuffleQuestions: boolean;
   shuffleOptions: boolean;
+  /** 是否將加強練習池題目混入抽題範圍（須使用者已 opt-in） */
+  includePracticePool?: boolean;
   showAnswerImmediately: boolean;
 }
 


### PR DESCRIPTION
PR #24 提供了 `useQuizSource` 但沒接到 `startQuiz`；本 PR 補上：

- `QuizConfig.includePracticePool?`
- `getRandomQuestionsFromPool()` 從自訂池抽題
- `useQuiz.startQuizWithPool(config)` async 方法
  - 當 `includePracticePool=true`：dynamic import + 合併 + 篩選（排除 unmapped_subject）+ 抽題
  - 當 `false`：與既有 `startQuiz` 行為一致

既有 `startQuiz` API 不變；caller 漸進採用。

Base: #26