### PR TITLE
feat(design): Carbon Ledger 視覺重設計 + App.test 補覆蓋

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,5 @@
+{
+  "enabledPlugins": {
+    "frontend-design@claude-plugins-official": true
+  }
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,0 @@
-{
-  "enabledPlugins": {
-    "frontend-design@claude-plugins-official": true
-  }
-}

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ PROGRESS_DASHBOARD.md
 batch_*_raw.json
 REMAINING_*.json
 check_progress.sh
+.claude/

--- a/quiz-app/index.html
+++ b/quiz-app/index.html
@@ -13,6 +13,15 @@
     <meta property="og:description" content="719 題考古題線上測驗，支援 AI 輔助學習" />
     <meta property="og:type" content="website" />
 
+    <!-- Carbon Ledger 字體系統：Fraunces (display serif, opsz+SOFT 軸)、
+         Public Sans (body humanist sans)、JetBrains Mono (tabular figures) -->
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght,SOFT@0,9..144,300..720,0..100;1,9..144,300..720,0..100&family=JetBrains+Mono:wght@400;500;600&family=Public+Sans:ital,wght@0,300..700;1,300..700&display=swap"
+      rel="stylesheet"
+    />
+
     <title>淨零碳備考神器 | iPAS 淨零碳規劃管理師考古題</title>
   </head>
   <body>

--- a/quiz-app/src/App.css
+++ b/quiz-app/src/App.css
@@ -53,3 +53,107 @@
     padding: var(--spacing-md) var(--spacing-sm);
   }
 }
+
+/* ==============================================================
+ * Carbon Ledger Footer 簽署列
+ * ============================================================== */
+
+.cl-footer {
+  background: var(--color-surface);
+  border-top: 1px solid var(--color-rule-strong);
+  margin-top: 4rem;
+  padding: 2rem clamp(1rem, 4vw, 3rem) 1rem;
+}
+
+.cl-footer__container {
+  max-width: 1200px;
+  margin: 0 auto;
+  display: grid;
+  grid-template-columns: 1.4fr 1fr 1fr;
+  gap: 2rem;
+  align-items: flex-start;
+}
+
+@media (max-width: 720px) {
+  .cl-footer__container {
+    grid-template-columns: 1fr;
+    gap: 1.5rem;
+  }
+}
+
+.cl-footer__col {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.cl-footer__mark {
+  letter-spacing: 0.2em;
+  color: var(--color-text-quiet);
+}
+
+.cl-footer__disclaimer {
+  font-size: 0.82rem;
+  line-height: 1.55;
+  color: var(--color-text-secondary);
+  margin: 0;
+  font-style: italic;
+  font-family: var(--font-display);
+  font-variation-settings: 'opsz' 14, 'wght' 360;
+}
+
+.cl-footer__links {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.cl-footer__links a {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  color: var(--color-text-secondary);
+  text-decoration: none;
+  font-size: 0.88rem;
+  border-bottom: 1px solid transparent;
+  transition: color 100ms ease, border-color 100ms ease;
+}
+
+.cl-footer__links a:hover {
+  color: var(--color-primary);
+  border-bottom-color: var(--color-primary);
+}
+
+.cl-footer__links .material-icons.sm {
+  font-size: 16px;
+  color: var(--color-text-quiet);
+}
+
+.cl-footer__counter {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  align-items: flex-start;
+}
+
+.cl-footer__counter-caption {
+  font-size: 0.72rem;
+  color: var(--color-text-quiet);
+  font-style: italic;
+}
+
+.cl-footer__sig {
+  margin: 1.5rem 0 0.75rem;
+}
+
+.cl-footer__copy {
+  font-size: 0.7rem;
+  letter-spacing: 0.2em;
+  color: var(--color-text-quiet);
+  text-align: center;
+  margin: 0;
+  text-transform: uppercase;
+}

--- a/quiz-app/src/App.css
+++ b/quiz-app/src/App.css
@@ -81,6 +81,26 @@
   }
 }
 
+@media (max-width: 640px) {
+  .cl-footer {
+    margin-top: 2.5rem;
+    padding: 1.5rem 1rem 0.85rem;
+  }
+  .cl-footer__container {
+    gap: 1.25rem;
+  }
+  .cl-footer__disclaimer {
+    font-size: 0.78rem;
+  }
+  .cl-footer__sig {
+    margin: 1rem 0 0.6rem;
+  }
+  .cl-footer__copy {
+    font-size: 0.62rem;
+    letter-spacing: 0.15em;
+  }
+}
+
 .cl-footer__col {
   display: flex;
   flex-direction: column;

--- a/quiz-app/src/App.test.tsx
+++ b/quiz-app/src/App.test.tsx
@@ -1,0 +1,78 @@
+// App component test — covers practice-mode wiring from PR #34
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, fireEvent, cleanup, waitFor } from '@testing-library/react';
+import App from './App';
+
+// 還原真實 localStorage（test-setup.ts mock 成空函式）
+function installRealLocalStorage() {
+  const store = new Map<string, string>();
+  Object.defineProperty(window, 'localStorage', {
+    value: {
+      getItem: (k: string): string | null => store.get(k) ?? null,
+      setItem: (k: string, v: string): void => { store.set(k, v); },
+      removeItem: (k: string): void => { store.delete(k); },
+      clear: (): void => { store.clear(); },
+      key: (i: number): string | null => Array.from(store.keys())[i] ?? null,
+      get length(): number { return store.size; },
+    },
+    writable: true,
+    configurable: true,
+  });
+}
+
+beforeAll(() => { installRealLocalStorage(); });
+
+beforeEach(() => {
+  // mock fetch（VisitorCounter 啟動時呼叫）— 預設失敗讓元件回 null
+  vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 503 }));
+});
+
+afterEach(() => {
+  cleanup();
+  localStorage.clear();
+  vi.restoreAllMocks();
+});
+
+describe('App', () => {
+  it('renders Header brand and HomePage by default', () => {
+    render(<App />);
+    expect(screen.getAllByText(/淨零碳備考神器/).length).toBeGreaterThan(0);
+    expect(screen.getByLabelText(/開啟設定/)).toBeInTheDocument();
+  });
+
+  it('navigates to settings page when 開啟設定 clicked', () => {
+    render(<App />);
+    fireEvent.click(screen.getByLabelText(/開啟設定/));
+    expect(screen.getByText(/^外觀$/)).toBeInTheDocument();
+    expect(screen.getByText(/^無障礙$/)).toBeInTheDocument();
+  });
+
+  it('starts quiz from HomePage and lands on QuizPage', async () => {
+    render(<App />);
+    const startBtn = screen.getByRole('button', { name: /開始/ });
+    fireEvent.click(startBtn);
+    // QuizPage shows question card with at least an option button
+    await waitFor(() => {
+      // 第 X 題 indicator
+      expect(screen.getByText(/第\s*1\s*題/)).toBeInTheDocument();
+    });
+  });
+
+  it('practice-mode enabled triggers async startQuizWithPool path', async () => {
+    localStorage.setItem('practice-pool-enabled', '1');
+    localStorage.setItem('practice-pool-ai-opt-in', '1');
+    render(<App />);
+    const startBtn = screen.getByRole('button', { name: /開始/ });
+    fireEvent.click(startBtn);
+    // 練習池載入是 async，等到 quiz page 出現
+    await waitFor(() => {
+      expect(screen.getByText(/第\s*1\s*題/)).toBeInTheDocument();
+    });
+  });
+
+  it('Header GitHub icon link points to discussions', () => {
+    render(<App />);
+    const link = screen.getByLabelText(/社群討論/);
+    expect(link).toHaveAttribute('href', expect.stringContaining('/discussions/1'));
+  });
+});

--- a/quiz-app/src/App.test.tsx
+++ b/quiz-app/src/App.test.tsx
@@ -20,9 +20,28 @@ function installRealLocalStorage() {
   });
 }
 
+// test-setup.ts 已 mock matchMedia，但 vi.restoreAllMocks 會清掉；每個 test 重新確保
+function ensureMatchMedia() {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    configurable: true,
+    value: (query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    }),
+  });
+}
+
 beforeAll(() => { installRealLocalStorage(); });
 
 beforeEach(() => {
+  ensureMatchMedia();
   // mock fetch（VisitorCounter 啟動時呼叫）— 預設失敗讓元件回 null
   vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 503 }));
 });
@@ -30,7 +49,7 @@ beforeEach(() => {
 afterEach(() => {
   cleanup();
   localStorage.clear();
-  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
 });
 
 describe('App', () => {

--- a/quiz-app/src/App.tsx
+++ b/quiz-app/src/App.tsx
@@ -115,34 +115,55 @@ function App() {
         )}
       </main>
 
-      {/* 頁尾 */}
-      <footer className="app-footer">
-        <div className="container">
-          <div className="footer-links">
-            <a
-              href="https://github.com/thc1006/ipas-net-zero-quiz"
-              target="_blank"
-              rel="noopener noreferrer"
-              aria-label="GitHub 專案連結"
-            >
-              <span className="material-icons sm">code</span>
-              GitHub
-            </a>
-            <span className="divider">·</span>
-            <a
-              href="https://github.com/thc1006/ipas-net-zero-quiz/discussions/1"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              問題回報
-            </a>
-            <span className="divider">·</span>
-            <VisitorCounter />
+      {/* 頁尾 — Carbon Ledger 簽署列 */}
+      <footer className="app-footer cl-footer">
+        <div className="container cl-footer__container">
+          <div className="cl-footer__col cl-footer__col--brand">
+            <span className="cl-eyebrow cl-footer__mark">— END OF DOCUMENT</span>
+            <p className="cl-footer__disclaimer">
+              題庫僅供練習參考；非 iPAS 官方教材。每題答案皆附第一手 primary-source 引證。
+            </p>
           </div>
-          <p className="copyright">
-            題庫僅供練習參考
-          </p>
+
+          <div className="cl-footer__col cl-footer__col--links">
+            <span className="cl-eyebrow">索引</span>
+            <ul className="cl-footer__links">
+              <li>
+                <a
+                  href="https://github.com/thc1006/ipas-net-zero-quiz"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  aria-label="GitHub 專案連結"
+                >
+                  <span className="material-icons sm">code</span>
+                  原始碼
+                </a>
+              </li>
+              <li>
+                <a
+                  href="https://github.com/thc1006/ipas-net-zero-quiz/discussions/1"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  <span className="material-icons sm">forum</span>
+                  社群討論 / 問題回報
+                </a>
+              </li>
+            </ul>
+          </div>
+
+          <div className="cl-footer__col cl-footer__col--meta">
+            <span className="cl-eyebrow">登錄</span>
+            <div className="cl-footer__counter">
+              <VisitorCounter />
+              <span className="cl-footer__counter-caption">累積訪客（per-session 去重）</span>
+            </div>
+          </div>
         </div>
+        <hr className="cl-rule cl-rule--soft cl-footer__sig" aria-hidden="true" />
+        <p className="copyright cl-footer__copy cl-figure" aria-label="copyright">
+          NZ-Q · ARCHIVE EDITION 2026 / Q2 · v1.0.0
+        </p>
       </footer>
     </div>
   );

--- a/quiz-app/src/components/Header/Header.css
+++ b/quiz-app/src/components/Header/Header.css
@@ -167,7 +167,16 @@
   color: var(--color-primary) !important;
 }
 
-@media (max-width: 480px) {
+@media (max-width: 640px) {
   .cl-header__subtitle { display: none; }
-  .cl-header__title { font-size: 0.95rem; }
+  .cl-header__title { font-size: 1rem; }
+  .cl-header__container { min-height: 56px; padding: 0 0.85rem; }
+  .cl-header__mark { width: 30px; height: 30px; }
+  .cl-header__brand { gap: 0.6rem; }
+  .cl-header__nav { gap: 0.15rem; }
+  .cl-header__icon-btn { padding: 0.45rem !important; }
+}
+
+@media (max-width: 380px) {
+  .cl-header__title { font-size: 0.92rem; }
 }

--- a/quiz-app/src/components/Header/Header.css
+++ b/quiz-app/src/components/Header/Header.css
@@ -144,27 +144,50 @@
 }
 
 .cl-header__subtitle {
-  font-size: 0.62rem !important;
-  color: var(--color-text-quiet) !important;
-  letter-spacing: 0.16em !important;
+  font-size: 0.78rem;
+  color: var(--color-text-quiet);
+  letter-spacing: 0.02em;
   margin-top: 0.2rem;
+  font-weight: 400;
 }
 
 .cl-header__nav {
+  display: inline-flex;
+  align-items: center;
   gap: 0;
   border-left: 1px solid var(--color-rule-soft);
   padding-left: 0.5rem;
   margin-left: 0.5rem;
 }
 
+/* Icon button — 自包含樣式（不再依賴 .btn .btn-text .icon-btn 全域樣式，
+   也不需 !important 來壓 cascade）*/
 .cl-header__icon-btn {
-  border-radius: 2px !important;
-  color: var(--color-text-secondary) !important;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  border: 0;
+  padding: 0.55rem;
+  border-radius: 2px;
+  color: var(--color-text-secondary);
+  cursor: pointer;
+  transition: background-color 100ms ease, color 100ms ease;
+  text-decoration: none;
 }
 
 .cl-header__icon-btn:hover {
-  background: var(--color-surface-variant) !important;
-  color: var(--color-primary) !important;
+  background: var(--color-surface-variant);
+  color: var(--color-primary);
+}
+
+.cl-header__icon-btn:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
+.cl-header__icon-btn .material-icons {
+  font-size: 22px;
 }
 
 @media (max-width: 640px) {
@@ -174,7 +197,7 @@
   .cl-header__mark { width: 30px; height: 30px; }
   .cl-header__brand { gap: 0.6rem; }
   .cl-header__nav { gap: 0.15rem; }
-  .cl-header__icon-btn { padding: 0.45rem !important; }
+  .cl-header__icon-btn { padding: 0.45rem; }
 }
 
 @media (max-width: 380px) {

--- a/quiz-app/src/components/Header/Header.css
+++ b/quiz-app/src/components/Header/Header.css
@@ -89,3 +89,85 @@
     padding: var(--spacing-xs) var(--spacing-sm);
   }
 }
+
+/* ==============================================================
+ * Carbon Ledger 覆蓋層
+ * ============================================================== */
+
+.cl-header {
+  background: var(--color-surface);
+  border-bottom: 1px solid var(--color-rule-strong);
+  box-shadow: none;
+}
+
+.cl-header__container {
+  align-items: stretch;
+  padding: 0 clamp(1rem, 3vw, 2rem);
+  min-height: 64px;
+}
+
+.cl-header__brand {
+  gap: 0.85rem;
+  padding: 0.5rem 0.5rem 0.5rem 0;
+  align-items: center;
+}
+
+.cl-header__brand:hover {
+  background: transparent;
+}
+.cl-header__brand:hover .cl-header__title {
+  color: var(--color-primary);
+}
+
+.cl-header__mark {
+  color: var(--color-primary);
+  flex-shrink: 0;
+  transition: transform 240ms ease;
+}
+.cl-header__brand:hover .cl-header__mark {
+  transform: rotate(-8deg);
+}
+
+.cl-header__words {
+  align-items: flex-start;
+  gap: 0.1rem;
+}
+
+.cl-header__title {
+  font-family: var(--font-display);
+  font-variation-settings: 'opsz' 24, 'wght' 540, 'SOFT' 30;
+  font-size: 1.05rem;
+  letter-spacing: -0.01em;
+  color: var(--color-text-primary);
+  line-height: 1;
+  transition: color 100ms ease;
+}
+
+.cl-header__subtitle {
+  font-size: 0.62rem !important;
+  color: var(--color-text-quiet) !important;
+  letter-spacing: 0.16em !important;
+  margin-top: 0.2rem;
+}
+
+.cl-header__nav {
+  gap: 0;
+  border-left: 1px solid var(--color-rule-soft);
+  padding-left: 0.5rem;
+  margin-left: 0.5rem;
+}
+
+.cl-header__icon-btn {
+  border-radius: 2px !important;
+  color: var(--color-text-secondary) !important;
+}
+
+.cl-header__icon-btn:hover {
+  background: var(--color-surface-variant) !important;
+  color: var(--color-primary) !important;
+}
+
+@media (max-width: 480px) {
+  .cl-header__subtitle { display: none; }
+  .cl-header__title { font-size: 0.95rem; }
+}

--- a/quiz-app/src/components/Header/Header.tsx
+++ b/quiz-app/src/components/Header/Header.tsx
@@ -1,4 +1,6 @@
-// Header 元件 - 頂部導覽列
+// Header 元件 — Carbon Ledger 版頂部導覽列
+// 設計：左側為「碳足跡」logomark（CO₂ 圓 + 序號）+ Fraunces wordmark；
+//      右側為功能列；社群討論用 forum icon（不再是章魚貓）
 import type { useAccessibility } from '../../hooks/useAccessibility';
 import './Header.css';
 
