### PR TITLE
feat: wire practice pool into main flow + README + boost coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,38 +1,52 @@
 # 淨零碳備考神器 | iPAS 淨零碳規劃管理師考古題
 
 [![Deploy Quiz App to GitHub Pages](https://github.com/thc1006/ipas-net-zero-quiz/actions/workflows/quiz-app-deploy.yml/badge.svg)](https://github.com/thc1006/ipas-net-zero-quiz/actions/workflows/quiz-app-deploy.yml)
+[![Quiz App CI](https://github.com/thc1006/ipas-net-zero-quiz/actions/workflows/quiz-app-ci.yml/badge.svg?branch=main)](https://github.com/thc1006/ipas-net-zero-quiz/actions/workflows/quiz-app-ci.yml)
+[![codecov](https://codecov.io/gh/thc1006/ipas-net-zero-quiz/branch/main/graph/badge.svg)](https://codecov.io/gh/thc1006/ipas-net-zero-quiz)
 
 線上測驗：**https://thc1006.github.io/ipas-net-zero-quiz/**
 
 ## 功能特色
 
-- **719 題考古題**：涵蓋考科一和考科二
+- **648 題主題庫**：涵蓋考科一（淨零碳規劃管理基礎）與考科二（碳盤查範圍與程序）
+- **加強練習池（選用）**：開啟後額外提供 153 題補充題（55 題公開模擬題 + 98 題 AI 產題），每題附來源徽章
 - **練習/考試模式**：即時答案反饋或最後顯示結果
-- **深色模式**：保護眼睛，適合夜間使用
-- **無障礙支援**：高對比度、CVD 色覺辨認模式、可調字體大小
-- **成績匯出**：匯出測驗結果和錯題記錄
-- **AI 輔助**：題目解析和相似題目生成（使用 Gemini）
+- **參考來源連結**：每題答題後顯示權威引證（環境部、EUR-Lex、IPCC、ISO 等），URL 全部 curl 實測通過
+- **AI 解析**：透過 Puter.js 呼叫 OpenAI GPT-5.4 提供題目分析（無需 API key 設定）
+- **無障礙支援**：高對比度、CVD 色覺辨認模式、可調字體大小、深色模式
+- **EU AI Act 合規**：AI 產題依 Art.50（2026-08-02 起）規範揭露，UI 顯示警示徽章
+- **成績匯出**：匯出測驗結果與錯題記錄
+
+## 加強練習池
+
+額外的 153 題補充題庫，**獨立於主題庫**，使用者於設定頁明確 opt-in 才啟用：
+
+| 來源 | 題數 | 說明 |
+|---|---|---|
+| `external_mock` | 55 | 取自 vocus 講師、HackMD、yamol 等公開模擬題（非官方歷屆，iPAS 不公開歷屆）|
+| `ai_generated` | 98 | 由 LLM 代理依 ISO/CBAM/環境部等法規與標準產生，並經獨立驗證代理逐題以權威來源（law.moj.gov.tw、EUR-Lex、IPCC、ISO 等）交叉比對通過 |
+
+每題顯示來源徽章（「模擬題」/「AI 產題」），AI 產題用警示色 + 邊框與 quality_flags（時效性 / 爭議 / 低信心）chips。資料 schema 在啟動時於 dev 模式 fail-fast 驗證。
 
 ## 考科範圍
 
 ### 考科一：淨零碳規劃管理基礎概論
-- 淨零排放國際發展與政策趨勢
-- 永續發展與碳中和目標
-- 溫室氣體基礎知識
-- 碳管理策略與工具
+- 淨零排放國際發展與政策趨勢、CBAM、Paris Article 6
+- 永續發展與碳中和目標、PAS 2060 / ISO 14068-1
+- 溫室氣體基礎知識、IPCC GWP（AR5/AR6）
+- 碳管理策略與工具、SBTi、ISSB IFRS S1/S2
 
 ### 考科二：淨零碳盤查範圍與程序概要
-- ISO 14064 溫室氣體盤查標準
-- 組織碳盤查範疇與邊界
-- 排放係數與計算方法
-- 碳盤查報告與查證
+- ISO 14064-1:2018 六分類（Cat 1–6）盤查範疇
+- 組織碳盤查邊界（營運／財務／股權控制法）
+- 排放係數與計算方法、AR5 GWP（環境部 113/2/5 公告）
+- 碳盤查報告與查證、CFP-PCR、產品碳足跡
 
 ## 開發
 
 ### 環境需求
-
 - Node.js >= 20.0.0
-- pnpm >= 9.0.0（推薦使用 Corepack）
+- pnpm >= 9.0.0（CI 自動以 `npm install -g corepack@latest` 升級 Corepack 解 [#612](https://github.com/nodejs/corepack/issues/612) 簽名問題）
 
 ### 安裝與執行
 
@@ -43,7 +57,7 @@ corepack enable
 # 安裝依賴
 pnpm install
 
-# 開發模式
+# 開發模式（含 schema validators dev fail-fast）
 pnpm dev
 
 # 建置
@@ -52,24 +66,40 @@ pnpm build
 # 預覽建置結果
 pnpm preview
 
-# 執行測試
-pnpm test
+# 執行測試（vitest）
+pnpm test:run
 
-# E2E 測試
+# 含 coverage
+pnpm test:coverage
+
+# E2E 測試（playwright）
 pnpm test:e2e
+
+# Lint + Type check
+pnpm lint && pnpm type-check
 ```
 
 ## Stack
 
-- **框架**：React 18 + TypeScript
-- **建置工具**：Vite 6
-- **測試**：Vitest + Playwright
-- **部署**：GitHub Pages
+- **框架**：React 18 + TypeScript（嚴格模式）
+- **建置工具**：Vite 6（含 dynamic import code-splitting）
+- **測試**：Vitest + @testing-library/react + Playwright
+- **CI**：GitHub Actions（lint + tsc + test + build + e2e + CodeQL + Codecov）
+- **AI**：Puter.js + OpenAI GPT-5.4
+- **訪客計數**：Abacus（jasoncameron.dev）+ counterapi.dev fallback
+- **部署**：GitHub Pages（push to main 自動部署）
+
+## 資料品質政策
+
+- 每個答案修正都附 curl 實測通過的 primary-source URL
+- AI 產題嚴格隔離於 `ai_generated` source_type，不混入主題庫
+- 每題支援 `metadata.sources_verified_date` 與 `provenance.verify_verdict` 審計欄位
+- Schema validator 於 dev 模式啟動時自動驗證主題庫與練習池
 
 ## 授權
 
-本工具僅供練習參考。
+本工具僅供練習參考；題庫資料為個人整理，非官方發布。
 
 ## 問題回報
 
-如有任何問題或建議，請至 [Discussions](https://github.com/thc1006/ipas-net-zero-quiz/discussions/1) 回報。
+如有任何問題或建議，請至 [Discussions #1](https://github.com/thc1006/ipas-net-zero-quiz/discussions/1) 回報。

--- a/quiz-app/src/App.tsx
+++ b/quiz-app/src/App.tsx
@@ -2,6 +2,7 @@
 import { useState, useCallback } from 'react';
 import { useQuiz } from './hooks/useQuiz';
 import { useAccessibility } from './hooks/useAccessibility';
+import { usePracticeMode } from './hooks/usePracticeMode';
 import { HomePage } from './pages/HomePage';
 import { QuizPage } from './pages/QuizPage';
 import { ResultPage } from './pages/ResultPage';
@@ -19,14 +20,20 @@ function App() {
 
   const quiz = useQuiz();
   const accessibility = useAccessibility();
+  const practiceMode = usePracticeMode();
 
-  // 開始測驗
+  // 開始測驗 — 若使用者已啟用「加強練習池」（settings toggle），自動把練習池
+  // 題目混入抽題範圍（async startQuizWithPool）；否則沿用同步 startQuiz。
   const handleStartQuiz = useCallback(
-    (config: QuizConfig) => {
-      quiz.startQuiz(config);
+    async (config: QuizConfig) => {
+      if (practiceMode.enabled) {
+        await quiz.startQuizWithPool({ ...config, includePracticePool: true });
+      } else {
+        quiz.startQuiz(config);
+      }
       setCurrentView('quiz');
     },
-    [quiz]
+    [quiz, practiceMode.enabled]
   );
 
   // 完成測驗
@@ -46,12 +53,16 @@ function App() {
   }, [quiz]);
 
   // 重新測驗
-  const handleRetry = useCallback(() => {
+  const handleRetry = useCallback(async () => {
     if (lastResult?.config) {
-      quiz.startQuiz(lastResult.config);
+      if (practiceMode.enabled) {
+        await quiz.startQuizWithPool({ ...lastResult.config, includePracticePool: true });
+      } else {
+        quiz.startQuiz(lastResult.config);
+      }
       setCurrentView('quiz');
     }
-  }, [quiz, lastResult]);
+  }, [quiz, lastResult, practiceMode.enabled]);
 
   // 開啟設定
   const handleOpenSettings = useCallback(() => {

--- a/quiz-app/src/components/SourceBadge/SourceBadge.test.tsx
+++ b/quiz-app/src/components/SourceBadge/SourceBadge.test.tsx
@@ -1,0 +1,59 @@
+// SourceBadge component test
+import { afterEach, describe, expect, it } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import { SourceBadge } from './SourceBadge';
+
+afterEach(() => cleanup());
+
+describe('SourceBadge', () => {
+  it('renders external_mock with 模擬題 label', () => {
+    render(<SourceBadge sourceType="external_mock" />);
+    expect(screen.getByText('模擬題')).toBeInTheDocument();
+  });
+
+  it('renders ai_generated with AI 產題 label', () => {
+    render(<SourceBadge sourceType="ai_generated" />);
+    expect(screen.getByText('AI 產題')).toBeInTheDocument();
+  });
+
+  it('compact mode hides badge text', () => {
+    const { container } = render(
+      <SourceBadge sourceType="ai_generated" compact />
+    );
+    expect(container.querySelector('.badge-text')).toBeNull();
+  });
+
+  it('renders quality_flags chips', () => {
+    render(
+      <SourceBadge
+        sourceType="external_mock"
+        qualityFlags={['time_sensitive', 'ambiguous']}
+      />
+    );
+    expect(screen.getByText('時效')).toBeInTheDocument();
+    expect(screen.getByText('爭議')).toBeInTheDocument();
+  });
+
+  it('ignores unknown quality flag', () => {
+    render(
+      <SourceBadge
+        sourceType="external_mock"
+        qualityFlags={['unmapped_subject', 'duplicate_topic']}
+      />
+    );
+    // FLAG_LABEL only has time_sensitive/ambiguous/low_confidence; others rendered as nothing
+    expect(screen.queryByText('unmapped_subject')).toBeNull();
+  });
+
+  it('ai_generated badge has tone-ai class for warning color', () => {
+    const { container } = render(<SourceBadge sourceType="ai_generated" />);
+    const badge = container.querySelector('.source-badge');
+    expect(badge?.classList.contains('tone-ai')).toBe(true);
+  });
+
+  it('disclosure title text references EU AI Act for ai_generated', () => {
+    render(<SourceBadge sourceType="ai_generated" />);
+    const badge = screen.getByLabelText(/EU AI Act/);
+    expect(badge).toBeInTheDocument();
+  });
+});

--- a/quiz-app/src/hooks/useAccessibility.test.ts
+++ b/quiz-app/src/hooks/useAccessibility.test.ts
@@ -1,7 +1,27 @@
 // useAccessibility test — settings persistence + theme attribute
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 import { renderHook, act, cleanup } from '@testing-library/react';
 import { useAccessibility } from './useAccessibility';
+
+
+// 還原真實 localStorage 行為（test-setup.ts 把它 mock 成空函式）
+function installRealLocalStorage() {
+  const store = new Map<string, string>();
+  Object.defineProperty(window, 'localStorage', {
+    value: {
+      getItem: (k: string): string | null => store.get(k) ?? null,
+      setItem: (k: string, v: string): void => { store.set(k, v); },
+      removeItem: (k: string): void => { store.delete(k); },
+      clear: (): void => { store.clear(); },
+      key: (i: number): string | null => Array.from(store.keys())[i] ?? null,
+      get length(): number { return store.size; },
+    },
+    writable: true,
+    configurable: true,
+  });
+}
+
+beforeAll(() => { installRealLocalStorage(); });
 
 afterEach(() => {
   cleanup();

--- a/quiz-app/src/hooks/useAccessibility.test.ts
+++ b/quiz-app/src/hooks/useAccessibility.test.ts
@@ -1,0 +1,70 @@
+// useAccessibility test — settings persistence + theme attribute
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { renderHook, act, cleanup } from '@testing-library/react';
+import { useAccessibility } from './useAccessibility';
+
+afterEach(() => {
+  cleanup();
+  localStorage.clear();
+  document.documentElement.removeAttribute('data-theme');
+});
+
+describe('useAccessibility', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('default settings include darkMode and fontSize', () => {
+    const { result } = renderHook(() => useAccessibility());
+    expect(result.current.settings).toHaveProperty('darkMode');
+    expect(result.current.settings).toHaveProperty('fontSize');
+    expect(result.current.settings).toHaveProperty('cvdMode');
+    expect(result.current.settings).toHaveProperty('highContrast');
+  });
+
+  it('toggleDarkMode flips darkMode', () => {
+    const { result } = renderHook(() => useAccessibility());
+    const before = result.current.settings.darkMode;
+    act(() => result.current.toggleDarkMode());
+    expect(result.current.settings.darkMode).toBe(!before);
+  });
+
+  it('toggleHighContrast flips highContrast', () => {
+    const { result } = renderHook(() => useAccessibility());
+    const before = result.current.settings.highContrast;
+    act(() => result.current.toggleHighContrast());
+    expect(result.current.settings.highContrast).toBe(!before);
+  });
+
+  it('setFontSize updates fontSize', () => {
+    const { result } = renderHook(() => useAccessibility());
+    act(() => result.current.setFontSize('large'));
+    expect(result.current.settings.fontSize).toBe('large');
+  });
+
+  it('setCvdMode updates cvdMode', () => {
+    const { result } = renderHook(() => useAccessibility());
+    act(() => result.current.setCvdMode('protanopia'));
+    expect(result.current.settings.cvdMode).toBe('protanopia');
+  });
+
+  it('updates data-theme attribute on documentElement when darkMode changes', () => {
+    const { result } = renderHook(() => useAccessibility());
+    act(() => {
+      // explicitly enable dark mode
+      if (!result.current.settings.darkMode) result.current.toggleDarkMode();
+    });
+    expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
+  });
+
+  it('resetToDefault restores defaults', () => {
+    const { result } = renderHook(() => useAccessibility());
+    act(() => {
+      result.current.setFontSize('xlarge');
+      result.current.setCvdMode('deuteranopia');
+    });
+    act(() => result.current.resetToDefault());
+    expect(['normal']).toContain(result.current.settings.fontSize);
+    expect(result.current.settings.cvdMode).toBe('none');
+  });
+});

--- a/quiz-app/src/hooks/usePracticeMode.test.ts
+++ b/quiz-app/src/hooks/usePracticeMode.test.ts
@@ -1,0 +1,54 @@
+// usePracticeMode test — localStorage-backed enable/optIn state
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { renderHook, act, cleanup } from '@testing-library/react';
+import { usePracticeMode } from './usePracticeMode';
+
+afterEach(() => {
+  cleanup();
+  localStorage.clear();
+});
+
+describe('usePracticeMode', () => {
+  it('initial state from empty localStorage: disabled, not opted-in', () => {
+    const { result } = renderHook(() => usePracticeMode());
+    expect(result.current.enabled).toBe(false);
+    expect(result.current.hasOptedIn).toBe(false);
+  });
+
+  it('reads existing localStorage on mount', () => {
+    localStorage.setItem('practice-pool-enabled', '1');
+    localStorage.setItem('practice-pool-ai-opt-in', '1');
+    const { result } = renderHook(() => usePracticeMode());
+    expect(result.current.enabled).toBe(true);
+    expect(result.current.hasOptedIn).toBe(true);
+  });
+
+  it('enable() sets enabled and persists', () => {
+    const { result } = renderHook(() => usePracticeMode());
+    act(() => result.current.enable());
+    expect(result.current.enabled).toBe(true);
+    expect(localStorage.getItem('practice-pool-enabled')).toBe('1');
+  });
+
+  it('disable() unsets enabled', () => {
+    localStorage.setItem('practice-pool-enabled', '1');
+    const { result } = renderHook(() => usePracticeMode());
+    act(() => result.current.disable());
+    expect(result.current.enabled).toBe(false);
+    expect(localStorage.getItem('practice-pool-enabled')).toBe('0');
+  });
+
+  it('acceptOptIn() sets both opted-in and enabled', () => {
+    const { result } = renderHook(() => usePracticeMode());
+    act(() => result.current.acceptOptIn());
+    expect(result.current.hasOptedIn).toBe(true);
+    expect(result.current.enabled).toBe(true);
+  });
+
+  it('resetOptIn() unsets opted-in', () => {
+    localStorage.setItem('practice-pool-ai-opt-in', '1');
+    const { result } = renderHook(() => usePracticeMode());
+    act(() => result.current.resetOptIn());
+    expect(result.current.hasOptedIn).toBe(false);
+  });
+});

--- a/quiz-app/src/hooks/usePracticeMode.test.ts
+++ b/quiz-app/src/hooks/usePracticeMode.test.ts
@@ -1,5 +1,5 @@
 // usePracticeMode test — localStorage-backed enable/optIn state
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 import { renderHook, act, cleanup } from '@testing-library/react';
 import { usePracticeMode } from './usePracticeMode';
 

--- a/quiz-app/src/hooks/usePracticeMode.test.ts
+++ b/quiz-app/src/hooks/usePracticeMode.test.ts
@@ -1,7 +1,27 @@
 // usePracticeMode test — localStorage-backed enable/optIn state
-import { afterEach, describe, expect, it } from 'vitest';
+import { beforeAll, afterEach, describe, expect, it } from 'vitest';
 import { renderHook, act, cleanup } from '@testing-library/react';
 import { usePracticeMode } from './usePracticeMode';
+
+
+// 還原真實 localStorage 行為（test-setup.ts 把它 mock 成空函式）
+function installRealLocalStorage() {
+  const store = new Map<string, string>();
+  Object.defineProperty(window, 'localStorage', {
+    value: {
+      getItem: (k: string): string | null => store.get(k) ?? null,
+      setItem: (k: string, v: string): void => { store.set(k, v); },
+      removeItem: (k: string): void => { store.delete(k); },
+      clear: (): void => { store.clear(); },
+      key: (i: number): string | null => Array.from(store.keys())[i] ?? null,
+      get length(): number { return store.size; },
+    },
+    writable: true,
+    configurable: true,
+  });
+}
+
+beforeAll(() => { installRealLocalStorage(); });
 
 afterEach(() => {
   cleanup();

--- a/quiz-app/src/hooks/useQuizSource.test.tsx
+++ b/quiz-app/src/hooks/useQuizSource.test.tsx
@@ -1,5 +1,5 @@
 // useQuizSource hook test — practice mode flag drives pool inclusion
-import { afterEach, describe, expect, it, beforeEach } from 'vitest';
+import { afterEach, beforeAll, describe, expect, it, beforeEach } from 'vitest';
 import { renderHook, waitFor, cleanup } from '@testing-library/react';
 import { useQuizSource } from './useQuizSource';
 import { __resetPracticePoolCacheForTesting } from '../utils/practice-pool';

--- a/quiz-app/src/hooks/useQuizSource.test.tsx
+++ b/quiz-app/src/hooks/useQuizSource.test.tsx
@@ -4,6 +4,26 @@ import { renderHook, waitFor, cleanup } from '@testing-library/react';
 import { useQuizSource } from './useQuizSource';
 import { __resetPracticePoolCacheForTesting } from '../utils/practice-pool';
 
+
+// 還原真實 localStorage 行為（test-setup.ts 把它 mock 成空函式）
+function installRealLocalStorage() {
+  const store = new Map<string, string>();
+  Object.defineProperty(window, 'localStorage', {
+    value: {
+      getItem: (k: string): string | null => store.get(k) ?? null,
+      setItem: (k: string, v: string): void => { store.set(k, v); },
+      removeItem: (k: string): void => { store.delete(k); },
+      clear: (): void => { store.clear(); },
+      key: (i: number): string | null => Array.from(store.keys())[i] ?? null,
+      get length(): number { return store.size; },
+    },
+    writable: true,
+    configurable: true,
+  });
+}
+
+beforeAll(() => { installRealLocalStorage(); });
+
 afterEach(() => {
   cleanup();
   localStorage.clear();

--- a/quiz-app/src/pages/HomePage.test.tsx
+++ b/quiz-app/src/pages/HomePage.test.tsx
@@ -1,0 +1,42 @@
+// HomePage component test — practice mode indicator + start callback
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { HomePage } from './HomePage';
+
+afterEach(() => {
+  cleanup();
+  localStorage.clear();
+});
+
+describe('HomePage', () => {
+  it('renders title and stats badges', () => {
+    render(<HomePage onStartQuiz={() => {}} />);
+    expect(screen.getByText(/淨零碳備考神器/)).toBeInTheDocument();
+    // stats badges
+    expect(screen.getByText(/考科一/)).toBeInTheDocument();
+    expect(screen.getByText(/考科二/)).toBeInTheDocument();
+  });
+
+  it('does NOT show practice-pool indicator when disabled', () => {
+    render(<HomePage onStartQuiz={() => {}} />);
+    expect(screen.queryByText(/加強練習池啟用中/)).toBeNull();
+  });
+
+  it('shows practice-pool indicator when enabled', () => {
+    localStorage.setItem('practice-pool-enabled', '1');
+    render(<HomePage onStartQuiz={() => {}} />);
+    expect(screen.getByText(/加強練習池啟用中/)).toBeInTheDocument();
+  });
+
+  it('calls onStartQuiz with current config when 開始 clicked', () => {
+    const onStartQuiz = vi.fn();
+    render(<HomePage onStartQuiz={onStartQuiz} />);
+    const startBtn = screen.getByRole('button', { name: /開始/ });
+    fireEvent.click(startBtn);
+    expect(onStartQuiz).toHaveBeenCalledOnce();
+    const config = onStartQuiz.mock.calls[0][0];
+    expect(config).toHaveProperty('mode');
+    expect(config).toHaveProperty('subject');
+    expect(config).toHaveProperty('questionCount');
+  });
+});

--- a/quiz-app/src/pages/HomePage.test.tsx
+++ b/quiz-app/src/pages/HomePage.test.tsx
@@ -1,7 +1,27 @@
 // HomePage component test — practice mode indicator + start callback
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { beforeAll, afterEach, describe, expect, it, vi } from 'vitest';
 import { render, screen, fireEvent, cleanup } from '@testing-library/react';
 import { HomePage } from './HomePage';
+
+
+// 還原真實 localStorage 行為（test-setup.ts 把它 mock 成空函式）
+function installRealLocalStorage() {
+  const store = new Map<string, string>();
+  Object.defineProperty(window, 'localStorage', {
+    value: {
+      getItem: (k: string): string | null => store.get(k) ?? null,
+      setItem: (k: string, v: string): void => { store.set(k, v); },
+      removeItem: (k: string): void => { store.delete(k); },
+      clear: (): void => { store.clear(); },
+      key: (i: number): string | null => Array.from(store.keys())[i] ?? null,
+      get length(): number { return store.size; },
+    },
+    writable: true,
+    configurable: true,
+  });
+}
+
+beforeAll(() => { installRealLocalStorage(); });
 
 afterEach(() => {
   cleanup();

--- a/quiz-app/src/pages/HomePage.test.tsx
+++ b/quiz-app/src/pages/HomePage.test.tsx
@@ -32,9 +32,9 @@ describe('HomePage', () => {
   it('renders title and stats badges', () => {
     render(<HomePage onStartQuiz={() => {}} />);
     expect(screen.getByText(/淨零碳備考神器/)).toBeInTheDocument();
-    // stats badges
-    expect(screen.getByText(/考科一/)).toBeInTheDocument();
-    expect(screen.getByText(/考科二/)).toBeInTheDocument();
+    // 考科一 / 考科二 出現多次（select option + badge），用 getAllByText
+    expect(screen.getAllByText(/考科一/).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/考科二/).length).toBeGreaterThan(0);
   });
 
   it('does NOT show practice-pool indicator when disabled', () => {

--- a/quiz-app/src/pages/HomePage.tsx
+++ b/quiz-app/src/pages/HomePage.tsx
@@ -2,6 +2,7 @@
 import { useState, useCallback } from 'react';
 import { stats } from '../data/questions';
 import { defaultConfig } from '../hooks/useQuiz';
+import { usePracticeMode } from '../hooks/usePracticeMode';
 import type { QuizConfig, ExamSubject } from '../types/quiz';
 import './HomePage.css';
 
@@ -11,6 +12,7 @@ interface HomePageProps {
 
 export function HomePage({ onStartQuiz }: HomePageProps) {
   const [config, setConfig] = useState<QuizConfig>(defaultConfig);
+  const practiceMode = usePracticeMode();
 
   const handleSubjectChange = useCallback(
     (e: React.ChangeEvent<HTMLSelectElement>) => {
@@ -73,6 +75,12 @@ export function HomePage({ onStartQuiz }: HomePageProps) {
           <span className="badge badge-info">
             考科二 {stats.subject2} 題
           </span>
+          {practiceMode.enabled && (
+            <span className="badge badge-warning" title="加強練習池啟用中：包含模擬題與 AI 產題">
+              <span className="material-icons sm">auto_awesome</span>
+              加強練習池啟用中
+            </span>
+          )}
         </div>
       </section>
 

--- a/quiz-app/src/pages/SettingsPage.test.tsx
+++ b/quiz-app/src/pages/SettingsPage.test.tsx
@@ -1,9 +1,29 @@
 // SettingsPage component test — practice toggle + opt-in dialog flow
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { beforeAll, afterEach, describe, expect, it, vi } from 'vitest';
 import { render, screen, fireEvent, cleanup, waitFor } from '@testing-library/react';
 import { SettingsPage } from './SettingsPage';
 import { useAccessibility } from '../hooks/useAccessibility';
 import { renderHook } from '@testing-library/react';
+
+
+// 還原真實 localStorage 行為（test-setup.ts 把它 mock 成空函式）
+function installRealLocalStorage() {
+  const store = new Map<string, string>();
+  Object.defineProperty(window, 'localStorage', {
+    value: {
+      getItem: (k: string): string | null => store.get(k) ?? null,
+      setItem: (k: string, v: string): void => { store.set(k, v); },
+      removeItem: (k: string): void => { store.delete(k); },
+      clear: (): void => { store.clear(); },
+      key: (i: number): string | null => Array.from(store.keys())[i] ?? null,
+      get length(): number { return store.size; },
+    },
+    writable: true,
+    configurable: true,
+  });
+}
+
+beforeAll(() => { installRealLocalStorage(); });
 
 afterEach(() => {
   cleanup();

--- a/quiz-app/src/pages/SettingsPage.test.tsx
+++ b/quiz-app/src/pages/SettingsPage.test.tsx
@@ -1,0 +1,58 @@
+// SettingsPage component test — practice toggle + opt-in dialog flow
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, fireEvent, cleanup, waitFor } from '@testing-library/react';
+import { SettingsPage } from './SettingsPage';
+import { useAccessibility } from '../hooks/useAccessibility';
+import { renderHook } from '@testing-library/react';
+
+afterEach(() => {
+  cleanup();
+  localStorage.clear();
+});
+
+function renderSettings(onClose = () => {}) {
+  const { result: accResult } = renderHook(() => useAccessibility());
+  return render(<SettingsPage accessibility={accResult.current} onClose={onClose} />);
+}
+
+describe('SettingsPage', () => {
+  it('renders main sections', () => {
+    renderSettings();
+    expect(screen.getByText(/外觀/)).toBeInTheDocument();
+    expect(screen.getByText(/無障礙/)).toBeInTheDocument();
+    expect(screen.getByText(/加強練習池/)).toBeInTheDocument();
+  });
+
+  it('clicking close button calls onClose', () => {
+    const onClose = vi.fn();
+    renderSettings(onClose);
+    fireEvent.click(screen.getByLabelText('關閉設定'));
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it('practice-pool toggle with no opt-in opens dialog', async () => {
+    renderSettings();
+    const toggle = screen.getByLabelText('啟用加強練習池');
+    fireEvent.click(toggle);
+    await waitFor(() => {
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+    });
+  });
+
+  it('practice-pool toggle with prior opt-in skips dialog and enables', () => {
+    localStorage.setItem('practice-pool-ai-opt-in', '1');
+    renderSettings();
+    const toggle = screen.getByLabelText('啟用加強練習池') as HTMLInputElement;
+    fireEvent.click(toggle);
+    expect(localStorage.getItem('practice-pool-enabled')).toBe('1');
+  });
+
+  it('toggle when already enabled disables', () => {
+    localStorage.setItem('practice-pool-ai-opt-in', '1');
+    localStorage.setItem('practice-pool-enabled', '1');
+    renderSettings();
+    const toggle = screen.getByLabelText('啟用加強練習池') as HTMLInputElement;
+    fireEvent.click(toggle);
+    expect(localStorage.getItem('practice-pool-enabled')).toBe('0');
+  });
+});


### PR DESCRIPTION
三件事一次處理：

## 1. 練習池真的可以從主畫面用了
PR #33 帶入了所有資料/types/hooks/components，但 `App.tsx` 從不讀 `practiceMode.enabled`、永遠呼叫同步 `startQuiz`。本 PR：

- `App.tsx handleStartQuiz / handleRetry` 讀 `practiceMode.enabled` 決定走 `startQuiz`(同步) vs `startQuizWithPool`(async)
- `HomePage` 啟用時顯示「加強練習池啟用中」徽章

使用流程：Settings → 啟用加強練習（看 opt-in 對話框）→ 回首頁開始測驗 → 自動混入練習池題（含 SourceBadge + 來源連結）。

## 2. README 更新
- 719→648 主題庫 + 153 練習池
- Gemini → OpenAI GPT-5.4 (Puter.js)
- 新增加強練習池、EU AI Act 揭露、CI/Codecov 徽章
- 開發指令補齊（lint / type-check / coverage / e2e）

## 3. 補測試從 51.54% → 預期 80%+
新增 5 支測試檔（29 個 test case）：
- `usePracticeMode.test.ts` (6)
- `useAccessibility.test.ts` (7)
- `SourceBadge.test.tsx` (7)
- `HomePage.test.tsx` (4)
- `SettingsPage.test.tsx` (5)
EOF
)