### PR TITLE
chore(test): loosen fragile assertions + startQuizWithPool tests

### DIFF
--- a/quiz-app/src/data/audit-corrections.test.ts
+++ b/quiz-app/src/data/audit-corrections.test.ts
@@ -66,22 +66,22 @@ describe('audit corrections regression', () => {
       expect(q?.answer).toBe('A');
     });
     it('option A is 土壤', () => {
-      expect(q?.options.A).toBe('土壤');
+      expect(q?.options.A).toBe('土壤');  // 短字無需 loose
     });
   });
 
   describe('CBAM Omnibus dates (Reg 2025/2083)', () => {
     it('c1-038 surrender deadline option C → 9 月 30 日', () => {
-      expect(byId('c1-038')?.options.C).toBe('9 月 30 日');
+      expect(byId('c1-038')?.options.C).toMatch(/9\s*月\s*30\s*日/);
     });
     it('c1-040 first submission option B → 2027 年 9 月 30 日', () => {
-      expect(byId('c1-040')?.options.B).toBe('2027 年 9 月 30 日');
+      expect(byId('c1-040')?.options.B).toMatch(/2027\s*年\s*9\s*月\s*30\s*日/);
     });
   });
 
   describe('NDC 3.0 update', () => {
     it('c2-086 option B → 28 % ± 2 %', () => {
-      expect(byId('c2-086')?.options.B).toBe('28 % ± 2 %');
+      expect(byId('c2-086')?.options.B).toMatch(/28\s*%\s*±\s*2\s*%/);
     });
   });
 
@@ -90,11 +90,11 @@ describe('audit corrections regression', () => {
     const sf6_60 = byIndex(494);
     it('gist[480] 50kg SF6 answer D = 1,175 tCO2e', () => {
       const optD = sf6_50?.options.find((o) => o.key === 'D')?.text;
-      expect(optD).toBe('1,175 tCO2e');
+      expect(optD).toMatch(/1[,\s]?175\s*tCO2e/);
     });
     it('gist[494] 60kg SF6 answer D = 1,410 tCO2e', () => {
       const optD = sf6_60?.options.find((o) => o.key === 'D')?.text;
-      expect(optD).toBe('1,410 tCO2e');
+      expect(optD).toMatch(/1[,\s]?410\s*tCO2e/);
     });
   });
 

--- a/quiz-app/src/hooks/startQuizWithPool.test.tsx
+++ b/quiz-app/src/hooks/startQuizWithPool.test.tsx
@@ -1,0 +1,86 @@
+// startQuizWithPool 測試 — async 開始測驗、混入練習池
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { useQuiz } from './useQuiz';
+import { __resetPracticePoolCacheForTesting } from '../utils/practice-pool';
+
+describe('useQuiz.startQuizWithPool', () => {
+  beforeEach(() => __resetPracticePoolCacheForTesting());
+
+  it('without includePracticePool behaves like startQuiz (uses main bank)', async () => {
+    const { result } = renderHook(() => useQuiz());
+    await act(async () => {
+      await result.current.startQuizWithPool({
+        mode: 'practice',
+        subject: 'all',
+        questionCount: 5,
+        shuffleQuestions: true,
+        shuffleOptions: false,
+        showAnswerImmediately: true,
+        includePracticePool: false,
+      });
+    });
+    expect(result.current.state.questions).toHaveLength(5);
+    expect(result.current.state.isActive).toBe(true);
+    // none of the picked questions should be from practice pool
+    for (const q of result.current.state.questions) {
+      expect(q.sourceType).not.toBe('practice_pool');
+    }
+  });
+
+  it('with includePracticePool can mix in pool items', async () => {
+    const { result } = renderHook(() => useQuiz());
+    await act(async () => {
+      await result.current.startQuizWithPool({
+        mode: 'practice',
+        subject: 'all',
+        questionCount: 30,
+        shuffleQuestions: false, // ordered: mainBank first then pool
+        shuffleOptions: false,
+        showAnswerImmediately: true,
+        includePracticePool: true,
+      });
+    });
+    expect(result.current.state.questions).toHaveLength(30);
+  });
+
+  it('exam mode filters out questions without answer', async () => {
+    const { result } = renderHook(() => useQuiz());
+    await act(async () => {
+      await result.current.startQuizWithPool({
+        mode: 'exam',
+        subject: 'all',
+        questionCount: 10,
+        shuffleQuestions: false,
+        shuffleOptions: false,
+        showAnswerImmediately: false,
+        includePracticePool: true,
+      });
+    });
+    for (const q of result.current.state.questions) {
+      expect(q.hasAnswer).toBe(true);
+    }
+  });
+
+  it('subject filter excludes unmapped_subject pool items', async () => {
+    const { result } = renderHook(() => useQuiz());
+    await act(async () => {
+      await result.current.startQuizWithPool({
+        mode: 'practice',
+        subject: '考科1',
+        questionCount: 50,
+        shuffleQuestions: true,
+        shuffleOptions: false,
+        showAnswerImmediately: true,
+        includePracticePool: true,
+      });
+    });
+    for (const q of result.current.state.questions) {
+      // 全部都應該是考科1 + 不應帶 unmapped_subject 旗標
+      if (q.sourceType === 'practice_pool') {
+        expect(q.qualityFlags?.includes('unmapped_subject')).not.toBe(true);
+      }
+      expect(q.subject).toBe('考科1');
+    }
+  });
+});


### PR DESCRIPTION
兩件 deep-review 中的 medium：

1. PR #19 audit-corrections.test 字面斷言（千分號/空格 cosmetic 改會炸）→ 改 regex 容錯
2. 補 startQuizWithPool 4 case 測試（不混池 / 混池 / exam 過濾 / subject 篩 unmapped）

Base: #29