@@ -12,22 +14,52 @@ export function Header({ onOpenSettings, onGoHome, accessibility }: HeaderProps)
   const { settings, toggleDarkMode } = accessibility;
 
   return (
-    <header className="app-header">
-      <div className="header-container">
-        {/* Logo / 標題 */}
-        <button className="header-logo" onClick={onGoHome} aria-label="回首頁">
-          <span className="material-icons lg">eco</span>
-          <div className="logo-text">
-            <span className="logo-title">淨零碳備考神器</span>
-            <span className="logo-subtitle">iPAS 考古題練習</span>
+    <header className="app-header cl-header">
+      <div className="header-container cl-header__container">
+        {/* Logomark + wordmark */}
+        <button className="header-logo cl-header__brand" onClick={onGoHome} aria-label="回首頁">
+          <svg
+            className="cl-header__mark"
+            viewBox="0 0 36 36"
+            width="36"
+            height="36"
+            aria-hidden="true"
+          >
+            {/* 雙圓：外圓代表大氣，內圓代表碳；缺口表示「淨零」差距正在被計量 */}
+            <circle cx="18" cy="18" r="15.5" fill="none" stroke="currentColor" strokeWidth="1" opacity="0.3" />
+            <circle cx="18" cy="18" r="11" fill="none" stroke="currentColor" strokeWidth="1.5" />
+            <path
+              d="M 18 7 A 11 11 0 0 1 26.7 23.7"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="3"
+              strokeLinecap="round"
+            />
+            {/* tabular CO₂ marker */}
+            <text
+              x="18"
+              y="22.5"
+              textAnchor="middle"
+              fontSize="9.5"
+              fontFamily="JetBrains Mono, monospace"
+              fontWeight="600"
+              fill="currentColor"
+            >
+              CO₂
+            </text>
+          </svg>
+          <div className="logo-text cl-header__words">
+            <span className="logo-title cl-header__title">淨零碳備考神器</span>
+            <span className="logo-subtitle cl-header__subtitle cl-eyebrow">
+              ARCHIVE / iPAS-NZ
+            </span>
           </div>
         </button>
 
         {/* 功能按鈕 */}
-        <nav className="header-actions" aria-label="功能選單">
-          {/* 深色模式切換 */}
+        <nav className="header-actions cl-header__nav" aria-label="功能選單">
           <button
-            className="btn btn-text icon-btn"
+            className="btn btn-text icon-btn cl-header__icon-btn"
             onClick={toggleDarkMode}
             aria-label={settings.darkMode ? '切換淺色模式' : '切換深色模式'}
             title={settings.darkMode ? '淺色模式' : '深色模式'}
@@ -37,9 +69,8 @@ export function Header({ onOpenSettings, onGoHome, accessibility }: HeaderProps)
             </span>
           </button>
 
-          {/* 設定 */}
           <button
-            className="btn btn-text icon-btn"
+            className="btn btn-text icon-btn cl-header__icon-btn"
             onClick={onOpenSettings}
             aria-label="開啟設定"
             title="設定"
@@ -47,24 +78,16 @@ export function Header({ onOpenSettings, onGoHome, accessibility }: HeaderProps)
             <span className="material-icons">settings</span>
           </button>
 
-          {/* 社群討論 / 回報題目 */}
+          {/* 社群討論 / 回報題目 — 改用 forum icon 對齊意圖 */}
           <a
             href="https://github.com/thc1006/ipas-net-zero-quiz/discussions/1"
             target="_blank"
             rel="noopener noreferrer"
-            className="btn btn-text icon-btn"
+            className="btn btn-text icon-btn cl-header__icon-btn"
             aria-label="社群討論 / 回報題目"
             title="社群討論"
           >
-            <svg
-              viewBox="0 0 24 24"
-              width="24"
-              height="24"
-              fill="currentColor"
-              aria-hidden="true"
-            >
-              <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
-            </svg>
+            <span className="material-icons">forum</span>
           </a>
         </nav>
       </div>

--- a/quiz-app/src/components/Header/Header.tsx
+++ b/quiz-app/src/components/Header/Header.tsx
@@ -50,8 +50,8 @@ export function Header({ onOpenSettings, onGoHome, accessibility }: HeaderProps)
           </svg>
           <div className="logo-text cl-header__words">
             <span className="logo-title cl-header__title">淨零碳備考神器</span>
-            <span className="logo-subtitle cl-header__subtitle cl-eyebrow">
-              ARCHIVE / iPAS-NZ
+            <span className="logo-subtitle cl-header__subtitle">
+              iPAS 考古題
             </span>
           </div>
         </button>
@@ -59,7 +59,7 @@ export function Header({ onOpenSettings, onGoHome, accessibility }: HeaderProps)
         {/* 功能按鈕 */}
         <nav className="header-actions cl-header__nav" aria-label="功能選單">
           <button
-            className="btn btn-text icon-btn cl-header__icon-btn"
+            className="cl-header__icon-btn"
             onClick={toggleDarkMode}
             aria-label={settings.darkMode ? '切換淺色模式' : '切換深色模式'}
             title={settings.darkMode ? '淺色模式' : '深色模式'}
@@ -70,7 +70,7 @@ export function Header({ onOpenSettings, onGoHome, accessibility }: HeaderProps)
           </button>
 
           <button
-            className="btn btn-text icon-btn cl-header__icon-btn"
+            className="cl-header__icon-btn"
             onClick={onOpenSettings}
             aria-label="開啟設定"
             title="設定"
@@ -83,7 +83,7 @@ export function Header({ onOpenSettings, onGoHome, accessibility }: HeaderProps)
             href="https://github.com/thc1006/ipas-net-zero-quiz/discussions/1"
             target="_blank"
             rel="noopener noreferrer"
-            className="btn btn-text icon-btn cl-header__icon-btn"
+            className="cl-header__icon-btn"
             aria-label="社群討論 / 回報題目"
             title="社群討論"
           >

--- a/quiz-app/src/components/PracticeOptInDialog/PracticeOptInDialog.css
+++ b/quiz-app/src/components/PracticeOptInDialog/PracticeOptInDialog.css
@@ -1,56 +1,332 @@
-/* PracticeOptInDialog 樣式 */
+/*
+ * PracticeOptInDialog — Carbon Ledger 版
+ * 兩欄佈局：左欄為視覺化來源條形比例，右欄為文字解說 + CTA。
+ */
 
 .optin-overlay {
   position: fixed;
   inset: 0;
-  background: rgba(0, 0, 0, 0.55);
+  background: rgba(15, 27, 31, 0.55);
   display: flex;
   align-items: center;
   justify-content: center;
   z-index: 1000;
-  padding: var(--spacing-md);
+  padding: clamp(1rem, 4vw, 3rem);
+  backdrop-filter: blur(2px);
+  -webkit-backdrop-filter: blur(2px);
+  animation: cl-overlay-in 220ms ease both;
+}
+
+@keyframes cl-overlay-in {
+  from { opacity: 0; }
+  to { opacity: 1; }
 }
 
 .optin-dialog {
   background: var(--color-surface);
   color: var(--color-text-primary);
-  border-radius: var(--radius-lg);
-  padding: var(--spacing-lg);
-  max-width: 560px;
+  border-radius: 4px;
+  border: 1px solid var(--color-border);
+  max-width: 780px;
   width: 100%;
-  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+  max-height: calc(100vh - 4rem);
+  overflow-y: auto;
+  box-shadow: var(--shadow-4);
+  animation: cl-dialog-in 280ms cubic-bezier(0.2, 0.8, 0.2, 1) both;
+  position: relative;
 }
 
-.optin-dialog h2 {
-  margin-top: 0;
-  margin-bottom: var(--spacing-md);
+@keyframes cl-dialog-in {
+  from { transform: translateY(8px); opacity: 0; }
+  to { transform: translateY(0); opacity: 1; }
 }
 
-.optin-dialog p,
-.optin-dialog ul {
-  font-size: var(--font-size-sm);
-  line-height: 1.6;
-  margin: var(--spacing-sm) 0;
+/* archive corner mark */
+.optin-dialog::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 60px;
+  height: 4px;
+  background: var(--color-primary);
 }
 
-.optin-dialog ul {
-  padding-left: 1.25em;
+.optin-dialog__head {
+  padding: 1.75rem 2rem 1.25rem;
+  border-bottom: 1px solid var(--color-rule-soft);
 }
 
-.optin-dialog li {
-  margin-bottom: var(--spacing-xs);
+.optin-dialog__title {
+  font-size: clamp(1.6rem, 3vw, 2.4rem);
+  margin: 0.4rem 0 0;
+  line-height: 1;
+  letter-spacing: -0.02em;
 }
 
-.optin-note {
-  font-size: var(--font-size-xs);
+.optin-dialog__body {
+  display: grid;
+  grid-template-columns: 1fr 1.4fr;
+  gap: 2rem;
+  padding: 1.5rem 2rem;
+  align-items: flex-start;
+}
+
+@media (max-width: 720px) {
+  .optin-dialog__body {
+    grid-template-columns: 1fr;
+    gap: 1.5rem;
+  }
+}
+
+/* === left panel: source bars === */
+
+.optin-source-panel {
+  background: var(--color-surface-variant);
+  padding: 1.25rem;
+  border-radius: 3px;
+  border: 1px solid var(--color-rule-soft);
+}
+
+.optin-source-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.optin-source-row {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.optin-source-row__head {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  font-size: 0.85rem;
+}
+
+.optin-source-row__label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-variation-settings: 'wght' 540;
+  color: var(--color-text-primary);
+}
+
+.optin-source-row__dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+}
+.optin-source-row__dot.tone-mock {
+  background: var(--color-info);
+}
+.optin-source-row__dot.tone-ai {
+  background: var(--color-warning);
+}
+
+.optin-source-row__count {
+  font-size: 1.4rem;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  color: var(--color-text-primary);
+}
+
+.optin-source-bar {
+  height: 8px;
+  background: var(--color-info);
+  border-radius: 1px;
+  position: relative;
+  /* 條形帶斜紋紋理 — 像會計賬本的網點 */
+  background-image: repeating-linear-gradient(
+    -45deg,
+    transparent,
+    transparent 4px,
+    rgba(0, 0, 0, 0.08) 4px,
+    rgba(0, 0, 0, 0.08) 5px
+  );
+  background-color: var(--color-info);
+  animation: cl-bar-grow 600ms cubic-bezier(0.2, 0.8, 0.2, 1) both;
+  transform-origin: left center;
+}
+.optin-source-bar.tone-ai {
+  background-color: var(--color-warning);
+}
+
+@keyframes cl-bar-grow {
+  from { transform: scaleX(0); }
+  to { transform: scaleX(1); }
+}
+
+.optin-source-row__caption {
+  font-size: 0.75rem;
+  color: var(--color-text-quiet);
+  font-style: italic;
+}
+
+.optin-source-total {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  margin-top: 0.5rem;
+  padding-top: 0.75rem;
+  border-top: 1px solid var(--color-rule-strong);
+}
+
+.optin-source-total__num {
+  font-size: 1.8rem;
+  font-weight: 600;
+  letter-spacing: -0.04em;
+  color: var(--color-primary);
+}
+
+/* === right panel: copy === */
+
+.optin-dialog__copy {
+  font-size: 0.95rem;
+  line-height: 1.65;
+}
+
+.optin-dialog__lead {
+  font-family: var(--font-display);
+  font-variation-settings: 'opsz' 24, 'wght' 380;
+  font-size: 1.1rem;
+  line-height: 1.45;
+  margin: 0 0 1.25rem;
+  color: var(--color-text-primary);
+}
+
+.optin-dialog__lead em {
+  font-style: italic;
+  font-variation-settings: 'opsz' 24, 'wght' 360, 'SOFT' 100;
+  color: var(--color-primary);
+  margin: 0 0.05em;
+}
+
+.optin-bullets {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+}
+
+.optin-bullets li {
+  display: grid;
+  grid-template-columns: 28px 1fr;
+  gap: 0.65rem;
+  align-items: flex-start;
+  font-size: 0.9rem;
   color: var(--color-text-secondary);
-  border-top: 1px solid var(--color-border, rgba(0, 0, 0, 0.1));
-  padding-top: var(--spacing-sm);
+  line-height: 1.55;
 }
+
+.optin-bullets em {
+  font-style: italic;
+  color: var(--color-text-primary);
+}
+
+.optin-bullets .cl-fn-marker {
+  margin-top: 0.2em;
+}
+
+.optin-bullets .cl-figure {
+  font-size: 0.86em;
+  background: var(--color-rule-soft);
+  padding: 0 0.3em;
+  border-radius: 1px;
+  color: var(--color-text-primary);
+}
+
+.optin-disclosure {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin: 1rem 0 0;
+  padding: 0.65rem 0.85rem;
+  font-size: 0.78rem;
+  background: var(--color-primary-soft);
+  color: var(--color-text-primary);
+  border-left: 2px solid var(--color-primary);
+  border-radius: 1px;
+}
+
+.optin-disclosure .material-icons.sm {
+  font-size: 16px;
+  color: var(--color-primary);
+}
+
+/* === actions === */
 
 .optin-actions {
   display: flex;
   justify-content: flex-end;
-  gap: var(--spacing-sm);
-  margin-top: var(--spacing-md);
+  gap: 0.75rem;
+  padding: 1.25rem 2rem;
+  border-top: 1px solid var(--color-rule-soft);
+  background: var(--color-surface-variant);
+}
+
+.cl-btn-primary,
+.cl-btn-secondary {
+  font-family: var(--font-body);
+  font-size: 0.92rem;
+  font-variation-settings: 'wght' 540;
+  padding: 0.6rem 1.1rem;
+  border-radius: 2px;
+  cursor: pointer;
+  border: 1px solid transparent;
+  transition: transform 80ms ease, box-shadow 100ms ease;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  letter-spacing: 0.02em;
+}
+
+.cl-btn-secondary {
+  background: transparent;
+  border-color: var(--color-border);
+  color: var(--color-text-primary);
+}
+.cl-btn-secondary:hover {
+  border-color: var(--color-text-secondary);
+  background: var(--color-surface);
+}
+
+.cl-btn-primary {
+  background: var(--color-primary);
+  color: var(--color-on-primary);
+  box-shadow: 0 1px 0 var(--color-primary-dark);
+}
+.cl-btn-primary:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 3px 0 var(--color-primary-dark);
+}
+.cl-btn-primary:active {
+  transform: translateY(1px);
+  box-shadow: 0 0 0 var(--color-primary-dark);
+}
+
+.cl-btn-primary__arrow {
+  font-size: 18px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .optin-overlay,
+  .optin-dialog,
+  .optin-source-bar {
+    animation: none !important;
+  }
+}
+
+.optin-dialog__sub {
+  margin: 0.5rem 0 0;
+  font-family: var(--font-display);
+  font-variation-settings: 'opsz' 24, 'wght' 360, 'SOFT' 100;
+  font-style: italic;
+  font-size: 1.05rem;
+  color: var(--color-text-secondary);
 }

--- a/quiz-app/src/components/PracticeOptInDialog/PracticeOptInDialog.css
+++ b/quiz-app/src/components/PracticeOptInDialog/PracticeOptInDialog.css
@@ -330,3 +330,55 @@
   font-size: 1.05rem;
   color: var(--color-text-secondary);
 }
+
+/* ============== MOBILE TUNING (≤640px) ============== */
+@media (max-width: 640px) {
+  .optin-overlay {
+    padding: 0.75rem;
+    align-items: flex-end; /* 從底部滑上來，較像原生 mobile sheet */
+  }
+  .optin-dialog {
+    max-height: calc(100vh - 1.5rem);
+    border-radius: 4px 4px 0 0;
+  }
+  .optin-dialog__head {
+    padding: 1.25rem 1.25rem 1rem;
+  }
+  .optin-dialog__title {
+    font-size: 1.5rem;
+  }
+  .optin-dialog__sub {
+    font-size: 0.95rem;
+  }
+  .optin-dialog__body {
+    padding: 1rem 1.25rem;
+    gap: 1rem;
+  }
+  .optin-source-panel {
+    padding: 0.85rem;
+  }
+  .optin-source-row__count {
+    font-size: 1.2rem;
+  }
+  .optin-dialog__lead {
+    font-size: 1rem;
+    margin-bottom: 1rem;
+  }
+  .optin-bullets li {
+    font-size: 0.86rem;
+  }
+  .optin-disclosure {
+    font-size: 0.74rem;
+    padding: 0.55rem 0.7rem;
+  }
+  .optin-actions {
+    padding: 1rem 1.25rem;
+    flex-direction: column-reverse; /* primary CTA 在上 */
+    gap: 0.5rem;
+  }
+  .optin-actions .cl-btn-primary,
+  .optin-actions .cl-btn-secondary {
+    width: 100%;
+    justify-content: center;
+  }
+}

--- a/quiz-app/src/components/PracticeOptInDialog/PracticeOptInDialog.tsx
+++ b/quiz-app/src/components/PracticeOptInDialog/PracticeOptInDialog.tsx
@@ -2,6 +2,7 @@
 // 設計：兩欄佈局；左欄視覺敘事（兩種來源視覺化條形）、右欄文字解說與 CTA。
 // 對應 EU AI Act Art.50（2026-08-02 起）對 AI 生成文字之揭露義務。
 import { useEffect, useRef } from 'react';
+import { PRACTICE_POOL_COUNTS } from '../../data/practice-pool-counts';
 import './PracticeOptInDialog.css';
 
 interface PracticeOptInDialogProps {
@@ -60,9 +61,10 @@ export function PracticeOptInDialog({ open, onAccept, onDecline }: PracticeOptIn
 
   if (!open) return null;
 
-  // 條形比例：54:89 為實際數字
-  const mockPct = (54 / 143) * 100;
-  const aiPct = (89 / 143) * 100;
+  // 條形比例：以實際 pool 計數為單一事實來源
+  const { externalMock, aiGenerated, total } = PRACTICE_POOL_COUNTS;
+  const mockPct = (externalMock / total) * 100;
+  const aiPct = (aiGenerated / total) * 100;
 
   return (
     <div
@@ -94,7 +96,7 @@ export function PracticeOptInDialog({ open, onAccept, onDecline }: PracticeOptIn
                     <span className="optin-source-row__dot tone-mock" />
                     模擬題
                   </span>
-                  <span className="cl-figure optin-source-row__count">54</span>
+                  <span className="cl-figure optin-source-row__count">{externalMock}</span>
                 </div>
                 <div
                   className="optin-source-bar"
@@ -109,7 +111,7 @@ export function PracticeOptInDialog({ open, onAccept, onDecline }: PracticeOptIn
                     <span className="optin-source-row__dot tone-ai" />
                     AI 產題
                   </span>
-                  <span className="cl-figure optin-source-row__count">89</span>
+                  <span className="cl-figure optin-source-row__count">{aiGenerated}</span>
                 </div>
                 <div
                   className="optin-source-bar tone-ai"
@@ -120,7 +122,7 @@ export function PracticeOptInDialog({ open, onAccept, onDecline }: PracticeOptIn
 
               <div className="optin-source-total">
                 <span className="cl-eyebrow">total addendum</span>
-                <span className="cl-figure optin-source-total__num">143</span>
+                <span className="cl-figure optin-source-total__num">{total}</span>
               </div>
             </div>
           </aside>
@@ -129,7 +131,7 @@ export function PracticeOptInDialog({ open, onAccept, onDecline }: PracticeOptIn
           <div className="optin-dialog__copy">
             <p id="optin-desc" className="optin-dialog__lead">
               這是一份<em>獨立於主題庫</em>的補充題庫。
-              啟用後，下一場練習的抽題範圍會混入這 143 題，每一題都會帶來源徽章——
+              啟用後，下一場練習的抽題範圍會混入這 {total} 題，每一題都會帶來源徽章——
               你隨時看得出眼前這題出自哪裡。
             </p>
 

--- a/quiz-app/src/components/PracticeOptInDialog/PracticeOptInDialog.tsx
+++ b/quiz-app/src/components/PracticeOptInDialog/PracticeOptInDialog.tsx
@@ -1,5 +1,6 @@
-// 加強練習池 opt-in 對話框：首次啟用時揭露 AI 產題與第三方模擬題之來源
-// 對應 EU AI Act Art.50（2026-08-02 起）對 AI 生成文字之揭露義務
+// 加強練習池 opt-in 對話框 — Carbon Ledger 友善版
+// 設計：兩欄佈局；左欄視覺敘事（兩種來源視覺化條形）、右欄文字解說與 CTA。
+// 對應 EU AI Act Art.50（2026-08-02 起）對 AI 生成文字之揭露義務。
 import { useEffect, useRef } from 'react';
 import './PracticeOptInDialog.css';
 
@@ -35,7 +36,6 @@ export function PracticeOptInDialog({ open, onAccept, onDecline }: PracticeOptIn
         return;
       }
       if (e.key !== 'Tab') return;
-      // Simple focus trap
       const nodes = dialogRef.current?.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR);
       if (!nodes || nodes.length === 0) return;
       const f = nodes[0];
@@ -59,6 +59,11 @@ export function PracticeOptInDialog({ open, onAccept, onDecline }: PracticeOptIn
   }, [open, onDecline]);
 
   if (!open) return null;
+
+  // 條形比例：54:89 為實際數字
+  const mockPct = (54 / 143) * 100;
+  const aiPct = (89 / 143) * 100;
+
   return (
     <div
       className="optin-overlay"
@@ -67,38 +72,110 @@ export function PracticeOptInDialog({ open, onAccept, onDecline }: PracticeOptIn
       aria-labelledby="optin-title"
       aria-describedby="optin-desc"
       onClick={(e) => {
-        // 點擊 overlay 外圍視為 decline（保留 dialog 內點擊）
         if (e.target === e.currentTarget) onDecline();
       }}
     >
       <div className="optin-dialog" ref={dialogRef} tabIndex={-1}>
-        <h2 id="optin-title">啟用加強練習池</h2>
-        <p id="optin-desc">
-          加強練習池是<strong>獨立於主題庫的補充題目</strong>，總計 143 題。題目來自兩種來源：
-        </p>
-        <ul>
-          <li>
-            <strong>模擬題（54 題）</strong>：取自 vocus 講師、HackMD、yamol 等公開模擬題，
-            非官方歷屆試題（iPAS 不公開歷屆）。
-          </li>
-          <li>
-            <strong>AI 產題（89 題）</strong>：由語言模型依環境部、CBAM、ISO 等法規與標準
-            產生，並經獨立驗證代理逐題以權威來源（law.moj.gov.tw、EUR-Lex、IPCC、ISO 等）
-            交叉比對通過。
-          </li>
-        </ul>
-        <p className="optin-note">
-          每題皆顯示來源徽章。AI 產題答案雖經驗證，仍以官方教材為最終依據。
-          本揭露依 EU AI Act Art. 50（2026-08-02 起對 AI 生成文字強制揭露）。
-        </p>
-        <div className="optin-actions">
-          <button className="btn btn-secondary" onClick={onDecline}>
+        <header className="optin-dialog__head">
+          <span className="cl-eyebrow">Addendum / 加強練習池</span>
+          <h2 id="optin-title" className="cl-display optin-dialog__title">
+            啟用加強練習池
+          </h2>
+          <p className="optin-dialog__sub">加進來，可以嗎？</p>
+        </header>
+
+        <div className="optin-dialog__body">
+          {/* 左欄：視覺化來源 */}
+          <aside className="optin-source-panel" aria-hidden="true">
+            <div className="optin-source-stack">
+              <div className="optin-source-row">
+                <div className="optin-source-row__head">
+                  <span className="optin-source-row__label">
+                    <span className="optin-source-row__dot tone-mock" />
+                    模擬題
+                  </span>
+                  <span className="cl-figure optin-source-row__count">54</span>
+                </div>
+                <div
+                  className="optin-source-bar"
+                  style={{ width: `${mockPct}%` }}
+                />
+                <div className="optin-source-row__caption">vocus 講師、HackMD、yamol</div>
+              </div>
+
+              <div className="optin-source-row">
+                <div className="optin-source-row__head">
+                  <span className="optin-source-row__label">
+                    <span className="optin-source-row__dot tone-ai" />
+                    AI 產題
+                  </span>
+                  <span className="cl-figure optin-source-row__count">89</span>
+                </div>
+                <div
+                  className="optin-source-bar tone-ai"
+                  style={{ width: `${aiPct}%` }}
+                />
+                <div className="optin-source-row__caption">由獨立驗證代理 cross-check</div>
+              </div>
+
+              <div className="optin-source-total">
+                <span className="cl-eyebrow">total addendum</span>
+                <span className="cl-figure optin-source-total__num">143</span>
+              </div>
+            </div>
+          </aside>
+
+          {/* 右欄：文字 */}
+          <div className="optin-dialog__copy">
+            <p id="optin-desc" className="optin-dialog__lead">
+              這是一份<em>獨立於主題庫</em>的補充題庫。
+              啟用後，下一場練習的抽題範圍會混入這 143 題，每一題都會帶來源徽章——
+              你隨時看得出眼前這題出自哪裡。
+            </p>
+
+            <ol className="optin-bullets">
+              <li>
+                <span className="cl-fn-marker">1</span>
+                <div>
+                  <strong>模擬題</strong>取自公開講師整理（vocus / HackMD / yamol 等）；
+                  iPAS 不公開歷屆試題，這是<em>非官方</em>的最佳替代。
+                </div>
+              </li>
+              <li>
+                <span className="cl-fn-marker">2</span>
+                <div>
+                  <strong>AI 產題</strong>由語言模型基於環境部、CBAM Reg、ISO 14064/14067、IPCC 等法規與標準
+                  產生，每題經獨立驗證代理逐條對照<span className="cl-figure">law.moj.gov.tw</span>、
+                  <span className="cl-figure">EUR-Lex</span>、<span className="cl-figure">IPCC</span>、<span className="cl-figure">ISO</span>。
+                </div>
+              </li>
+              <li>
+                <span className="cl-fn-marker">3</span>
+                <div>
+                  <strong>仍以官方教材為最終依據。</strong>
+                  AI 產題不可能保證 100% 正確；用來補強，不取代你手邊的講義。
+                </div>
+              </li>
+            </ol>
+
+            <p className="optin-disclosure">
+              <span className="material-icons sm">verified_user</span>
+              <span>
+                揭露依 <span className="cl-figure">EU AI Act Art. 50</span>（2026-08-02 對 AI 生成文字強制揭露生效）
+              </span>
+            </p>
+          </div>
+        </div>
+
+        <footer className="optin-actions">
+          <button className="btn btn-secondary cl-btn-secondary" onClick={onDecline}>
             暫不啟用
           </button>
-          <button className="btn btn-primary" onClick={onAccept}>
+          <button className="btn btn-primary cl-btn-primary" onClick={onAccept}>
             我已了解，啟用加強練習
+            <span className="material-icons cl-btn-primary__arrow">arrow_forward</span>
           </button>
-        </div>
+        </footer>
       </div>
     </div>
   );

--- a/quiz-app/src/components/SourceBadge/SourceBadge.css
+++ b/quiz-app/src/components/SourceBadge/SourceBadge.css
@@ -1,51 +1,123 @@
-/* SourceBadge 樣式 */
+/*
+ * SourceBadge — Carbon Ledger 樣式
+ * 礦物色 dot + 等寬縮寫 (EM/AI) + 微體標籤；AI 產題用 oxide rust + 邊框警示
+ */
 
 .source-badge {
   display: inline-flex;
   align-items: center;
-  gap: var(--spacing-xs);
-  padding: 2px 8px;
-  border-radius: var(--radius-full);
-  font-size: var(--font-size-xs);
-  font-weight: 500;
+  gap: 0.4rem;
+  padding: 3px 8px;
+  border-radius: 2px;
+  font-family: var(--font-body);
+  font-size: 0.72rem;
+  letter-spacing: 0.04em;
   line-height: 1.4;
   vertical-align: middle;
+  border: 1px solid transparent;
+  background: var(--color-surface-elevated);
+}
+
+.source-badge__dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  background: currentColor;
+}
+
+.source-badge__abbrev {
+  font-size: 0.7rem;
+  letter-spacing: 0.08em;
+  font-weight: 600;
+  color: inherit;
+  opacity: 0.7;
 }
 
 .source-badge .badge-text {
   white-space: nowrap;
+  font-variation-settings: 'wght' 540;
 }
 
+/* === Light tones === */
+
 .source-badge.tone-mock {
-  background: var(--color-info-bg, #e0f2fe);
-  color: var(--color-info-fg, #0369a1);
+  background: var(--color-info-bg);
+  color: var(--color-info-fg);
+  border-color: var(--color-info-bg);
 }
 
 .source-badge.tone-ai {
-  background: var(--color-warning-bg, #fef3c7);
-  color: var(--color-warning-fg, #92400e);
-  border: 1px solid var(--color-warning-fg, #92400e);
+  background: var(--color-warning-bg);
+  color: var(--color-warning-fg);
+  border-color: var(--color-warning);
+  /* slight inset emboss 表「需注意」*/
+  box-shadow: inset 0 0 0 1px var(--color-warning-bg);
 }
 
-/* 與 useAccessibility 對齊：使用 [data-theme="dark"]，不靠 system prefers */
-[data-theme="dark"] .source-badge.tone-mock {
-  background: rgba(59, 130, 246, 0.15);
-  color: #93c5fd;
+.source-badge.tone-ai .source-badge__dot {
+  background: var(--color-warning);
+  /* 跳動的小光圈 — 視線吸引 */
+  animation: cl-ai-pulse 2.4s ease-in-out infinite;
+  box-shadow: 0 0 0 0 var(--color-warning);
 }
-[data-theme="dark"] .source-badge.tone-ai {
-  background: rgba(245, 158, 11, 0.15);
-  color: #fbbf24;
-  border-color: rgba(245, 158, 11, 0.4);
+
+@keyframes cl-ai-pulse {
+  0%, 100% {
+    box-shadow: 0 0 0 0 rgba(168, 91, 26, 0.35);
+  }
+  50% {
+    box-shadow: 0 0 0 4px rgba(168, 91, 26, 0);
+  }
 }
+
+/* === Dark mode（依 [data-theme="dark"]）=== */
+
+[data-theme='dark'] .source-badge.tone-mock {
+  background: var(--color-info-bg);
+  color: var(--color-info-fg);
+  border-color: rgba(179, 197, 199, 0.3);
+}
+
+[data-theme='dark'] .source-badge.tone-ai {
+  background: var(--color-warning-bg);
+  color: var(--color-warning-fg);
+  border-color: var(--color-warning);
+}
+
+/* === quality flag chips === */
 
 .flag-chip {
-  display: inline-block;
+  display: inline-flex;
+  align-items: center;
   padding: 0 6px;
-  border-radius: var(--radius-sm, 4px);
-  font-size: 0.85em;
-  background: rgba(0, 0, 0, 0.08);
+  border-radius: 2px;
+  font-size: 0.7rem;
+  letter-spacing: 0.04em;
+  font-variation-settings: 'wght' 500;
+  background: var(--color-rule-soft);
+  color: var(--color-text-quiet);
 }
 
-.flag-time_sensitive { background: rgba(239, 68, 68, 0.15); color: #b91c1c; }
-.flag-ambiguous     { background: rgba(168, 85, 247, 0.15); color: #6b21a8; }
-.flag-low_confidence{ background: rgba(107, 114, 128, 0.15); color: #4b5563; }
+.flag-time_sensitive {
+  background: var(--color-error-bg);
+  color: var(--color-error-fg);
+}
+
+.flag-ambiguous {
+  background: var(--color-info-bg);
+  color: var(--color-info-fg);
+  font-style: italic;
+}
+
+.flag-low_confidence {
+  background: var(--color-rule-soft);
+  color: var(--color-text-quiet);
+}
+
+/* prefer-reduced-motion */
+@media (prefers-reduced-motion: reduce) {
+  .source-badge.tone-ai .source-badge__dot {
+    animation: none;
+  }
+}

--- a/quiz-app/src/components/SourceBadge/SourceBadge.tsx
+++ b/quiz-app/src/components/SourceBadge/SourceBadge.tsx
@@ -13,10 +13,10 @@ interface SourceBadgeProps {
 
 const SOURCE_LABEL: Record<
   PracticePoolSourceType,
-  { text: string; icon: string; tone: string; abbrev: string }
+  { text: string; tone: string; abbrev: string }
 > = {
-  external_mock: { text: '模擬題', icon: 'menu_book', tone: 'mock', abbrev: 'EM' },
-  ai_generated: { text: 'AI 產題', icon: 'auto_awesome', tone: 'ai', abbrev: 'AI' },
+  external_mock: { text: '模擬題', tone: 'mock', abbrev: 'EM' },
+  ai_generated: { text: 'AI 產題', tone: 'ai', abbrev: 'AI' },
 };
 
 const FLAG_LABEL: Partial<Record<PracticePoolQualityFlag, string>> = {

--- a/quiz-app/src/components/SourceBadge/SourceBadge.tsx
+++ b/quiz-app/src/components/SourceBadge/SourceBadge.tsx
@@ -1,5 +1,6 @@
-// 練習池題目來源徽章。
-// 對 ai_generated 題顯示「AI 產題」並符合 EU AI Act Art.50（2026-08-02 起）揭露要求。
+// 練習池題目來源徽章 — Carbon Ledger 精緻版
+// 設計：礦物色 dot + serif italic label；AI 產題用 oxide rust 警示色 + 編號註腳風
+// 對 ai_generated 題符合 EU AI Act Art.50（2026-08-02 起）揭露要求。
 import './SourceBadge.css';
 import type { PracticePoolSourceType, PracticePoolQualityFlag } from '../../types/practicePool';
 
@@ -10,9 +11,12 @@ interface SourceBadgeProps {
   compact?: boolean;
 }
 
-const SOURCE_LABEL: Record<PracticePoolSourceType, { text: string; icon: string; tone: string }> = {
-  external_mock: { text: '模擬題', icon: 'menu_book', tone: 'mock' },
-  ai_generated: { text: 'AI 產題', icon: 'auto_awesome', tone: 'ai' },
+const SOURCE_LABEL: Record<
+  PracticePoolSourceType,
+  { text: string; icon: string; tone: string; abbrev: string }
+> = {
+  external_mock: { text: '模擬題', icon: 'menu_book', tone: 'mock', abbrev: 'EM' },
+  ai_generated: { text: 'AI 產題', icon: 'auto_awesome', tone: 'ai', abbrev: 'AI' },
 };
 
 const FLAG_LABEL: Partial<Record<PracticePoolQualityFlag, string>> = {
@@ -30,8 +34,9 @@ export function SourceBadge({ sourceType, qualityFlags = [], compact = false }: 
 
   return (
     <span className={`source-badge tone-${meta.tone}`} title={title} aria-label={title}>
-      <span className="material-icons sm" aria-hidden="true">
-        {meta.icon}
+      <span className="source-badge__dot" aria-hidden="true" />
+      <span className="source-badge__abbrev cl-figure" aria-hidden="true">
+        {meta.abbrev}
       </span>
       {!compact && <span className="badge-text">{meta.text}</span>}
       {qualityFlags

--- a/quiz-app/src/data/practice-pool-counts.ts
+++ b/quiz-app/src/data/practice-pool-counts.ts
@@ -1,0 +1,9 @@
+// Practice pool 數量單一事實來源 — UI 揭露文案禁止漂移到不同數字。
+// 來源：src/data/practice_pool.json `_meta.totals`（2026-04-25 版）。
+// 若 practice_pool.json 內容變動需同步更新此處（dev 啟動時的 schema validator
+// 會 assert 內容形狀，但不會 assert 跟此常數一致 — 所以人工同步）。
+export const PRACTICE_POOL_COUNTS = {
+  externalMock: 55,
+  aiGenerated: 98,
+  total: 153,
+} as const;

--- a/quiz-app/src/main.tsx
+++ b/quiz-app/src/main.tsx
@@ -3,6 +3,7 @@ import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App';
 import './styles/global.css';
+import './styles/carbon-ledger.css';
 import { assertPracticePoolValid } from './utils/practice-pool-schema';
 import { assertMainBankValid } from './utils/main-bank-schema';
 

--- a/quiz-app/src/pages/HomePage.css
+++ b/quiz-app/src/pages/HomePage.css
@@ -1,172 +1,672 @@
-/* HomePage 樣式 */
+/*
+ * HomePage — Carbon Ledger 樣式
+ * 編輯式 grid + 寬鬆白邊；數字用 mono；標題用 Fraunces serif w/ italic SOFT 軸
+ */
 
-.home-page {
-  max-width: 900px;
+.home-page,
+.cl-page {
+  max-width: 1100px;
   margin: 0 auto;
+  padding: clamp(1.25rem, 3vw, 3rem) clamp(1rem, 4vw, 3rem);
 }
 
-/* 標題區 */
-.hero-section {
-  text-align: center;
-  padding: var(--spacing-xl) 0;
+/* ============== HERO ============== */
+
+.cl-hero {
+  position: relative;
+  padding-bottom: 2.5rem;
 }
 
-.hero-section h1 {
+.cl-hero__meta {
   display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: var(--spacing-sm);
-  font-size: var(--font-size-3xl);
-  font-weight: 700;
-  color: var(--color-text-primary);
-  margin-bottom: var(--spacing-sm);
-}
-
-.hero-icon {
-  color: var(--color-primary);
-}
-
-.hero-subtitle {
-  font-size: var(--font-size-lg);
-  color: var(--color-text-secondary);
-  margin-bottom: var(--spacing-lg);
-}
-
-.stats-badges {
-  display: flex;
-  justify-content: center;
-  gap: var(--spacing-sm);
+  justify-content: space-between;
+  align-items: baseline;
   flex-wrap: wrap;
+  gap: 0.5rem 1rem;
+  margin-bottom: 2rem;
+  padding-bottom: 0.75rem;
+  border-bottom: 1px solid var(--color-rule-strong);
 }
 
-/* 測驗配置區 */
-.config-section {
-  margin-bottom: var(--spacing-xl);
+.cl-hero__archive-id {
+  color: var(--color-text-quiet);
 }
 
-.config-section h2 {
-  font-size: var(--font-size-xl);
-  font-weight: 600;
-  margin-bottom: var(--spacing-lg);
+.cl-hero__title {
+  font-size: clamp(3.5rem, 9vw, 7rem);
+  margin: 0 0 1.5rem;
   color: var(--color-text-primary);
 }
 
-.config-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-  gap: var(--spacing-md);
-  margin-bottom: var(--spacing-lg);
-}
-
-.config-item {
-  display: flex;
-  flex-direction: column;
-  gap: var(--spacing-xs);
-}
-
-.config-item label {
-  font-size: var(--font-size-sm);
-  font-weight: 500;
-  color: var(--color-text-secondary);
-}
-
-.config-item select,
-.config-item input[type='number'] {
-  padding: var(--spacing-sm) var(--spacing-md);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-sm);
-  background: var(--color-surface);
-  font-size: var(--font-size-base);
-  transition: border-color var(--transition-fast);
-}
-
-.config-item select:focus,
-.config-item input:focus {
-  outline: none;
-  border-color: var(--color-primary);
-  box-shadow: 0 0 0 2px rgba(46, 125, 50, 0.2);
-}
-
-.checkbox-item label {
-  display: flex;
-  align-items: center;
-  gap: var(--spacing-sm);
-  cursor: pointer;
-  font-size: var(--font-size-base);
-  color: var(--color-text-primary);
-}
-
-.checkbox-item input[type='checkbox'] {
-  width: 18px;
-  height: 18px;
-  accent-color: var(--color-primary);
-}
-
-/* 開始按鈕 */
-.start-btn {
-  width: 100%;
-  padding: var(--spacing-md);
-  font-size: var(--font-size-lg);
-}
-
-/* 考科說明區 */
-.info-section {
-  margin-bottom: var(--spacing-xl);
-}
-
-.info-cards {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
-  gap: var(--spacing-md);
-}
-
-.info-card h3 {
-  display: flex;
-  align-items: center;
-  gap: var(--spacing-sm);
-  font-size: var(--font-size-lg);
-  font-weight: 600;
+.cl-hero__title em {
+  display: inline;
   color: var(--color-primary);
-  margin-bottom: var(--spacing-sm);
+  font-variation-settings: 'opsz' 144, 'wght' 380, 'SOFT' 100;
+  margin: 0 0.05em;
 }
 
-.info-title {
-  font-size: var(--font-size-sm);
+.cl-hero__lead {
+  max-width: 38em;
+  font-size: clamp(1rem, 1.4vw, 1.15rem);
+  line-height: 1.65;
   color: var(--color-text-secondary);
-  margin-bottom: var(--spacing-md);
+  margin: 0 0 1.5rem;
 }
 
-.info-card ul {
-  list-style: none;
+.cl-hero__lead-tail {
+  display: block;
+  margin-top: 0.5rem;
+  color: var(--color-text-quiet);
+  font-size: 0.95em;
+}
+
+.cl-hero__stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 1.25rem 2rem;
+  margin: 2rem 0 0;
   padding: 0;
 }
 
-.info-card li {
+.cl-hero__stat {
+  margin: 0;
+  padding-top: 1rem;
+  border-top: 1px solid var(--color-rule-soft);
+}
+
+.cl-hero__stat dt {
+  display: block;
+  margin-bottom: 0.5rem;
+}
+
+.cl-hero__stat dd {
+  margin: 0;
+  display: flex;
+  align-items: baseline;
+  gap: 0.6em;
+}
+
+.cl-hero__stat-num {
+  font-size: 2.4rem;
+  font-weight: 600;
+  letter-spacing: -0.04em;
+  color: var(--color-text-primary);
+  line-height: 1;
+}
+
+.cl-hero__stat-unit {
+  font-size: 0.82rem;
+  color: var(--color-text-quiet);
+}
+
+.cl-hero__stat--addendum .cl-hero__stat-num {
+  color: var(--color-warning);
+}
+
+/* Practice-mode banner */
+.cl-hero__practice-on {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+  margin-top: 1.75rem;
+  padding: 0.85rem 1rem;
+  background: var(--color-warning-bg);
+  border-left: 3px solid var(--color-warning);
+  border-radius: 2px;
+  font-size: 0.92rem;
+  line-height: 1.5;
+  color: var(--color-warning-fg);
+}
+
+.cl-hero__practice-on .cl-fn-marker {
+  background: var(--color-warning);
+  color: #fff;
+  flex-shrink: 0;
+  margin-top: 0.1em;
+}
+
+.cl-hero__practice-label {
+  font-variation-settings: 'wght' 600;
+}
+
+/* ============== WORKSHEET ============== */
+
+.cl-worksheet {
+  margin-top: 4rem;
+  padding: 2rem clamp(1.25rem, 2.5vw, 2.5rem);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: 4px;
+  box-shadow: var(--shadow-2);
   position: relative;
-  padding-left: var(--spacing-lg);
-  margin-bottom: var(--spacing-xs);
-  font-size: var(--font-size-sm);
+}
+
+/* paper "punch holes" — atmospheric archive cue */
+.cl-worksheet::before {
+  content: '';
+  position: absolute;
+  left: 8px;
+  top: 24px;
+  bottom: 24px;
+  width: 6px;
+  background-image: radial-gradient(
+    circle at 50% 16px,
+    var(--color-rule-soft) 3px,
+    transparent 3.5px
+  );
+  background-size: 6px 32px;
+  background-repeat: repeat-y;
+  opacity: 0.7;
+  pointer-events: none;
+}
+
+.cl-worksheet__head {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-bottom: 2rem;
+  padding-bottom: 0.75rem;
+  border-bottom: 1px solid var(--color-rule-strong);
+}
+
+.cl-worksheet__title {
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  margin: 0;
   color: var(--color-text-primary);
 }
 
-.info-card li::before {
-  content: '•';
-  position: absolute;
-  left: var(--spacing-sm);
+.cl-worksheet__formno {
+  color: var(--color-text-quiet);
+}
+
+/* Fieldset — labelled section */
+.cl-fieldset {
+  border: 0;
+  padding: 0;
+  margin: 0 0 1.75rem;
+}
+
+.cl-fieldset--row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  gap: 1.5rem 2rem;
+  justify-content: space-between;
+}
+
+.cl-fieldset__legend {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  font-family: var(--font-body);
+  font-variation-settings: 'wght' 540;
+  font-size: 0.85rem;
+  letter-spacing: 0.05em;
+  color: var(--color-text-primary);
+  margin-bottom: 0.75rem;
+  padding: 0;
+}
+
+.cl-fieldset__legend--inline {
+  margin-bottom: 0;
+}
+
+/* Subject cards */
+.cl-subject-cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 0.75rem;
+}
+
+.cl-subject-card {
+  display: grid;
+  grid-template-areas:
+    'no    count'
+    'title count'
+    'sub   count';
+  grid-template-columns: 1fr auto;
+  gap: 0.2rem 0.75rem;
+  padding: 1rem 1.1rem;
+  background: var(--color-surface-elevated);
+  border: 1px solid var(--color-border);
+  border-radius: 3px;
+  cursor: pointer;
+  text-align: left;
+  font-family: var(--font-body);
+  color: var(--color-text-primary);
+  transition: transform 80ms ease, border-color 100ms ease, box-shadow 100ms ease;
+}
+
+.cl-subject-card:hover {
+  border-color: var(--color-text-secondary);
+}
+
+.cl-subject-card.is-active {
+  border-color: var(--color-primary);
+  box-shadow: inset 0 0 0 1px var(--color-primary), var(--shadow-1);
+  background: var(--color-surface);
+}
+
+.cl-subject-card__no {
+  grid-area: no;
+  font-size: 0.78rem;
+  color: var(--color-text-quiet);
+  letter-spacing: 0.05em;
+}
+
+.cl-subject-card.is-active .cl-subject-card__no {
   color: var(--color-primary);
 }
 
-/* 響應式 */
-@media (max-width: 768px) {
-  .hero-section h1 {
-    font-size: var(--font-size-2xl);
-  }
+.cl-subject-card__title {
+  grid-area: title;
+  font-family: var(--font-display);
+  font-variation-settings: 'opsz' 36, 'wght' 480, 'SOFT' 30;
+  font-size: 1.4rem;
+  letter-spacing: -0.02em;
+  line-height: 1.1;
+}
 
-  .hero-subtitle {
-    font-size: var(--font-size-base);
-  }
+.cl-subject-card__sub {
+  grid-area: sub;
+  font-size: 0.78rem;
+  color: var(--color-text-quiet);
+  line-height: 1.4;
+}
 
-  .config-grid {
-    grid-template-columns: 1fr;
+.cl-subject-card__count {
+  grid-area: count;
+  align-self: center;
+  font-size: 1.6rem;
+  font-weight: 600;
+  letter-spacing: -0.04em;
+  color: var(--color-text-primary);
+  white-space: nowrap;
+}
+
+.cl-subject-card__count small {
+  font-size: 0.55em;
+  color: var(--color-text-quiet);
+  margin-left: 0.15em;
+  font-weight: 400;
+}
+
+.cl-subject-card.is-active .cl-subject-card__count {
+  color: var(--color-primary);
+}
+
+/* Mode segmented */
+.cl-mode-segmented {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 0.75rem;
+}
+
+.cl-mode-card {
+  display: grid;
+  grid-template-areas:
+    'icon title'
+    'icon desc';
+  grid-template-columns: 36px 1fr;
+  gap: 0.25rem 0.85rem;
+  padding: 0.9rem 1rem;
+  background: transparent;
+  border: 1px solid var(--color-border);
+  border-radius: 3px;
+  cursor: pointer;
+  text-align: left;
+  font-family: var(--font-body);
+  color: var(--color-text-primary);
+  transition: border-color 100ms ease;
+}
+
+.cl-mode-card:hover {
+  border-color: var(--color-text-secondary);
+}
+
+.cl-mode-card.is-active {
+  border-color: var(--color-primary);
+  box-shadow: inset 0 0 0 1px var(--color-primary);
+  background: var(--color-primary-soft);
+}
+
+.cl-mode-card__icon {
+  grid-area: icon;
+  align-self: center;
+  font-size: 28px;
+  color: var(--color-text-secondary);
+}
+
+.cl-mode-card.is-active .cl-mode-card__icon {
+  color: var(--color-primary);
+}
+
+.cl-mode-card__title {
+  grid-area: title;
+  font-variation-settings: 'wght' 600;
+  font-size: 1rem;
+}
+
+.cl-mode-card__desc {
+  grid-area: desc;
+  font-size: 0.82rem;
+  color: var(--color-text-quiet);
+  line-height: 1.4;
+}
+
+/* Count block */
+.cl-count-block {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.cl-count-input {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.6rem;
+  border-bottom: 2px solid var(--color-rule-strong);
+  padding-bottom: 0.25rem;
+}
+
+.cl-count-input input[type='number'] {
+  background: transparent;
+  border: 0;
+  font-size: 2.6rem;
+  width: 3ch;
+  font-variation-settings: 'wght' 540;
+  letter-spacing: -0.04em;
+  color: var(--color-text-primary);
+  padding: 0;
+  -moz-appearance: textfield;
+}
+.cl-count-input input::-webkit-outer-spin-button,
+.cl-count-input input::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+.cl-count-input input:focus-visible {
+  outline: none;
+  border-bottom-color: var(--color-primary);
+}
+
+.cl-count-input__unit {
+  color: var(--color-text-quiet);
+  font-size: 0.82rem;
+}
+
+/* Shuffle switch */
+.cl-shuffle-switch {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  cursor: pointer;
+  user-select: none;
+  font-size: 0.9rem;
+  position: relative;
+}
+
+.cl-shuffle-switch input {
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.cl-shuffle-switch__track {
+  width: 38px;
+  height: 22px;
+  border-radius: 12px;
+  background: var(--color-rule-soft);
+  border: 1px solid var(--color-border);
+  position: relative;
+  transition: background 120ms ease;
+}
+
+.cl-shuffle-switch__track::after {
+  content: '';
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 16px;
+  height: 16px;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: 50%;
+  transition: transform 120ms ease, background 120ms ease;
+}
+
+.cl-shuffle-switch input:checked ~ .cl-shuffle-switch__track {
+  background: var(--color-primary);
+  border-color: var(--color-primary-dark);
+}
+.cl-shuffle-switch input:checked ~ .cl-shuffle-switch__track::after {
+  transform: translateX(16px);
+  background: #fff;
+  border-color: var(--color-primary-dark);
+}
+
+.cl-shuffle-switch__label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  color: var(--color-text-primary);
+}
+
+.cl-shuffle-switch__label .material-icons.sm {
+  font-size: 18px;
+  color: var(--color-text-quiet);
+}
+
+/* CTA */
+.cl-cta-row {
+  margin-top: 2.5rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid var(--color-rule-strong);
+}
+
+.cl-cta-primary {
+  display: inline-flex;
+  align-items: center;
+  gap: 1.5rem;
+  padding: 1rem 1.6rem;
+  background: var(--color-primary);
+  color: var(--color-on-primary);
+  border: 0;
+  border-radius: 2px;
+  font-family: var(--font-body);
+  cursor: pointer;
+  transition: transform 80ms ease, box-shadow 100ms ease;
+  box-shadow: 0 1px 0 var(--color-primary-dark);
+  position: relative;
+}
+
+.cl-cta-primary:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 3px 0 var(--color-primary-dark);
+}
+.cl-cta-primary:active {
+  transform: translateY(1px);
+  box-shadow: 0 0 0 var(--color-primary-dark);
+}
+
+.cl-cta-primary__label {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.15rem;
+  font-size: 1.1rem;
+  font-variation-settings: 'wght' 600;
+  letter-spacing: 0.02em;
+}
+
+.cl-cta-primary__sublabel {
+  font-size: 0.78rem;
+  font-variation-settings: 'wght' 400;
+  letter-spacing: 0.05em;
+  opacity: 0.8;
+}
+
+.cl-cta-primary__arrow {
+  font-size: 24px;
+}
+
+.cl-cta-fineprint {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.6rem;
+  margin: 1rem 0 0;
+  font-size: 0.82rem;
+  color: var(--color-text-quiet);
+  line-height: 1.5;
+  max-width: 60ch;
+}
+
+.cl-cta-fineprint .cl-fn-marker {
+  background: var(--color-text-quiet);
+  flex-shrink: 0;
+  margin-top: 0.15em;
+}
+
+/* ============== DOSSIER ============== */
+
+.cl-dossier {
+  margin-top: 4rem;
+}
+
+.cl-dossier h2.cl-eyebrow {
+  margin-bottom: 1.25rem;
+  font-size: 0.78rem;
+}
+
+.cl-dossier__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 1.5rem;
+}
+
+.cl-dossier__card {
+  padding: 1.5rem 1.5rem 1.75rem;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: 4px;
+  position: relative;
+}
+
+.cl-dossier__card-head {
+  display: flex;
+  align-items: baseline;
+  gap: 1rem;
+  margin-bottom: 0.5rem;
+  padding-bottom: 0.75rem;
+  border-bottom: 1px solid var(--color-rule-soft);
+}
+
+.cl-dossier__no {
+  font-size: 1rem;
+  color: var(--color-primary);
+  letter-spacing: 0.04em;
+}
+
+.cl-dossier__card-title {
+  font-size: 1.6rem;
+  margin: 0;
+  letter-spacing: -0.02em;
+  color: var(--color-text-primary);
+}
+
+.cl-dossier__sub {
+  font-size: 0.92rem;
+  color: var(--color-text-secondary);
+  margin: 0 0 1rem;
+  font-style: italic;
+}
+
+.cl-dossier__list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  font-size: 0.92rem;
+  line-height: 1.55;
+}
+
+.cl-dossier__list li {
+  position: relative;
+  padding-left: 1.4rem;
+  color: var(--color-text-secondary);
+}
+
+.cl-dossier__list li::before {
+  content: '·';
+  position: absolute;
+  left: 0.4rem;
+  font-family: var(--font-mono);
+  color: var(--color-primary);
+  font-size: 1.4em;
+  line-height: 0.5;
+  top: 0.5em;
+}
+
+/* ============== utilities ============== */
+
+.cl-visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* fade-in stagger */
+.animate-fade-in .cl-hero {
+  animation: cl-rise 600ms ease both;
+}
+.animate-fade-in .cl-worksheet {
+  animation: cl-rise 600ms ease 80ms both;
+}
+.animate-fade-in .cl-dossier {
+  animation: cl-rise 600ms ease 160ms both;
+}
+
+@keyframes cl-rise {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+/* responsive */
+@media (max-width: 720px) {
+  .cl-fieldset--row {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+  .cl-cta-primary {
+    width: 100%;
+    justify-content: space-between;
+  }
+}
+
+/* 標題保持單一文字節點（測試 textContent 匹配），用 max-width 製造視覺折行 */
+.cl-hero__title {
+  max-width: 12ch;
+}
+
+@media (max-width: 480px) {
+  .cl-hero__title {
+    max-width: 100%;
   }
 }

--- a/quiz-app/src/pages/HomePage.css
+++ b/quiz-app/src/pages/HomePage.css
@@ -675,7 +675,9 @@
 /* Carbon Ledger 在大螢幕優雅，小螢幕需收緊間距、調整字級、單欄排版 */
 @media (max-width: 640px) {
   .cl-page {
-    padding: 0 1rem;
+    /* 只壓 horizontal padding；vertical 維持 base style 的 clamp 上下值 */
+    padding-left: 1rem;
+    padding-right: 1rem;
   }
 
   /* Hero — 縮 padding、防 meta 溢出 */

--- a/quiz-app/src/pages/HomePage.css
+++ b/quiz-app/src/pages/HomePage.css
@@ -670,3 +670,106 @@
     max-width: 100%;
   }
 }
+
+/* ============== MOBILE TUNING (≤640px) ============== */
+/* Carbon Ledger 在大螢幕優雅，小螢幕需收緊間距、調整字級、單欄排版 */
+@media (max-width: 640px) {
+  .cl-page {
+    padding: 0 1rem;
+  }
+
+  /* Hero — 縮 padding、防 meta 溢出 */
+  .cl-hero {
+    padding-bottom: 1.75rem;
+  }
+  .cl-hero__meta {
+    margin-bottom: 1.25rem;
+    gap: 0.35rem 0.75rem;
+  }
+  .cl-hero__title {
+    font-size: clamp(2.4rem, 12vw, 4rem);
+    margin-bottom: 1rem;
+  }
+  .cl-hero__lead {
+    font-size: 0.95rem;
+    margin-bottom: 1rem;
+  }
+  .cl-hero__lead-tail {
+    display: block;
+    margin-top: 0.5rem;
+    font-size: 0.88rem;
+  }
+  .cl-hero__stats {
+    grid-template-columns: repeat(2, 1fr);
+    gap: 0.85rem 1rem;
+    margin-top: 1.25rem;
+  }
+  .cl-hero__stat-num {
+    font-size: 1.8rem;
+  }
+  .cl-hero__stat-unit {
+    font-size: 0.72rem;
+  }
+
+  /* Practice banner — 收緊內距 */
+  .cl-hero__practice-on {
+    padding: 0.7rem 0.85rem;
+    font-size: 0.85rem;
+    margin-top: 1.25rem;
+  }
+
+  /* Worksheet — 隱藏裝飾性 punch-holes（小螢幕會擠壓內容）；padding 縮減 */
+  .cl-worksheet {
+    margin-top: 2.5rem;
+    padding: 1.5rem 1.1rem;
+  }
+  .cl-worksheet::before {
+    display: none;
+  }
+  .cl-worksheet__head {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.4rem;
+  }
+  .cl-worksheet__title {
+    font-size: 1.4rem;
+  }
+
+  /* Subject / Mode cards — 強制單欄，加大 tap target */
+  .cl-subject-cards,
+  .cl-mode-segmented {
+    grid-template-columns: 1fr;
+    gap: 0.6rem;
+  }
+  .cl-subject-card {
+    padding: 0.85rem 1rem;
+    min-height: 64px;
+  }
+  .cl-subject-card__title {
+    font-size: 1.2rem;
+  }
+  .cl-subject-card__count {
+    font-size: 1.4rem;
+  }
+  .cl-mode-card {
+    padding: 0.85rem;
+    min-height: 64px;
+  }
+
+  /* CTA — 全寬已在 720 處理；更小螢幕縮 padding 與字級 */
+  .cl-cta-primary {
+    padding: 0.85rem 1.1rem;
+  }
+  .cl-cta-primary__label {
+    font-size: 1rem;
+  }
+  .cl-cta-primary__sublabel {
+    font-size: 0.78rem;
+  }
+
+  /* Dossier — 兩欄改單欄 */
+  .cl-dossier__grid {
+    grid-template-columns: 1fr;
+    gap: 1rem;
+  }
+}

--- a/quiz-app/src/pages/HomePage.test.tsx
+++ b/quiz-app/src/pages/HomePage.test.tsx
@@ -31,8 +31,10 @@ afterEach(() => {
 describe('HomePage', () => {
   it('renders title and stats badges', () => {
     render(<HomePage onStartQuiz={() => {}} />);
-    expect(screen.getByText(/淨零碳備考神器/)).toBeInTheDocument();
-    // 考科一 / 考科二 出現多次（select option + badge），用 getAllByText
+    // h1 含 <em> 子節點 → 用 getByRole 的 accessible name (==textContent)
+    expect(
+      screen.getByRole('heading', { level: 1, name: /淨零碳備考神器/ })
+    ).toBeInTheDocument();
     expect(screen.getAllByText(/考科一/).length).toBeGreaterThan(0);
     expect(screen.getAllByText(/考科二/).length).toBeGreaterThan(0);
   });

--- a/quiz-app/src/pages/HomePage.test.tsx
+++ b/quiz-app/src/pages/HomePage.test.tsx
@@ -62,4 +62,69 @@ describe('HomePage', () => {
     expect(config).toHaveProperty('subject');
     expect(config).toHaveProperty('questionCount');
   });
+
+  it('subject card click switches subject (pickSubject)', () => {
+    const onStartQuiz = vi.fn();
+    render(<HomePage onStartQuiz={onStartQuiz} />);
+    // 點考科一卡片
+    const subj1Card = screen.getAllByRole('radio').find(
+      (el) => el.getAttribute('aria-label') !== '測驗模式'
+        && el.textContent?.includes('§01')
+    );
+    expect(subj1Card).toBeTruthy();
+    fireEvent.click(subj1Card!);
+    fireEvent.click(screen.getByRole('button', { name: /開始/ }));
+    expect(onStartQuiz.mock.calls[0][0].subject).toBe('考科1');
+  });
+
+  it('mode card click switches mode + showAnswerImmediately (pickMode)', () => {
+    const onStartQuiz = vi.fn();
+    render(<HomePage onStartQuiz={onStartQuiz} />);
+    // 找 exam mode card（含「考試」文字）
+    const examCard = screen.getAllByRole('radio').find(
+      (el) => el.textContent?.includes('考試')
+    );
+    expect(examCard).toBeTruthy();
+    fireEvent.click(examCard!);
+    fireEvent.click(screen.getByRole('button', { name: /開始/ }));
+    const cfg = onStartQuiz.mock.calls[0][0];
+    expect(cfg.mode).toBe('exam');
+    expect(cfg.showAnswerImmediately).toBe(false);
+  });
+
+  it('count input change updates questionCount (handleCountChange)', () => {
+    const onStartQuiz = vi.fn();
+    render(<HomePage onStartQuiz={onStartQuiz} />);
+    const countInput = screen.getByLabelText(/題數/) as HTMLInputElement;
+    fireEvent.change(countInput, { target: { value: '25' } });
+    fireEvent.click(screen.getByRole('button', { name: /開始/ }));
+    expect(onStartQuiz.mock.calls[0][0].questionCount).toBe(25);
+  });
+
+  it('shuffle checkbox toggles shuffleQuestions (handleShuffleChange)', () => {
+    const onStartQuiz = vi.fn();
+    render(<HomePage onStartQuiz={onStartQuiz} />);
+    const shuffleCb = screen.getByRole('checkbox') as HTMLInputElement;
+    fireEvent.click(shuffleCb);
+    fireEvent.click(screen.getByRole('button', { name: /開始/ }));
+    expect(onStartQuiz.mock.calls[0][0].shuffleQuestions).toBe(true);
+  });
+
+  it('hidden subject select onChange path (handleSubjectChange)', () => {
+    const onStartQuiz = vi.fn();
+    render(<HomePage onStartQuiz={onStartQuiz} />);
+    const select = screen.getByLabelText(/考科範圍 \(備援 select\)/) as HTMLSelectElement;
+    fireEvent.change(select, { target: { value: '考科2' } });
+    fireEvent.click(screen.getByRole('button', { name: /開始/ }));
+    expect(onStartQuiz.mock.calls[0][0].subject).toBe('考科2');
+  });
+
+  it('hidden mode select onChange path (handleModeChange)', () => {
+    const onStartQuiz = vi.fn();
+    render(<HomePage onStartQuiz={onStartQuiz} />);
+    const select = screen.getByLabelText(/測驗模式 \(備援 select\)/) as HTMLSelectElement;
+    fireEvent.change(select, { target: { value: 'exam' } });
+    fireEvent.click(screen.getByRole('button', { name: /開始/ }));
+    expect(onStartQuiz.mock.calls[0][0].mode).toBe('exam');
+  });
 });

--- a/quiz-app/src/pages/HomePage.test.tsx
+++ b/quiz-app/src/pages/HomePage.test.tsx
@@ -31,9 +31,10 @@ afterEach(() => {
 describe('HomePage', () => {
   it('renders title and stats badges', () => {
     render(<HomePage onStartQuiz={() => {}} />);
-    // h1 含 <em> 子節點 → 用 getByRole 的 accessible name (==textContent)
+    // h1 含 <em> 子節點 → jsdom accessible-name 會在 inline element 兩側補空白
+    // 所以 "淨零碳<em>備考</em>神器" 的 name 是 "淨零碳 備考 神器"
     expect(
-      screen.getByRole('heading', { level: 1, name: /淨零碳備考神器/ })
+      screen.getByRole('heading', { level: 1, name: /淨零碳\s*備考\s*神器/ })
     ).toBeInTheDocument();
     expect(screen.getAllByText(/考科一/).length).toBeGreaterThan(0);
     expect(screen.getAllByText(/考科二/).length).toBeGreaterThan(0);

--- a/quiz-app/src/pages/HomePage.test.tsx
+++ b/quiz-app/src/pages/HomePage.test.tsx
@@ -105,7 +105,8 @@ describe('HomePage', () => {
     const onStartQuiz = vi.fn();
     render(<HomePage onStartQuiz={onStartQuiz} />);
     const shuffleCb = screen.getByRole('checkbox') as HTMLInputElement;
-    fireEvent.click(shuffleCb);
+    // jsdom 對 fireEvent.click 不一定 toggle checked → 直接 dispatch change with checked=true
+    fireEvent.change(shuffleCb, { target: { checked: true } });
     fireEvent.click(screen.getByRole('button', { name: /開始/ }));
     expect(onStartQuiz.mock.calls[0][0].shuffleQuestions).toBe(true);
   });

--- a/quiz-app/src/pages/HomePage.tsx
+++ b/quiz-app/src/pages/HomePage.tsx
@@ -2,6 +2,7 @@
 // 設計概念：頁面像一本「碳審計年鑑」的扉頁；配置區像填寫測驗工作單。
 import { useState, useCallback } from 'react';
 import { stats } from '../data/questions';
+import { PRACTICE_POOL_COUNTS } from '../data/practice-pool-counts';
 import { defaultConfig } from '../hooks/useQuiz';
 import { usePracticeMode } from '../hooks/usePracticeMode';
 import type { QuizConfig, ExamSubject } from '../types/quiz';
@@ -150,7 +151,7 @@ export function HomePage({ onStartQuiz }: HomePageProps) {
           <div className="cl-hero__stat cl-hero__stat--addendum">
             <dt className="cl-eyebrow">補充 / Addendum</dt>
             <dd>
-              <span className="cl-figure cl-hero__stat-num">+153</span>
+              <span className="cl-figure cl-hero__stat-num">+{PRACTICE_POOL_COUNTS.total}</span>
               <span className="cl-hero__stat-unit">加強練習池</span>
             </dd>
           </div>
@@ -161,7 +162,7 @@ export function HomePage({ onStartQuiz }: HomePageProps) {
             <span className="cl-fn-marker">±</span>
             <span>
               <strong className="cl-hero__practice-label">加強練習池啟用中</strong>
-              ：本場測驗將額外混入 153 題（55 模擬 + 98 AI 產題；每題附來源徽章）。
+              ：本場測驗將額外混入 {PRACTICE_POOL_COUNTS.total} 題（{PRACTICE_POOL_COUNTS.externalMock} 模擬 + {PRACTICE_POOL_COUNTS.aiGenerated} AI 產題；每題附來源徽章）。
               於設定頁可關閉。
             </span>
           </aside>
@@ -319,8 +320,8 @@ export function HomePage({ onStartQuiz }: HomePageProps) {
             <span className="cl-fn-marker">i</span>
             <span>
               {practiceMode.enabled
-                ? '加強練習池已啟用 — 抽題範圍將包含 153 題補充題（含 AI 產題揭露徽章）。'
-                : '預設僅抽自主題庫；前往「設定 → 加強練習池」可加入 153 題補充題。'}
+                ? `加強練習池已啟用 — 抽題範圍將包含 ${PRACTICE_POOL_COUNTS.total} 題補充題（含 AI 產題揭露徽章）。`
+                : `預設僅抽自主題庫；前往「設定 → 加強練習池」可加入 ${PRACTICE_POOL_COUNTS.total} 題補充題。`}
             </span>
           </p>
         </div>

--- a/quiz-app/src/pages/HomePage.tsx
+++ b/quiz-app/src/pages/HomePage.tsx
@@ -1,4 +1,5 @@
-// 首頁元件 - 測驗配置與開始
+// 首頁元件 — Carbon Ledger / Atmospheric Archive 設計
+// 設計概念：頁面像一本「碳審計年鑑」的扉頁；配置區像填寫測驗工作單。
 import { useState, useCallback } from 'react';
 import { stats } from '../data/questions';
 import { defaultConfig } from '../hooks/useQuiz';
@@ -9,6 +10,37 @@ import './HomePage.css';
 interface HomePageProps {
   onStartQuiz: (config: QuizConfig) => void;
 }
+
+const MODE_OPTIONS: ReadonlyArray<{
+  value: QuizConfig['mode'];
+  title: string;
+  desc: string;
+  icon: string;
+}> = [
+  {
+    value: 'practice',
+    title: '練習模式',
+    desc: '每題作答後立即看到答案與 AI 解析；適合學新主題',
+    icon: 'self_improvement',
+  },
+  {
+    value: 'exam',
+    title: '考試模式',
+    desc: '所有題目作答完才公布；模擬正式考場節奏',
+    icon: 'timer',
+  },
+];
+
+const SUBJECT_OPTIONS: ReadonlyArray<{
+  value: ExamSubject | 'all';
+  number: string;
+  title: string;
+  count: number;
+}> = [
+  { value: 'all', number: '00', title: '兩科混合', count: stats.total },
+  { value: '考科1', number: '01', title: '淨零碳規劃管理基礎概論', count: stats.subject1 },
+  { value: '考科2', number: '02', title: '淨零碳盤查範圍與程序概要', count: stats.subject2 },
+];
 
 export function HomePage({ onStartQuiz }: HomePageProps) {
   const [config, setConfig] = useState<QuizConfig>(defaultConfig);
@@ -49,135 +81,282 @@ export function HomePage({ onStartQuiz }: HomePageProps) {
     []
   );
 
+  const pickMode = useCallback(
+    (mode: QuizConfig['mode']) => {
+      setConfig((prev) => ({
+        ...prev,
+        mode,
+        showAnswerImmediately: mode === 'practice',
+      }));
+    },
+    []
+  );
+
+  const pickSubject = useCallback((subject: ExamSubject | 'all') => {
+    setConfig((prev) => ({ ...prev, subject }));
+  }, []);
+
   const handleStart = useCallback(() => {
     onStartQuiz(config);
   }, [config, onStartQuiz]);
 
   return (
-    <div className="home-page animate-fade-in">
-      {/* 標題區 */}
-      <section className="hero-section">
-        <h1>
-          <span className="material-icons lg hero-icon">eco</span>
-          淨零碳備考神器
+    <div className="home-page cl-page animate-fade-in">
+      {/* HERO — 像扉頁 */}
+      <section className="cl-hero">
+        <div className="cl-hero__meta">
+          <span className="cl-eyebrow">VOL.&nbsp;01 — 2026 / Q2 EDITION</span>
+          <span className="cl-eyebrow cl-hero__archive-id cl-figure">
+            ARCHIVE / iPAS-NZ
+          </span>
+        </div>
+
+        <h1 className="cl-hero__title cl-display">
+          淨零碳<em>備考</em>神器
         </h1>
-        <p className="hero-subtitle">
-          iPAS 淨零碳規劃管理師 考古題線上測驗
+
+        <p className="cl-hero__lead">
+          iPAS 淨零碳規劃管理師考古題的開放式檔案。
+          <span className="cl-hero__lead-tail">
+            每題對應一條官方法源；每個答案附有可追溯的 primary-source URL；每張練習單，皆是一次小型碳審計。
+          </span>
         </p>
-        <div className="stats-badges">
-          <span className="badge badge-success">
-            <span className="material-icons sm">quiz</span>
-            {stats.total} 題
-          </span>
-          <span className="badge badge-info">
-            考科一 {stats.subject1} 題
-          </span>
-          <span className="badge badge-info">
-            考科二 {stats.subject2} 題
-          </span>
-          {practiceMode.enabled && (
-            <span className="badge badge-warning" title="加強練習池啟用中：包含模擬題與 AI 產題">
-              <span className="material-icons sm">auto_awesome</span>
-              加強練習池啟用中
+
+        <hr className="cl-rule" aria-hidden="true" />
+
+        {/* Ledger-style stat row */}
+        <dl className="cl-hero__stats">
+          <div className="cl-hero__stat">
+            <dt className="cl-eyebrow">Q-Total</dt>
+            <dd>
+              <span className="cl-figure cl-hero__stat-num">{stats.total}</span>
+              <span className="cl-hero__stat-unit">主題庫題</span>
+            </dd>
+          </div>
+          <div className="cl-hero__stat">
+            <dt className="cl-eyebrow">考科一</dt>
+            <dd>
+              <span className="cl-figure cl-hero__stat-num">{stats.subject1}</span>
+              <span className="cl-hero__stat-unit">基礎概論</span>
+            </dd>
+          </div>
+          <div className="cl-hero__stat">
+            <dt className="cl-eyebrow">考科二</dt>
+            <dd>
+              <span className="cl-figure cl-hero__stat-num">{stats.subject2}</span>
+              <span className="cl-hero__stat-unit">盤查程序</span>
+            </dd>
+          </div>
+          <div className="cl-hero__stat cl-hero__stat--addendum">
+            <dt className="cl-eyebrow">補充 / Addendum</dt>
+            <dd>
+              <span className="cl-figure cl-hero__stat-num">+153</span>
+              <span className="cl-hero__stat-unit">加強練習池</span>
+            </dd>
+          </div>
+        </dl>
+
+        {practiceMode.enabled && (
+          <aside className="cl-hero__practice-on" role="status">
+            <span className="cl-fn-marker">±</span>
+            <span>
+              <strong className="cl-hero__practice-label">加強練習池啟用中</strong>
+              ：本場測驗將額外混入 153 題（55 模擬 + 98 AI 產題；每題附來源徽章）。
+              於設定頁可關閉。
             </span>
-          )}
-        </div>
+          </aside>
+        )}
       </section>
 
-      {/* 測驗配置 */}
-      <section className="config-section card">
-        <h2>測驗設定</h2>
+      {/* WORKSHEET — 配置區 */}
+      <section className="cl-worksheet" aria-labelledby="worksheet-title">
+        <header className="cl-worksheet__head">
+          <h2 id="worksheet-title" className="cl-worksheet__title cl-display">
+            填寫今日工作單
+          </h2>
+          <span className="cl-eyebrow cl-worksheet__formno cl-figure">
+            FORM&nbsp;/&nbsp;NZ-Q-001
+          </span>
+        </header>
 
-        <div className="config-grid">
-          {/* 考科選擇 */}
-          <div className="config-item">
-            <label htmlFor="subject">考科範圍</label>
-            <select
-              id="subject"
-              value={config.subject}
-              onChange={handleSubjectChange}
-            >
-              <option value="all">全部 ({stats.total} 題)</option>
-              <option value="考科1">
-                考科一：淨零碳規劃管理基礎概論 ({stats.subject1} 題)
-              </option>
-              <option value="考科2">
-                考科二：淨零碳盤查範圍與程序概要 ({stats.subject2} 題)
-              </option>
-            </select>
+        {/* 1. 科目選擇（卡片式） */}
+        <fieldset className="cl-fieldset">
+          <legend className="cl-fieldset__legend">
+            <span className="cl-fn-marker">1</span>
+            <span>科目範圍</span>
+          </legend>
+          <div className="cl-subject-cards" role="radiogroup" aria-label="考科範圍">
+            {SUBJECT_OPTIONS.map((opt) => {
+              const active = config.subject === opt.value;
+              return (
+                <button
+                  key={String(opt.value)}
+                  type="button"
+                  role="radio"
+                  aria-checked={active}
+                  className={`cl-subject-card ${active ? 'is-active' : ''}`}
+                  onClick={() => pickSubject(opt.value)}
+                >
+                  <span className="cl-subject-card__no cl-figure">§{opt.number}</span>
+                  <span className="cl-subject-card__title">
+                    {opt.value === '考科1' ? '考科一' : opt.value === '考科2' ? '考科二' : opt.title}
+                  </span>
+                  <span className="cl-subject-card__sub">
+                    {opt.value === 'all' ? '兩科一起練' : opt.title}
+                  </span>
+                  <span className="cl-subject-card__count cl-figure">
+                    {opt.count}
+                    <small>題</small>
+                  </span>
+                </button>
+              );
+            })}
           </div>
+          <select
+            id="subject"
+            value={config.subject}
+            onChange={handleSubjectChange}
+            className="cl-visually-hidden"
+            aria-label="考科範圍 (備援 select)"
+          >
+            <option value="all">全部 ({stats.total} 題)</option>
+            <option value="考科1">考科一：淨零碳規劃管理基礎概論 ({stats.subject1} 題)</option>
+            <option value="考科2">考科二：淨零碳盤查範圍與程序概要 ({stats.subject2} 題)</option>
+          </select>
+        </fieldset>
 
-          {/* 測驗模式 */}
-          <div className="config-item">
-            <label htmlFor="mode">測驗模式</label>
-            <select id="mode" value={config.mode} onChange={handleModeChange}>
-              <option value="practice">練習模式（即時顯示答案）</option>
-              <option value="exam">考試模式（最後顯示結果）</option>
-            </select>
+        {/* 2. 測驗模式（segmented） */}
+        <fieldset className="cl-fieldset">
+          <legend className="cl-fieldset__legend">
+            <span className="cl-fn-marker">2</span>
+            <span>測驗模式</span>
+          </legend>
+          <div className="cl-mode-segmented" role="radiogroup" aria-label="測驗模式">
+            {MODE_OPTIONS.map((opt) => {
+              const active = config.mode === opt.value;
+              return (
+                <button
+                  key={opt.value}
+                  type="button"
+                  role="radio"
+                  aria-checked={active}
+                  className={`cl-mode-card ${active ? 'is-active' : ''}`}
+                  onClick={() => pickMode(opt.value)}
+                >
+                  <span className="material-icons cl-mode-card__icon">{opt.icon}</span>
+                  <span className="cl-mode-card__title">{opt.title}</span>
+                  <span className="cl-mode-card__desc">{opt.desc}</span>
+                </button>
+              );
+            })}
           </div>
+          <select
+            id="mode"
+            value={config.mode}
+            onChange={handleModeChange}
+            className="cl-visually-hidden"
+            aria-label="測驗模式 (備援 select)"
+          >
+            <option value="practice">練習模式（即時顯示答案）</option>
+            <option value="exam">考試模式（最後顯示結果）</option>
+          </select>
+        </fieldset>
 
-          {/* 題數 */}
-          <div className="config-item">
-            <label htmlFor="count">題數</label>
-            <input
-              type="number"
-              id="count"
-              min={1}
-              max={100}
-              value={config.questionCount}
-              onChange={handleCountChange}
-              aria-label="題數"
-            />
-          </div>
-
-          {/* 隨機排序 */}
-          <div className="config-item checkbox-item">
-            <label>
-              <input
-                type="checkbox"
-                checked={config.shuffleQuestions}
-                onChange={handleShuffleChange}
-              />
-              <span>隨機出題順序</span>
+        {/* 3. 題數 + 隨機 */}
+        <fieldset className="cl-fieldset cl-fieldset--row">
+          <div className="cl-count-block">
+            <label htmlFor="count" className="cl-fieldset__legend cl-fieldset__legend--inline">
+              <span className="cl-fn-marker">3</span>
+              <span>題數</span>
             </label>
+            <div className="cl-count-input">
+              <input
+                type="number"
+                id="count"
+                min={1}
+                max={100}
+                value={config.questionCount}
+                onChange={handleCountChange}
+                aria-label="題數"
+                className="cl-figure"
+              />
+              <span className="cl-count-input__unit">題 / 1–100</span>
+            </div>
           </div>
-        </div>
 
-        {/* 開始按鈕 */}
-        <button className="btn btn-primary start-btn" onClick={handleStart}>
-          <span className="material-icons">play_arrow</span>
-          開始測驗
-        </button>
+          <label className="cl-shuffle-switch">
+            <input
+              type="checkbox"
+              checked={config.shuffleQuestions}
+              onChange={handleShuffleChange}
+            />
+            <span className="cl-shuffle-switch__track" aria-hidden="true" />
+            <span className="cl-shuffle-switch__label">
+              <span className="material-icons sm">shuffle</span>
+              隨機出題順序
+            </span>
+          </label>
+        </fieldset>
+
+        {/* CTA */}
+        <div className="cl-cta-row">
+          <button
+            type="button"
+            className="cl-cta-primary"
+            onClick={handleStart}
+            aria-label={`開始 ${config.questionCount} 題測驗`}
+          >
+            <span className="cl-cta-primary__label">
+              開始測驗
+              <span className="cl-cta-primary__sublabel cl-figure">
+                {config.questionCount} 題 · {config.mode === 'practice' ? '練習' : '考試'}
+              </span>
+            </span>
+            <span className="material-icons cl-cta-primary__arrow">arrow_forward</span>
+          </button>
+
+          <p className="cl-cta-fineprint">
+            <span className="cl-fn-marker">i</span>
+            <span>
+              {practiceMode.enabled
+                ? '加強練習池已啟用 — 抽題範圍將包含 153 題補充題（含 AI 產題揭露徽章）。'
+                : '預設僅抽自主題庫；前往「設定 → 加強練習池」可加入 153 題補充題。'}
+            </span>
+          </p>
+        </div>
       </section>
 
-      {/* 考科說明 */}
-      <section className="info-section">
-        <div className="info-cards">
-          <article className="info-card card">
-            <h3>
-              <span className="material-icons">menu_book</span>
-              考科一
-            </h3>
-            <p className="info-title">淨零碳規劃管理基礎概論</p>
-            <ul>
-              <li>淨零排放國際發展與政策趨勢</li>
-              <li>永續發展與碳中和目標</li>
-              <li>溫室氣體基礎知識</li>
-              <li>碳管理策略與工具</li>
+      {/* 考科說明 — 改為兩欄 dossier */}
+      <section className="cl-dossier" aria-labelledby="dossier-title">
+        <h2 id="dossier-title" className="cl-eyebrow cl-section-mark">
+          考科檔案 / Dossier
+        </h2>
+        <div className="cl-dossier__grid">
+          <article className="cl-dossier__card">
+            <header className="cl-dossier__card-head">
+              <span className="cl-figure cl-dossier__no">§01</span>
+              <h3 className="cl-dossier__card-title cl-display">考科一</h3>
+            </header>
+            <p className="cl-dossier__sub">淨零碳規劃管理基礎概論</p>
+            <ul className="cl-dossier__list">
+              <li>淨零排放國際發展與政策趨勢、CBAM、Paris Agreement Article 6</li>
+              <li>永續發展與碳中和、PAS 2060 / ISO 14068-1</li>
+              <li>溫室氣體基礎與 IPCC GWP（AR5/AR6）</li>
+              <li>SBTi、ISSB IFRS S1/S2、TCFD</li>
             </ul>
           </article>
 
-          <article className="info-card card">
-            <h3>
-              <span className="material-icons">analytics</span>
-              考科二
-            </h3>
-            <p className="info-title">淨零碳盤查範圍與程序概要</p>
-            <ul>
-              <li>ISO 14064 溫室氣體盤查標準</li>
-              <li>組織碳盤查範疇與邊界</li>
-              <li>排放係數與計算方法</li>
-              <li>碳盤查報告與查證</li>
+          <article className="cl-dossier__card">
+            <header className="cl-dossier__card-head">
+              <span className="cl-figure cl-dossier__no">§02</span>
+              <h3 className="cl-dossier__card-title cl-display">考科二</h3>
+            </header>
+            <p className="cl-dossier__sub">淨零碳盤查範圍與程序概要</p>
+            <ul className="cl-dossier__list">
+              <li>ISO 14064-1:2018 六分類（Cat 1–6）</li>
+              <li>組織邊界（營運／財務／股權控制法）</li>
+              <li>排放係數與計算（環境部 113/2/5 公告 AR5 GWP）</li>
+              <li>查證、CFP-PCR、碳足跡標籤</li>
             </ul>
           </article>
         </div>

--- a/quiz-app/src/pages/ResultPage.css
+++ b/quiz-app/src/pages/ResultPage.css
@@ -821,7 +821,8 @@
 .cl-result-stats__row--correct .cl-result-stats__num { color: var(--color-success); }
 .cl-result-stats__row--wrong   .cl-result-stats__num { color: var(--color-error); }
 
-@media (max-width: 720px) {
+/* Stats border — tablet 範圍（641–720）：4 欄變單欄堆疊，row 之間用底線分隔 */
+@media (min-width: 641px) and (max-width: 720px) {
   .cl-result-stats__row {
     border-right: 0;
     border-bottom: 1px solid var(--color-rule-soft);
@@ -832,7 +833,8 @@
 /* ============== MOBILE TUNING (≤640px) ============== */
 @media (max-width: 640px) {
   .result-page.cl-page {
-    padding: 0 1rem;
+    padding-left: 1rem;
+    padding-right: 1rem;
   }
 
   /* Score card — 已在 720 stack；縮數字字級 + 對齊 */
@@ -852,18 +854,19 @@
     font-size: 0.86rem;
   }
 
-  /* Stats — 單列拉長太空，改 2x2 grid */
+  /* Stats — 2x2 grid；border：每 row 都有右框/底框，
+     右欄消右框、最後兩 row 消底框（純 cascade，無 !important） */
   .cl-result-stats {
     grid-template-columns: 1fr 1fr;
     margin-bottom: 2rem;
   }
   .cl-result-stats__row {
     padding: 0.85rem 1rem;
-    border-right: 1px solid var(--color-rule-soft) !important;
-    border-bottom: 1px solid var(--color-rule-soft) !important;
+    border-right: 1px solid var(--color-rule-soft);
+    border-bottom: 1px solid var(--color-rule-soft);
   }
-  .cl-result-stats__row:nth-child(2n) { border-right: 0 !important; }
-  .cl-result-stats__row:nth-last-child(-n + 2) { border-bottom: 0 !important; }
+  .cl-result-stats__row:nth-child(2n) { border-right: 0; }
+  .cl-result-stats__row:nth-last-child(-n + 2) { border-bottom: 0; }
   .cl-result-stats__num {
     font-size: 1.6rem;
   }

--- a/quiz-app/src/pages/ResultPage.css
+++ b/quiz-app/src/pages/ResultPage.css
@@ -828,3 +828,51 @@
   }
   .cl-result-stats__row:last-child { border-bottom: 0; }
 }
+
+/* ============== MOBILE TUNING (≤640px) ============== */
+@media (max-width: 640px) {
+  .result-page.cl-page {
+    padding: 0 1rem;
+  }
+
+  /* Score card — 已在 720 stack；縮數字字級 + 對齊 */
+  .cl-score-card {
+    text-align: left;
+  }
+  .cl-score-card__num {
+    font-size: clamp(4.5rem, 22vw, 6.5rem);
+  }
+  .cl-score-card__total {
+    font-size: 1.4rem;
+  }
+  .cl-score-card__comment {
+    font-size: clamp(1.6rem, 7vw, 2.4rem);
+  }
+  .cl-score-card__sub {
+    font-size: 0.86rem;
+  }
+
+  /* Stats — 單列拉長太空，改 2x2 grid */
+  .cl-result-stats {
+    grid-template-columns: 1fr 1fr;
+    margin-bottom: 2rem;
+  }
+  .cl-result-stats__row {
+    padding: 0.85rem 1rem;
+    border-right: 1px solid var(--color-rule-soft) !important;
+    border-bottom: 1px solid var(--color-rule-soft) !important;
+  }
+  .cl-result-stats__row:nth-child(2n) { border-right: 0 !important; }
+  .cl-result-stats__row:nth-last-child(-n + 2) { border-bottom: 0 !important; }
+  .cl-result-stats__num {
+    font-size: 1.6rem;
+  }
+
+  /* Action buttons — 全寬 stack */
+  .action-section {
+    flex-direction: column;
+  }
+  .action-section .btn {
+    width: 100%;
+  }
+}

--- a/quiz-app/src/pages/ResultPage.css
+++ b/quiz-app/src/pages/ResultPage.css
@@ -521,3 +521,310 @@
     width: 100%;
   }
 }
+
+/* ==============================================================
+ * Carbon Ledger 覆蓋層 — Audit Report style
+ * ============================================================== */
+
+.cl-result-head {
+  margin-bottom: 2rem;
+}
+
+.cl-result-head__meta {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  margin-bottom: 0.75rem;
+}
+
+.cl-result-head__meta .cl-figure {
+  color: var(--color-text-quiet);
+}
+
+.cl-score-card {
+  display: grid;
+  grid-template-columns: minmax(200px, auto) 1fr;
+  gap: 2.5rem;
+  align-items: center;
+  padding: 2rem 0 0;
+}
+
+.cl-score-card__numerals {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+  font-family: var(--font-mono);
+  color: var(--color-text-primary);
+}
+
+.cl-score-card__num {
+  font-size: clamp(5rem, 14vw, 10rem);
+  font-weight: 600;
+  letter-spacing: -0.06em;
+  line-height: 0.85;
+}
+
+.cl-score-card__total {
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  color: var(--color-text-quiet);
+  font-weight: 400;
+  letter-spacing: 0;
+}
+
+.cl-score-card__verdict {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.cl-score-card__band {
+  display: inline-block;
+  width: max-content;
+  padding: 0.2rem 0.6rem;
+  background: var(--color-text-primary);
+  color: var(--color-on-primary);
+  letter-spacing: 0.18em;
+  font-size: 0.65rem;
+  border-radius: 1px;
+}
+
+.cl-score-card--excellent .cl-score-card__band {
+  background: var(--color-primary);
+}
+.cl-score-card--excellent .cl-score-card__num {
+  color: var(--color-primary);
+}
+.cl-score-card--good .cl-score-card__band {
+  background: var(--color-success);
+}
+.cl-score-card--pass .cl-score-card__band {
+  background: var(--color-info);
+}
+.cl-score-card--fail .cl-score-card__band {
+  background: var(--color-error);
+}
+.cl-score-card--fail .cl-score-card__num {
+  color: var(--color-error);
+}
+
+.cl-score-card__comment {
+  font-size: clamp(2rem, 4vw, 3.2rem);
+  margin: 0;
+  font-variation-settings: 'opsz' 96, 'wght' 460, 'SOFT' 50;
+  letter-spacing: -0.03em;
+  line-height: 1;
+  color: var(--color-text-primary);
+}
+
+.cl-score-card__sub {
+  display: flex;
+  gap: 0.5rem;
+  align-items: flex-start;
+  max-width: 38em;
+  font-size: 0.92rem;
+  color: var(--color-text-secondary);
+  line-height: 1.5;
+  margin: 0.5rem 0 0;
+}
+
+.cl-score-card__sub .material-icons.sm {
+  font-size: 18px;
+  color: var(--color-text-quiet);
+  margin-top: 0.15em;
+}
+
+@media (max-width: 720px) {
+  .cl-score-card {
+    grid-template-columns: 1fr;
+    gap: 1rem;
+    padding-top: 1rem;
+  }
+}
+
+/* === ledger-style stat row === */
+
+.cl-result-stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 0;
+  margin: 1.5rem 0 2.5rem;
+  background: var(--color-surface);
+  border: 1px solid var(--color-rule-strong);
+  border-radius: 2px;
+  overflow: hidden;
+}
+
+.cl-result-stats__row {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 1rem 1.25rem;
+  border-right: 1px solid var(--color-rule-soft);
+}
+
+.cl-result-stats__row:last-child {
+  border-right: 0;
+}
+
+.cl-result-stats__num {
+  font-size: 2rem;
+  font-weight: 600;
+  letter-spacing: -0.04em;
+  color: var(--color-text-primary);
+  line-height: 1;
+}
+
+.cl-result-stats__num--time {
+  font-size: 1.3rem;
+  letter-spacing: 0.02em;
+}
+
+.cl-result-stats__row--correct .cl-result-stats__num {
+  color: var(--color-success);
+}
+.cl-result-stats__row--wrong .cl-result-stats__num {
+  color: var(--color-error);
+}
+
+@media (max-width: 720px) {
+  .cl-result-stats__row {
+    border-right: 0;
+    border-bottom: 1px solid var(--color-rule-soft);
+  }
+  .cl-result-stats__row:last-child {
+    border-bottom: 0;
+  }
+}
+
+/* ==============================================================
+ * Carbon Ledger 覆蓋層 — Audit Report style
+ * ============================================================== */
+
+.cl-result-head { margin-bottom: 2rem; }
+
+.cl-result-head__meta {
+  display: flex; justify-content: space-between; align-items: baseline;
+  margin-bottom: 0.75rem;
+}
+
+.cl-result-head__meta .cl-figure { color: var(--color-text-quiet); }
+
+.cl-score-card {
+  display: grid;
+  grid-template-columns: minmax(200px, auto) 1fr;
+  gap: 2.5rem;
+  align-items: center;
+  padding: 2rem 0 0;
+}
+
+.cl-score-card__numerals {
+  display: flex; align-items: baseline; gap: 0.5rem;
+  font-family: var(--font-mono);
+  color: var(--color-text-primary);
+}
+
+.cl-score-card__num {
+  font-size: clamp(5rem, 14vw, 10rem);
+  font-weight: 600;
+  letter-spacing: -0.06em;
+  line-height: 0.85;
+}
+
+.cl-score-card__total {
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  color: var(--color-text-quiet);
+  font-weight: 400;
+}
+
+.cl-score-card__verdict {
+  display: flex; flex-direction: column; gap: 0.5rem;
+}
+
+.cl-score-card__band {
+  display: inline-block; width: max-content;
+  padding: 0.2rem 0.6rem;
+  background: var(--color-text-primary);
+  color: var(--color-on-primary);
+  letter-spacing: 0.18em;
+  font-size: 0.65rem;
+  border-radius: 1px;
+}
+
+.cl-score-card--excellent .cl-score-card__band { background: var(--color-primary); }
+.cl-score-card--excellent .cl-score-card__num  { color: var(--color-primary); }
+.cl-score-card--good      .cl-score-card__band { background: var(--color-success); }
+.cl-score-card--pass      .cl-score-card__band { background: var(--color-info); }
+.cl-score-card--fail      .cl-score-card__band { background: var(--color-error); }
+.cl-score-card--fail      .cl-score-card__num  { color: var(--color-error); }
+
+.cl-score-card__comment {
+  font-size: clamp(2rem, 4vw, 3.2rem);
+  margin: 0;
+  font-variation-settings: 'opsz' 96, 'wght' 460, 'SOFT' 50;
+  letter-spacing: -0.03em;
+  line-height: 1;
+  color: var(--color-text-primary);
+}
+
+.cl-score-card__sub {
+  display: flex; gap: 0.5rem; align-items: flex-start;
+  max-width: 38em;
+  font-size: 0.92rem;
+  color: var(--color-text-secondary);
+  line-height: 1.5;
+  margin: 0.5rem 0 0;
+}
+
+.cl-score-card__sub .material-icons.sm {
+  font-size: 18px; color: var(--color-text-quiet);
+  margin-top: 0.15em;
+}
+
+@media (max-width: 720px) {
+  .cl-score-card {
+    grid-template-columns: 1fr;
+    gap: 1rem;
+    padding-top: 1rem;
+  }
+}
+
+.cl-result-stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 0;
+  margin: 1.5rem 0 2.5rem;
+  background: var(--color-surface);
+  border: 1px solid var(--color-rule-strong);
+  border-radius: 2px;
+  overflow: hidden;
+}
+
+.cl-result-stats__row {
+  display: flex; flex-direction: column; gap: 0.5rem;
+  padding: 1rem 1.25rem;
+  border-right: 1px solid var(--color-rule-soft);
+}
+
+.cl-result-stats__row:last-child { border-right: 0; }
+
+.cl-result-stats__num {
+  font-size: 2rem; font-weight: 600;
+  letter-spacing: -0.04em;
+  color: var(--color-text-primary);
+  line-height: 1;
+}
+
+.cl-result-stats__num--time {
+  font-size: 1.3rem; letter-spacing: 0.02em;
+}
+
+.cl-result-stats__row--correct .cl-result-stats__num { color: var(--color-success); }
+.cl-result-stats__row--wrong   .cl-result-stats__num { color: var(--color-error); }
+
+@media (max-width: 720px) {
+  .cl-result-stats__row {
+    border-right: 0;
+    border-bottom: 1px solid var(--color-rule-soft);
+  }
+  .cl-result-stats__row:last-child { border-bottom: 0; }
+}

--- a/quiz-app/src/pages/ResultPage.test.tsx
+++ b/quiz-app/src/pages/ResultPage.test.tsx
@@ -1,0 +1,168 @@
+// ResultPage component test — covers Carbon Ledger audit report header,
+// 4 score bands, ledger stats, wrong-list rendering, and action callbacks.
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { ResultPage } from './ResultPage';
+import type { QuizResult, AnswerRecord } from '../types/quiz';
+
+// 還原真實 localStorage（test-setup.ts 把它 mock 成空函式）
+function installRealLocalStorage() {
+  const store = new Map<string, string>();
+  Object.defineProperty(window, 'localStorage', {
+    value: {
+      getItem: (k: string): string | null => store.get(k) ?? null,
+      setItem: (k: string, v: string): void => { store.set(k, v); },
+      removeItem: (k: string): void => { store.delete(k); },
+      clear: (): void => { store.clear(); },
+      key: (i: number): string | null => Array.from(store.keys())[i] ?? null,
+      get length(): number { return store.size; },
+    },
+    writable: true,
+    configurable: true,
+  });
+}
+
+beforeAll(() => { installRealLocalStorage(); });
+
+beforeEach(() => {
+  // URL.createObjectURL / revokeObjectURL 在 jsdom 裡沒實作 — 給個 stub
+  vi.stubGlobal('URL', {
+    ...URL,
+    createObjectURL: vi.fn(() => 'blob:fake'),
+    revokeObjectURL: vi.fn(),
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  localStorage.clear();
+  vi.unstubAllGlobals();
+});
+
+function makeResult(overrides: Partial<QuizResult> = {}): QuizResult {
+  const answers: AnswerRecord[] = overrides.answers ?? [];
+  return {
+    config: {
+      mode: 'practice',
+      subject: 'all',
+      questionCount: 10,
+      shuffleQuestions: false,
+      shuffleOptions: false,
+      showAnswerImmediately: true,
+      ...((overrides.config ?? {}) as Partial<QuizResult['config']>),
+    },
+    startTime: Date.now() - 600000,
+    endTime: Date.now(),
+    totalTime: 125000, // 2 分 5 秒
+    answers,
+    score: 95,
+    totalAnswerable: 10,
+    correctCount: 9,
+    wrongCount: 1,
+    skippedCount: 0,
+    ...overrides,
+  };
+}
+
+describe('ResultPage', () => {
+  it('renders audit report head + BAND A for high score', () => {
+    render(
+      <ResultPage
+        result={makeResult({ score: 95, correctCount: 10, wrongCount: 0 })}
+        onGoHome={() => {}}
+        onRetry={() => {}}
+      />
+    );
+    expect(screen.getByText(/AUDIT REPORT/)).toBeInTheDocument();
+    expect(screen.getByText('BAND A')).toBeInTheDocument();
+    expect(screen.getByText('太棒了！')).toBeInTheDocument();
+    // ledger stats labels
+    expect(screen.getByText(/CR \/ 答對/)).toBeInTheDocument();
+    expect(screen.getByText(/DR \/ 答錯/)).toBeInTheDocument();
+    expect(screen.getByText(/Σ \/ 總題數/)).toBeInTheDocument();
+    expect(screen.getByText(/τ \/ 用時/)).toBeInTheDocument();
+    // 用時格式化
+    expect(screen.getByText(/2 分 5 秒/)).toBeInTheDocument();
+  });
+
+  it('shows BAND B for score 70-89', () => {
+    render(
+      <ResultPage
+        result={makeResult({ score: 75 })}
+        onGoHome={() => {}}
+        onRetry={() => {}}
+      />
+    );
+    expect(screen.getByText('BAND B')).toBeInTheDocument();
+    expect(screen.getByText('不錯喔！')).toBeInTheDocument();
+  });
+
+  it('shows BAND C for score 60-69', () => {
+    render(
+      <ResultPage
+        result={makeResult({ score: 65 })}
+        onGoHome={() => {}}
+        onRetry={() => {}}
+      />
+    );
+    expect(screen.getByText('BAND C')).toBeInTheDocument();
+    expect(screen.getByText('及格了！')).toBeInTheDocument();
+  });
+
+  it('shows BAND D and encourages retry for score < 60', () => {
+    render(
+      <ResultPage
+        result={makeResult({ score: 40 })}
+        onGoHome={() => {}}
+        onRetry={() => {}}
+      />
+    );
+    expect(screen.getByText('BAND D')).toBeInTheDocument();
+    expect(screen.getByText('再加油！')).toBeInTheDocument();
+  });
+
+  it('does NOT render wrong-section when no wrong answers', () => {
+    render(
+      <ResultPage
+        result={makeResult({ wrongCount: 0, correctCount: 10, answers: [] })}
+        onGoHome={() => {}}
+        onRetry={() => {}}
+      />
+    );
+    expect(screen.queryByText(/錯誤題目/)).toBeNull();
+  });
+
+  it('calls onGoHome and onRetry on action buttons', () => {
+    const onGoHome = vi.fn();
+    const onRetry = vi.fn();
+    render(
+      <ResultPage
+        result={makeResult()}
+        onGoHome={onGoHome}
+        onRetry={onRetry}
+      />
+    );
+    fireEvent.click(screen.getByRole('button', { name: /返回首頁/ }));
+    fireEvent.click(screen.getByRole('button', { name: /再測一次/ }));
+    expect(onGoHome).toHaveBeenCalledOnce();
+    expect(onRetry).toHaveBeenCalledOnce();
+  });
+
+  it('export button creates a download (URL.createObjectURL invoked)', () => {
+    const createSpy = vi.fn(() => 'blob:fake');
+    vi.stubGlobal('URL', {
+      ...URL,
+      createObjectURL: createSpy,
+      revokeObjectURL: vi.fn(),
+    });
+    render(
+      <ResultPage
+        result={makeResult()}
+        onGoHome={() => {}}
+        onRetry={() => {}}
+      />
+    );
+    fireEvent.click(screen.getByRole('button', { name: /匯出結果/ }));
+    expect(createSpy).toHaveBeenCalledOnce();
+  });
+});

--- a/quiz-app/src/pages/ResultPage.test.tsx
+++ b/quiz-app/src/pages/ResultPage.test.tsx
@@ -81,8 +81,8 @@ describe('ResultPage', () => {
     expect(screen.getByText(/DR \/ 答錯/)).toBeInTheDocument();
     expect(screen.getByText(/Σ \/ 總題數/)).toBeInTheDocument();
     expect(screen.getByText(/τ \/ 用時/)).toBeInTheDocument();
-    // 用時格式化（visible row + 隱藏 legacy block 都會 render，故 getAllByText）
-    expect(screen.getAllByText(/2 分 5 秒/).length).toBeGreaterThan(0);
+    // 用時格式化（legacy hidden block 已刪，只剩 ledger row）
+    expect(screen.getByText(/2 分 5 秒/)).toBeInTheDocument();
   });
 
   it('shows BAND B for score 70-89', () => {

--- a/quiz-app/src/pages/ResultPage.test.tsx
+++ b/quiz-app/src/pages/ResultPage.test.tsx
@@ -81,8 +81,8 @@ describe('ResultPage', () => {
     expect(screen.getByText(/DR \/ 答錯/)).toBeInTheDocument();
     expect(screen.getByText(/Σ \/ 總題數/)).toBeInTheDocument();
     expect(screen.getByText(/τ \/ 用時/)).toBeInTheDocument();
-    // 用時格式化
-    expect(screen.getByText(/2 分 5 秒/)).toBeInTheDocument();
+    // 用時格式化（visible row + 隱藏 legacy block 都會 render，故 getAllByText）
+    expect(screen.getAllByText(/2 分 5 秒/).length).toBeGreaterThan(0);
   });
 
   it('shows BAND B for score 70-89', () => {

--- a/quiz-app/src/pages/ResultPage.tsx
+++ b/quiz-app/src/pages/ResultPage.tsx
@@ -169,35 +169,61 @@ export function ResultPage({ result, onGoHome, onRetry }: ResultPageProps) {
   }, [score]);
 
   return (
-    <div className="result-page animate-fade-in">
-      {/* 分數區 */}
-      <section className={`score-section card ${scoreComment.class}`}>
-        <div className="score-icon">
-          <span className="material-icons">{scoreComment.icon}</span>
+    <div className="result-page cl-page animate-fade-in">
+      {/* CARBON LEDGER 報告頁首 */}
+      <section className="cl-result-head">
+        <div className="cl-result-head__meta">
+          <span className="cl-eyebrow">AUDIT REPORT</span>
+          <span className="cl-eyebrow cl-figure">
+            {new Date().toISOString().slice(0, 10)} · NZ-Q
+          </span>
         </div>
-        <h1 className="score-value">{score}</h1>
-        <p className="score-label">分</p>
-        <p className="score-comment">{scoreComment.text}</p>
+        <hr className="cl-rule" aria-hidden="true" />
+
+        <div className={`cl-score-card cl-score-card--${scoreComment.class}`}>
+          <div className="cl-score-card__numerals" aria-label={`分數 ${score} 分`}>
+            <span className="cl-figure cl-score-card__num">{score}</span>
+            <span className="cl-score-card__total cl-figure">/ 100</span>
+          </div>
+          <div className="cl-score-card__verdict">
+            <span className="cl-eyebrow cl-score-card__band">
+              {score >= 90 ? 'BAND A' : score >= 70 ? 'BAND B' : score >= 60 ? 'BAND C' : 'BAND D'}
+            </span>
+            <h1 className="cl-display cl-score-card__comment">{scoreComment.text}</h1>
+            <p className="cl-score-card__sub">
+              <span className="material-icons sm">{scoreComment.icon}</span>
+              <span>
+                {score >= 90 ? '本次表現名列前段；建議鎖定弱項細節提升一致性。'
+                : score >= 70 ? '掌握度良好；針對個別錯題深化理解可進一步提升。'
+                : score >= 60 ? '及格達標；建議重做錯題並精讀相關法規條文。'
+                : '建議重新從基礎概念走過一遍；錯題列表可作為複習索引。'}
+              </span>
+            </p>
+          </div>
+        </div>
       </section>
 
-      {/* 統計區 */}
-      <section className="stats-section">
-        <div className="stat-item correct">
-          <span className="material-icons">check_circle</span>
-          <span className="stat-value">{correctCount}</span>
-          <span className="stat-label">答對</span>
+      {/* LEDGER 統計列 */}
+      <section className="cl-result-stats" aria-label="本次測驗統計">
+        <div className="cl-result-stats__row cl-result-stats__row--correct">
+          <span className="cl-eyebrow">CR / 答對</span>
+          <span className="cl-figure cl-result-stats__num">{correctCount}</span>
         </div>
-        <div className="stat-item wrong">
-          <span className="material-icons">cancel</span>
-          <span className="stat-value">{wrongCount}</span>
-          <span className="stat-label">答錯</span>
+        <div className="cl-result-stats__row cl-result-stats__row--wrong">
+          <span className="cl-eyebrow">DR / 答錯</span>
+          <span className="cl-figure cl-result-stats__num">{wrongCount}</span>
         </div>
-        <div className="stat-item total">
-          <span className="material-icons">quiz</span>
-          <span className="stat-value">{totalAnswerable}</span>
-          <span className="stat-label">總題數</span>
+        <div className="cl-result-stats__row">
+          <span className="cl-eyebrow">Σ / 總題數</span>
+          <span className="cl-figure cl-result-stats__num">{totalAnswerable}</span>
         </div>
-        <div className="stat-item time">
+        <div className="cl-result-stats__row">
+          <span className="cl-eyebrow">τ / 用時</span>
+          <span className="cl-figure cl-result-stats__num cl-result-stats__num--time">
+            {formattedTime}
+          </span>
+        </div>
+        <div className="stat-item time" hidden aria-hidden="true">
           <span className="material-icons">timer</span>
           <span className="stat-value">{formattedTime}</span>
           <span className="stat-label">用時</span>

--- a/quiz-app/src/pages/ResultPage.tsx
+++ b/quiz-app/src/pages/ResultPage.tsx
@@ -223,11 +223,6 @@ export function ResultPage({ result, onGoHome, onRetry }: ResultPageProps) {
             {formattedTime}
           </span>
         </div>
-        <div className="stat-item time" hidden aria-hidden="true">
-          <span className="material-icons">timer</span>
-          <span className="stat-value">{formattedTime}</span>
-          <span className="stat-label">用時</span>
-        </div>
       </section>
 
       {/* 錯題列表 */}

--- a/quiz-app/src/styles/carbon-ledger.css
+++ b/quiz-app/src/styles/carbon-ledger.css
@@ -1,0 +1,282 @@
+/*
+ * Carbon Ledger / Atmospheric Archive — design system overlay
+ * 碳審計檔案風格設計系統，覆蓋既有 variables.css 之色票
+ *
+ * 概念：每題像研究檔案的條目；分數像會計收支表；來源像學術引文。
+ * 字體：Fraunces (display, variable serif w/ optical-size + soft axis)
+ *       Public Sans (body, US government font — dignified humanist sans)
+ *       JetBrains Mono (figures — tabular numerals)
+ * 配色：避免淨零陳腔濫調的葉綠；改用地殼礦物色（charcoal-teal、parchment、mineral-teal accent、oxide rust）
+ */
+
+:root {
+  /* ----- 字體系統 ----- */
+  --font-display: 'Fraunces', 'Noto Serif TC', 'Songti TC', Georgia, serif;
+  --font-body: 'Public Sans', 'Noto Sans TC', -apple-system, BlinkMacSystemFont,
+    'Segoe UI', sans-serif;
+  --font-mono: 'JetBrains Mono', 'Roboto Mono', 'Cascadia Code', Consolas, monospace;
+
+  /* Fraunces variable axes preset — display headlines */
+  --display-axes: 'opsz' 96, 'wght' 480, 'SOFT' 50;
+  --display-axes-tight: 'opsz' 144, 'wght' 360, 'SOFT' 0;
+  --body-axes: 'opsz' 14, 'wght' 420;
+
+  /* ----- 礦物色票（Carbon Ledger）— LIGHT ----- */
+  /* Surfaces */
+  --color-background: #efe9dc;        /* warm parchment */
+  --color-surface: #fbf6e9;            /* paper */
+  --color-surface-variant: #e6dfce;    /* aged paper */
+  --color-surface-elevated: #fdfbf2;   /* lifted card */
+
+  /* Inks */
+  --color-text-primary: #0f1b1f;       /* charcoal-teal */
+  --color-text-secondary: #495d61;     /* mid teal-grey */
+  --color-text-quiet: #6b7d80;         /* muted */
+  --color-text-disabled: #97a4a6;
+  --color-text-on-dark: #fbf6e9;
+
+  /* Mineral teal accent (verified / primary) */
+  --color-primary: #0e5c5c;
+  --color-primary-dark: #07383a;
+  --color-primary-light: #2c8079;
+  --color-primary-soft: #c7d9d6;
+  --color-on-primary: #fbf6e9;
+
+  /* Oxide rust accent (AI 揭露 + 警示) */
+  --color-warning: #a85b1a;
+  --color-warning-fg: #6e3a0d;
+  --color-warning-bg: #f0d9c0;
+
+  /* Slate (external_mock badge) */
+  --color-info: #38545a;
+  --color-info-fg: #1f3034;
+  --color-info-bg: #d6dee0;
+  --color-info-fg-dark: #b3c5c7;
+
+  /* Verified/correct (used sparingly) */
+  --color-success: #2c6041;
+  --color-success-fg: #173324;
+  --color-success-bg: #d2dfd5;
+
+  /* Errors / wrong answers */
+  --color-error: #8a2a23;
+  --color-error-fg: #5a1611;
+  --color-error-bg: #ecd1cd;
+
+  /* Rules / borders / hairlines */
+  --color-divider: #c8c0ad;
+  --color-border: #d4cfc2;
+  --color-rule-strong: #0f1b1f;
+  --color-rule-soft: rgba(15, 27, 31, 0.08);
+
+  /* Sidenote / footnote */
+  --color-footnote-marker: #0e5c5c;
+
+  /* ----- Shadows — quiet, paper-pressed ----- */
+  --shadow-1: 0 1px 0 rgba(15, 27, 31, 0.06), 0 0 0 1px rgba(15, 27, 31, 0.04);
+  --shadow-2: 0 2px 6px rgba(15, 27, 31, 0.08), 0 0 0 1px rgba(15, 27, 31, 0.05);
+  --shadow-3: 0 8px 18px rgba(15, 27, 31, 0.10), 0 0 0 1px rgba(15, 27, 31, 0.05);
+  --shadow-4: 0 18px 40px rgba(15, 27, 31, 0.18), 0 0 0 1px rgba(15, 27, 31, 0.05);
+  --shadow-press: inset 0 1px 0 rgba(15, 27, 31, 0.06);
+
+  /* ----- Grain (SVG data URI, ~1.6KB inline) ----- */
+  --grain-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='240' height='240'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='2' seed='4' stitchTiles='stitch'/><feColorMatrix values='0 0 0 0 0  0 0 0 0 0  0 0 0 0 0  0 0 0 0.55 0'/></filter><rect width='100%' height='100%' filter='url(%23n)' opacity='0.42'/></svg>");
+}
+
+/* ----- 礦物色票 — DARK ----- */
+[data-theme='dark'] {
+  --color-background: #0c1517;        /* deep teal-black */
+  --color-surface: #15211f;
+  --color-surface-variant: #1d2a28;
+  --color-surface-elevated: #1a2725;
+
+  --color-text-primary: #ebe4d2;       /* warm parchment ink (low contrast on warm bg) */
+  --color-text-secondary: #b8b0a0;
+  --color-text-quiet: #8a847a;
+  --color-text-disabled: #5a554d;
+  --color-text-on-dark: #ebe4d2;
+
+  --color-primary: #5dbab2;
+  --color-primary-dark: #3a8a82;
+  --color-primary-light: #93d6cf;
+  --color-primary-soft: rgba(93, 186, 178, 0.16);
+  --color-on-primary: #0c1517;
+
+  --color-warning: #d88e5a;
+  --color-warning-fg: #f0b08a;
+  --color-warning-bg: rgba(216, 142, 90, 0.16);
+
+  --color-info: #b3c5c7;
+  --color-info-fg: #d8e3e5;
+  --color-info-bg: rgba(179, 197, 199, 0.12);
+
+  --color-success: #7eb691;
+  --color-success-fg: #b3d4be;
+  --color-success-bg: rgba(126, 182, 145, 0.14);
+
+  --color-error: #e08a82;
+  --color-error-fg: #f0b3ad;
+  --color-error-bg: rgba(224, 138, 130, 0.14);
+
+  --color-divider: #2a3735;
+  --color-border: #2a3735;
+  --color-rule-strong: #ebe4d2;
+  --color-rule-soft: rgba(235, 228, 210, 0.08);
+
+  --color-footnote-marker: #5dbab2;
+
+  --shadow-1: 0 1px 0 rgba(0, 0, 0, 0.5);
+  --shadow-2: 0 2px 8px rgba(0, 0, 0, 0.5);
+  --shadow-3: 0 10px 24px rgba(0, 0, 0, 0.6);
+  --shadow-4: 0 22px 48px rgba(0, 0, 0, 0.7);
+}
+
+/* ===============================================================
+ *  全域排版風格 — apply only inside .app to avoid clobbering tests
+ * =============================================================== */
+
+html,
+body {
+  background: var(--color-background);
+  color: var(--color-text-primary);
+  font-family: var(--font-body);
+  font-feature-settings: 'ss01', 'cv11', 'tnum';
+  font-variation-settings: var(--body-axes);
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-rendering: optimizeLegibility;
+}
+
+body {
+  /* Subtle paper grain — fixed so it doesn't tile-jitter on scroll */
+  background-image: var(--grain-image);
+  background-size: 240px;
+  background-attachment: fixed;
+  background-blend-mode: multiply;
+  background-color: var(--color-background);
+}
+
+/* Display headlines use Fraunces — serif w/ optical-size axis */
+.cl-display {
+  font-family: var(--font-display);
+  font-variation-settings: var(--display-axes);
+  letter-spacing: -0.02em;
+  line-height: 0.95;
+}
+
+.cl-display--tight {
+  font-variation-settings: var(--display-axes-tight);
+  letter-spacing: -0.04em;
+}
+
+/* Italic display — for "verified" emphasis */
+.cl-display em {
+  font-style: italic;
+  font-variation-settings: 'opsz' 144, 'wght' 320, 'SOFT' 100;
+}
+
+/* Tabular numerals — numbers everywhere, especially scores */
+.cl-figure {
+  font-family: var(--font-mono);
+  font-variant-numeric: tabular-nums lining-nums;
+  letter-spacing: 0;
+}
+
+/* Smallcaps eyebrow labels */
+.cl-eyebrow {
+  font-family: var(--font-body);
+  font-variation-settings: 'wght' 580;
+  font-size: 0.72rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--color-text-quiet);
+}
+
+/* Hairline rule — page-level horizontal divider */
+.cl-rule {
+  border: 0;
+  border-top: 1px solid var(--color-rule-strong);
+  margin: 0;
+  height: 1px;
+}
+
+.cl-rule--soft {
+  border-top-color: var(--color-rule-soft);
+}
+
+/* Footnote marker — academic citation style */
+.cl-fn-marker {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 1.4em;
+  padding: 0 0.3em;
+  font-family: var(--font-mono);
+  font-size: 0.72em;
+  font-weight: 600;
+  line-height: 1.4;
+  color: var(--color-on-primary);
+  background: var(--color-footnote-marker);
+  border-radius: 2px;
+  vertical-align: 0.45em;
+  letter-spacing: 0.04em;
+}
+
+/* Ledger entry — DR/CR style row */
+.cl-ledger-row {
+  display: grid;
+  grid-template-columns: 32px 1fr auto;
+  gap: 0.75rem;
+  padding: 0.5rem 0;
+  border-bottom: 1px dotted var(--color-rule-soft);
+  font-size: 0.92rem;
+}
+
+.cl-ledger-row__index {
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  color: var(--color-text-quiet);
+  text-align: right;
+}
+
+.cl-ledger-row__label {
+  font-variation-settings: 'wght' 500;
+}
+
+.cl-ledger-row__value {
+  font-family: var(--font-mono);
+  font-variant-numeric: tabular-nums;
+  color: var(--color-text-primary);
+  font-variation-settings: 'wght' 600;
+}
+
+/* Section eyebrow with leading dot */
+.cl-section-mark {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5em;
+}
+.cl-section-mark::before {
+  content: '';
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--color-primary);
+}
+
+/* Focus outlines — high-contrast box, matches archive aesthetic */
+*:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+  border-radius: 2px;
+}
+
+/* Reduce motion */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    transition-duration: 0.01ms !important;
+  }
+}

--- a/quiz-app/vitest.config.ts
+++ b/quiz-app/vitest.config.ts
@@ -12,7 +12,13 @@ export default defineConfig({
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html'],
-      exclude: ['node_modules/', 'src/test-setup.ts'],
+      exclude: [
+        'node_modules/',
+        'src/test-setup.ts',
+        // Entry point — bootstrap-only side effects (createRoot + DEV-mode
+        // schema validate dynamic imports)；由 E2E 整合測試覆蓋
+        'src/main.tsx',
+      ],
     },
   },
   resolve: {


### PR DESCRIPTION
整體前端重新設計，Carbon Ledger / Atmospheric Archive 風格。

## 設計方向
礦物色 + parchment 紙質感，避免淨零陳腔濫調的葉綠色票。配色：parchment cream 背景、charcoal-teal 主文字、mineral-teal accent (#0E5C5C)、oxide rust (#A85B1A) 為 AI 揭露警示。字體：Fraunces (display serif w/ opsz+SOFT 軸)、Public Sans (body)、JetBrains Mono (figures)。

## 重設計 6 個元件
1. **HomePage** — 扉頁 hero + ledger 統計 + 卡片式科目/模式選擇 + 大 CTA
2. **PracticeOptInDialog** — 兩欄佈局，左視覺化來源比例條，右文字 + EU AI Act 揭露
3. **SourceBadge** — dot + tabular abbrev (EM/AI) + 跳動光圈
4. **Header** — 自訂雙圓 logomark + Fraunces wordmark；GitHub icon → forum icon
5. **ResultPage** — AUDIT REPORT 風格大分數 + Band A/B/C/D 標籤 + ledger 統計列
6. **Footer + VisitorCounter** — 三欄 archive signature + 'END OF DOCUMENT' 簽署列

## 補覆蓋
PR #34 Codecov 指出 App.tsx 16 行 0% 覆蓋；本 PR 加 src/App.test.tsx 5 case 涵蓋 practice-mode 路徑、settings 導航、Header link 等。

## 不引新依賴
純 CSS animations + inline SVG。Fonts via Google CDN（不進 bundle）。