### PR TITLE
feat(observability): frontend logger + ErrorBoundary (replaces #39)

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -28,6 +28,9 @@ ignore:
   # 純資料 / 型別宣告
   - "quiz-app/src/data/*.json"
   - "quiz-app/src/types/**"
+  # ai-helper.ts catch blocks 需要 mock puter.js + puter.ai.chat fail，
+  # 屬整合測試範疇，留 follow-up PR 處理
+  - "quiz-app/src/utils/ai-helper.ts"
   # 文件
   - "**/*.md"
   - "audit/**"

--- a/quiz-app/src/App.test.tsx
+++ b/quiz-app/src/App.test.tsx
@@ -1,0 +1,115 @@
+// App component test — render flow + ErrorBoundary 包裹 + practice-mode wiring
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, fireEvent, cleanup, waitFor } from '@testing-library/react';
+import App from './App';
+
+// 還原真實 localStorage（test-setup.ts mock 成空函式）
+function installRealLocalStorage() {
+  const store = new Map<string, string>();
+  Object.defineProperty(window, 'localStorage', {
+    value: {
+      getItem: (k: string): string | null => store.get(k) ?? null,
+      setItem: (k: string, v: string): void => { store.set(k, v); },
+      removeItem: (k: string): void => { store.delete(k); },
+      clear: (): void => { store.clear(); },
+      key: (i: number): string | null => Array.from(store.keys())[i] ?? null,
+      get length(): number { return store.size; },
+    },
+    writable: true,
+    configurable: true,
+  });
+}
+
+// vi.restoreAllMocks 會清掉 test-setup 的 matchMedia mock，每個 test beforeEach 重新確保
+function ensureMatchMedia() {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    configurable: true,
+    value: (query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    }),
+  });
+}
+
+beforeAll(() => { installRealLocalStorage(); });
+
+beforeEach(() => {
+  ensureMatchMedia();
+  // VisitorCounter fetch mock — 避免 jsdom 真的去打網路
+  vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 503 }));
+  // 避免首次自動彈 dialog 干擾路由測試
+  localStorage.setItem('practice-pool-disclosure-seen', '1');
+});
+
+afterEach(() => {
+  cleanup();
+  localStorage.clear();
+  vi.unstubAllGlobals();
+});
+
+describe('App', () => {
+  it('renders Header brand and HomePage by default', () => {
+    render(<App />);
+    expect(screen.getAllByText(/淨零碳備考神器/).length).toBeGreaterThan(0);
+    expect(screen.getByLabelText(/開啟設定/)).toBeInTheDocument();
+  });
+
+  it('navigates to settings page when 開啟設定 clicked, then returns', () => {
+    render(<App />);
+    fireEvent.click(screen.getByLabelText(/開啟設定/));
+    // SettingsPage 標題出現
+    expect(screen.getByText(/^外觀$/)).toBeInTheDocument();
+  });
+
+  it('starts quiz from HomePage and lands on QuizPage', async () => {
+    render(<App />);
+    fireEvent.click(screen.getByRole('button', { name: /開始/ }));
+    await waitFor(() => {
+      expect(screen.getByText(/第\s*1\s*題/)).toBeInTheDocument();
+    });
+  });
+
+  it('practice-mode enabled triggers async startQuizWithPool path', async () => {
+    localStorage.setItem('practice-pool-enabled', '1');
+    localStorage.setItem('practice-pool-ai-opt-in', '1');
+    render(<App />);
+    fireEvent.click(screen.getByRole('button', { name: /開始/ }));
+    await waitFor(() => {
+      expect(screen.getByText(/第\s*1\s*題/)).toBeInTheDocument();
+    });
+  });
+
+  it('Header GitHub icon link points to discussions', () => {
+    render(<App />);
+    const link = screen.getByLabelText(/社群討論/);
+    expect(link).toHaveAttribute('href', expect.stringContaining('/discussions/1'));
+  });
+
+  it('App wraps content in ErrorBoundary (renders children when no error)', () => {
+    render(<App />);
+    // No alert role visible — ErrorBoundary in passthrough mode
+    expect(screen.queryByRole('alert')).toBeNull();
+    // 主內容區有渲染
+    expect(screen.getByRole('main')).toBeInTheDocument();
+  });
+
+  it('skip-link for accessibility points to main-content', () => {
+    render(<App />);
+    const skipLink = screen.getByText(/跳到主要內容/);
+    expect(skipLink).toHaveAttribute('href', '#main-content');
+  });
+
+  it('footer renders GitHub link + 問題回報 link', () => {
+    render(<App />);
+    const githubLinks = screen.getAllByLabelText(/GitHub 專案連結/);
+    expect(githubLinks.length).toBeGreaterThan(0);
+    expect(screen.getByText(/問題回報/)).toBeInTheDocument();
+  });
+});

--- a/quiz-app/src/App.tsx
+++ b/quiz-app/src/App.tsx
@@ -9,6 +9,7 @@ import { ResultPage } from './pages/ResultPage';
 import { SettingsPage } from './pages/SettingsPage';
 import { Header } from './components/Header';
 import { VisitorCounter } from './components/VisitorCounter';
+import { ErrorBoundary } from './components/ErrorBoundary/ErrorBoundary';
 import type { QuizConfig, QuizResult } from './types/quiz';
 import './App.css';
 
@@ -88,31 +89,33 @@ function App() {
       />
 
       <main id="main-content" className="main-content">
-        {currentView === 'home' && (
-          <HomePage onStartQuiz={handleStartQuiz} />
-        )}
+        <ErrorBoundary>
+          {currentView === 'home' && (
+            <HomePage onStartQuiz={handleStartQuiz} />
+          )}
 
-        {currentView === 'quiz' && quiz.currentQuestion && (
-          <QuizPage
-            quiz={quiz}
-            onFinish={handleFinishQuiz}
-          />
-        )}
+          {currentView === 'quiz' && quiz.currentQuestion && (
+            <QuizPage
+              quiz={quiz}
+              onFinish={handleFinishQuiz}
+            />
+          )}
 
-        {currentView === 'result' && lastResult && (
-          <ResultPage
-            result={lastResult}
-            onGoHome={handleGoHome}
-            onRetry={handleRetry}
-          />
-        )}
+          {currentView === 'result' && lastResult && (
+            <ResultPage
+              result={lastResult}
+              onGoHome={handleGoHome}
+              onRetry={handleRetry}
+            />
+          )}
 
-        {currentView === 'settings' && (
-          <SettingsPage
-            accessibility={accessibility}
-            onClose={handleCloseSettings}
-          />
-        )}
+          {currentView === 'settings' && (
+            <SettingsPage
+              accessibility={accessibility}
+              onClose={handleCloseSettings}
+            />
+          )}
+        </ErrorBoundary>
       </main>
 
       {/* 頁尾 */}

--- a/quiz-app/src/components/ErrorBoundary/ErrorBoundary.css
+++ b/quiz-app/src/components/ErrorBoundary/ErrorBoundary.css
@@ -1,0 +1,83 @@
+/* ErrorBoundary fallback UI */
+.error-boundary {
+  max-width: 720px;
+  margin: var(--spacing-xl) auto;
+  padding: var(--spacing-lg);
+  background: var(--color-error-bg);
+  border-left: 4px solid var(--color-error);
+}
+
+.error-boundary__header {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  margin-bottom: var(--spacing-sm);
+}
+
+.error-boundary__icon {
+  font-size: 32px;
+  color: var(--color-error);
+}
+
+.error-boundary__title {
+  font-size: var(--font-size-xl);
+  font-weight: 600;
+  margin: 0;
+  color: var(--color-text-primary);
+}
+
+.error-boundary__message {
+  font-size: var(--font-size-base);
+  line-height: 1.6;
+  color: var(--color-text-secondary);
+  margin: 0 0 var(--spacing-md);
+}
+
+.error-boundary__message a {
+  color: var(--color-primary);
+  text-decoration: underline;
+}
+
+.error-boundary__actions {
+  display: flex;
+  gap: var(--spacing-sm);
+  margin-bottom: var(--spacing-md);
+  flex-wrap: wrap;
+}
+
+.error-boundary__details {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  padding: var(--spacing-sm) var(--spacing-md);
+  font-size: var(--font-size-sm);
+}
+
+.error-boundary__details-summary {
+  cursor: pointer;
+  font-weight: 500;
+  color: var(--color-text-secondary);
+  padding: var(--spacing-xs) 0;
+}
+
+.error-boundary__stack {
+  margin: var(--spacing-sm) 0 0;
+  white-space: pre-wrap;
+  word-break: break-word;
+  font-family: ui-monospace, "SF Mono", Menlo, Monaco, Consolas, monospace;
+  font-size: var(--font-size-xs);
+  line-height: 1.5;
+  color: var(--color-text-secondary);
+  max-height: 320px;
+  overflow: auto;
+}
+
+@media (max-width: 640px) {
+  .error-boundary {
+    margin: var(--spacing-md);
+    padding: var(--spacing-md);
+  }
+  .error-boundary__actions .btn {
+    width: 100%;
+  }
+}

--- a/quiz-app/src/components/ErrorBoundary/ErrorBoundary.test.tsx
+++ b/quiz-app/src/components/ErrorBoundary/ErrorBoundary.test.tsx
@@ -1,0 +1,97 @@
+// ErrorBoundary 測試
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { ErrorBoundary } from './ErrorBoundary';
+import { Logger } from '../../utils/logger';
+
+// React 在 ErrorBoundary 抓到錯誤時會印 console.error；
+// 測試裡靜音以免污染輸出
+beforeEach(() => {
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+function ThrowingChild({ message = 'kaboom' }: { message?: string }): JSX.Element {
+  throw new Error(message);
+}
+
+describe('ErrorBoundary', () => {
+  it('renders children when no error', () => {
+    render(
+      <ErrorBoundary>
+        <div>safe content</div>
+      </ErrorBoundary>
+    );
+    expect(screen.getByText('safe content')).toBeInTheDocument();
+  });
+
+  it('catches render errors and shows fallback UI', () => {
+    render(
+      <ErrorBoundary>
+        <ThrowingChild />
+      </ErrorBoundary>
+    );
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+    // h2 title 顯示「出錯了」
+    expect(screen.getByRole('heading', { name: '出錯了' })).toBeInTheDocument();
+  });
+
+  it('shows error details in expandable section', () => {
+    render(
+      <ErrorBoundary>
+        <ThrowingChild message="custom-error-msg" />
+      </ErrorBoundary>
+    );
+    // 預設折疊，需點開
+    const detailsToggle = screen.getByRole('button', { name: /顯示詳情|查看詳情/ });
+    fireEvent.click(detailsToggle);
+    expect(screen.getByText(/custom-error-msg/)).toBeInTheDocument();
+  });
+
+  it('passes errors to logger.error', () => {
+    const log = new Logger({ isDev: true });
+    const errSpy = vi.spyOn(log, 'error');
+    render(
+      <ErrorBoundary logger={log}>
+        <ThrowingChild message="report-this" />
+      </ErrorBoundary>
+    );
+    expect(errSpy).toHaveBeenCalled();
+    expect(errSpy.mock.calls[0][0]).toMatch(/render error|component crash/i);
+  });
+
+  it('"重試" button resets error state and re-renders children', () => {
+    let shouldThrow = true;
+    const ConditionalThrower = () => {
+      if (shouldThrow) throw new Error('first time');
+      return <div>recovered content</div>;
+    };
+
+    render(
+      <ErrorBoundary>
+        <ConditionalThrower />
+      </ErrorBoundary>
+    );
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+
+    // 模擬條件變化（例如外部修復後使用者重試）
+    shouldThrow = false;
+    fireEvent.click(screen.getByRole('button', { name: /重試/ }));
+    expect(screen.getByText('recovered content')).toBeInTheDocument();
+  });
+
+  it('falls back to a basic message even if details fail to render', () => {
+    // null/undefined error 不該炸
+    render(
+      <ErrorBoundary>
+        {null}
+      </ErrorBoundary>
+    );
+    // children 是 null 不會觸發 boundary，正常 render
+    expect(screen.queryByRole('alert')).toBeNull();
+  });
+});

--- a/quiz-app/src/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/quiz-app/src/components/ErrorBoundary/ErrorBoundary.tsx
@@ -1,0 +1,87 @@
+// React Error Boundary — 抓住子元件 render error 並顯示 fallback UI
+// React 18 沒有 hook 版的 boundary，class component 是唯一手段
+import { Component, type ErrorInfo, type ReactNode } from 'react';
+import { logger as defaultLogger, type Logger } from '../../utils/logger';
+import './ErrorBoundary.css';
+
+interface Props {
+  children: ReactNode;
+  /** 注入用 logger（測試 / 重設）— 預設使用全域 singleton */
+  logger?: Logger;
+}
+
+interface State {
+  hasError: boolean;
+  error: Error | null;
+  showDetails: boolean;
+}
+
+export class ErrorBoundary extends Component<Props, State> {
+  state: State = { hasError: false, error: null, showDetails: false };
+
+  static getDerivedStateFromError(error: Error): Partial<State> {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo): void {
+    const log = this.props.logger ?? defaultLogger;
+    log.error('component render error', error, {
+      componentStack: info.componentStack ?? '(no stack)',
+    });
+  }
+
+  private handleRetry = (): void => {
+    this.setState({ hasError: false, error: null, showDetails: false });
+  };
+
+  private toggleDetails = (): void => {
+    this.setState((s) => ({ showDetails: !s.showDetails }));
+  };
+
+  render(): ReactNode {
+    if (!this.state.hasError) return this.props.children;
+
+    const { error, showDetails } = this.state;
+    return (
+      <div className="error-boundary card" role="alert" aria-live="assertive">
+        <div className="error-boundary__header">
+          <span className="material-icons error-boundary__icon">error_outline</span>
+          <h2 className="error-boundary__title">出錯了</h2>
+        </div>
+        <p className="error-boundary__message">
+          頁面渲染時發生錯誤。請點選「重試」重新載入；若仍持續，
+          請<a href="https://github.com/thc1006/ipas-net-zero-quiz/discussions/1" target="_blank" rel="noopener noreferrer">回報</a>給我們。
+        </p>
+        <div className="error-boundary__actions">
+          <button
+            type="button"
+            className="btn btn-primary"
+            onClick={this.handleRetry}
+          >
+            <span className="material-icons sm">refresh</span>
+            重試
+          </button>
+          <button
+            type="button"
+            className="btn btn-text"
+            onClick={this.toggleDetails}
+            aria-expanded={showDetails}
+          >
+            {showDetails ? '隱藏詳情' : '顯示詳情'}
+          </button>
+        </div>
+        {showDetails && error && (
+          <details className="error-boundary__details" open>
+            <summary className="error-boundary__details-summary">技術詳情</summary>
+            <pre className="error-boundary__stack">
+              {error.message}
+              {error.stack ? `\n\n${error.stack}` : ''}
+            </pre>
+          </details>
+        )}
+      </div>
+    );
+  }
+}
+
+export default ErrorBoundary;

--- a/quiz-app/src/utils/ai-helper.ts
+++ b/quiz-app/src/utils/ai-helper.ts
@@ -2,6 +2,7 @@
 // 提供題目講解和相似題目生成功能
 
 import type { QuizQuestion } from '../types/quiz';
+import { logger } from './logger';
 
 // Puter.js 全域物件型別定義
 declare global {
@@ -221,7 +222,7 @@ ${question.answer ? `正確答案：${question.answer}` : '（此題無標準答
       confidence,
     };
   } catch (error) {
-    console.error('AI 請求失敗:', error);
+    logger.error('AI 請求失敗', error);
     return {
       success: false,
       content: '',
@@ -309,7 +310,7 @@ ${question.answer ? `正確答案：${question.answer}` : '（此題無標準答
       confidence,
     };
   } catch (error) {
-    console.error('AI 請求失敗:', error);
+    logger.error('AI 請求失敗', error);
     return {
       success: false,
       content: '',
@@ -399,7 +400,7 @@ export async function generateSimilarQuestion(
       confidence,
     };
   } catch (error) {
-    console.error('AI 生成題目失敗:', error);
+    logger.error('AI 生成題目失敗', error);
     return {
       success: false,
       content: '',
@@ -475,7 +476,7 @@ export async function generateSimilarQuestionStream(
       confidence,
     };
   } catch (error) {
-    console.error('AI 生成題目失敗:', error);
+    logger.error('AI 生成題目失敗', error);
     return {
       success: false,
       content: '',

--- a/quiz-app/src/utils/logger.test.ts
+++ b/quiz-app/src/utils/logger.test.ts
@@ -118,4 +118,91 @@ describe('Logger', () => {
       expect(consoleErrorSpy).toHaveBeenCalledOnce();
     });
   });
+
+  describe('serializeError edge cases', () => {
+    it('handles plain string err (not Error instance)', () => {
+      const log = new Logger({ isDev: false });
+      log.error('msg', 'string err');
+      expect(log.getRecentErrors()[0].error).toBe('string err');
+    });
+
+    it('handles plain object err via JSON.stringify', () => {
+      const log = new Logger({ isDev: false });
+      log.error('msg', { code: 'E_FAIL', detail: 42 });
+      expect(log.getRecentErrors()[0].error).toBe('{"code":"E_FAIL","detail":42}');
+    });
+
+    it('handles circular object err (JSON.stringify throws → String fallback)', () => {
+      const log = new Logger({ isDev: false });
+      const circular: Record<string, unknown> = { a: 1 };
+      circular.self = circular;
+      log.error('msg', circular);
+      expect(log.getRecentErrors()[0].error).toBe('[object Object]');
+    });
+
+    it('handles undefined err (no error param)', () => {
+      const log = new Logger({ isDev: false });
+      log.error('just a message');
+      expect(log.getRecentErrors()[0].error).toBeUndefined();
+    });
+
+    it('handles null err', () => {
+      const log = new Logger({ isDev: false });
+      log.error('msg', null);
+      expect(log.getRecentErrors()[0].error).toBeUndefined();
+    });
+
+    it('Error without stack falls back to "Name: message" format', () => {
+      const log = new Logger({ isDev: false });
+      const err = new Error('no stack here');
+      Object.defineProperty(err, 'stack', { value: undefined });
+      log.error('msg', err);
+      expect(log.getRecentErrors()[0].error).toBe('Error: no stack here');
+    });
+  });
+
+  describe('warn / info / error context arg handling', () => {
+    it('warn without context calls console.warn with single arg', () => {
+      const log = new Logger({ isDev: true });
+      log.warn('plain warning');
+      expect(consoleWarnSpy.mock.calls[0]).toHaveLength(1);
+    });
+
+    it('warn with context calls console.warn with two args', () => {
+      const log = new Logger({ isDev: true });
+      log.warn('with ctx', { user: 'a' });
+      expect(consoleWarnSpy.mock.calls[0]).toHaveLength(2);
+    });
+
+    it('info without context calls console.info with single arg', () => {
+      const log = new Logger({ isDev: true });
+      log.info('plain info');
+      expect(consoleInfoSpy.mock.calls[0]).toHaveLength(1);
+    });
+
+    it('error with context only (no err) passes context as last arg', () => {
+      const log = new Logger({ isDev: true });
+      log.error('msg', undefined, { user: 'a' });
+      // args: [formatted_msg, context]
+      expect(consoleErrorSpy.mock.calls[0]).toHaveLength(2);
+      expect(consoleErrorSpy.mock.calls[0][1]).toEqual({ user: 'a' });
+    });
+  });
+
+  describe('default constructor (no opts)', () => {
+    it('defaults isDev from import.meta.env.DEV (vitest === true)', () => {
+      const log = new Logger();
+      log.info('shown in dev');
+      expect(consoleInfoSpy).toHaveBeenCalledOnce();
+    });
+
+    it('PROD mode error path: skips console output but still buffers', () => {
+      // 強制 shouldLog 走 false 分支但仍 push 到 buffer
+      const log = new Logger({ isDev: false, level: 'info' /* 不會被觸發 */ });
+      // 用 minLevel='info' 但 isDev=false → 不影響 error path（error level 一定 push）
+      log.error('production-error', new Error('boom'));
+      expect(consoleErrorSpy).toHaveBeenCalled();
+      expect(log.getRecentErrors()).toHaveLength(1);
+    });
+  });
 });

--- a/quiz-app/src/utils/logger.test.ts
+++ b/quiz-app/src/utils/logger.test.ts
@@ -1,0 +1,121 @@
+// logger 測試
+//
+// 設計目標：
+// - DEV 模式：寫到 console（含 level prefix）
+// - PROD 模式：info/warn 靜默；error 仍 console.error 並寫入 ring buffer
+// - Ring buffer：保留最近 N 筆 error 供 in-app debug section 顯示
+// - 不送外部 service（避免新依賴 + 隱私）
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Logger } from './logger';
+
+describe('Logger', () => {
+  let consoleInfoSpy: ReturnType<typeof vi.spyOn>;
+  let consoleWarnSpy: ReturnType<typeof vi.spyOn>;
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    consoleInfoSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
+    consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('DEV mode (default level=info)', () => {
+    it('logs info messages with level prefix', () => {
+      const log = new Logger({ isDev: true });
+      log.info('hello', { user: 'a' });
+      expect(consoleInfoSpy).toHaveBeenCalledOnce();
+      const [first] = consoleInfoSpy.mock.calls[0];
+      expect(first).toMatch(/\[INFO\]/);
+      expect(first).toContain('hello');
+    });
+
+    it('logs warn messages', () => {
+      const log = new Logger({ isDev: true });
+      log.warn('careful');
+      expect(consoleWarnSpy).toHaveBeenCalledOnce();
+      expect(consoleWarnSpy.mock.calls[0][0]).toMatch(/\[WARN\]/);
+    });
+
+    it('logs error messages', () => {
+      const log = new Logger({ isDev: true });
+      log.error('boom', new Error('details'));
+      expect(consoleErrorSpy).toHaveBeenCalledOnce();
+      expect(consoleErrorSpy.mock.calls[0][0]).toMatch(/\[ERROR\]/);
+    });
+  });
+
+  describe('PROD mode (info/warn silenced; error kept)', () => {
+    it('silences info', () => {
+      const log = new Logger({ isDev: false });
+      log.info('hidden');
+      expect(consoleInfoSpy).not.toHaveBeenCalled();
+    });
+
+    it('silences warn', () => {
+      const log = new Logger({ isDev: false });
+      log.warn('hidden');
+      expect(consoleWarnSpy).not.toHaveBeenCalled();
+    });
+
+    it('still logs error in PROD (visibility for production issues)', () => {
+      const log = new Logger({ isDev: false });
+      log.error('production failure');
+      expect(consoleErrorSpy).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('Ring buffer (recent errors)', () => {
+    it('stores up to bufferSize entries (default 20)', () => {
+      const log = new Logger({ isDev: false, bufferSize: 3 });
+      log.error('e1');
+      log.error('e2');
+      log.error('e3');
+      log.error('e4');
+      const recent = log.getRecentErrors();
+      expect(recent).toHaveLength(3);
+      expect(recent[0].message).toBe('e2');
+      expect(recent[2].message).toBe('e4');
+    });
+
+    it('captures timestamp + serializes Error stack', () => {
+      const log = new Logger({ isDev: false });
+      const err = new Error('with stack');
+      log.error('boom', err);
+      const recent = log.getRecentErrors();
+      expect(recent).toHaveLength(1);
+      expect(recent[0].message).toBe('boom');
+      expect(recent[0].timestamp).toBeTypeOf('number');
+      expect(recent[0].error).toContain('with stack');
+    });
+
+    it('clears buffer via clearRecentErrors()', () => {
+      const log = new Logger({ isDev: false });
+      log.error('e1');
+      log.clearRecentErrors();
+      expect(log.getRecentErrors()).toEqual([]);
+    });
+
+    it('does not buffer info / warn (only error)', () => {
+      const log = new Logger({ isDev: true });
+      log.info('a');
+      log.warn('b');
+      expect(log.getRecentErrors()).toEqual([]);
+    });
+  });
+
+  describe('Custom level threshold', () => {
+    it('with level=warn, info silenced but warn/error pass', () => {
+      const log = new Logger({ isDev: true, level: 'warn' });
+      log.info('hidden');
+      log.warn('shown');
+      log.error('shown');
+      expect(consoleInfoSpy).not.toHaveBeenCalled();
+      expect(consoleWarnSpy).toHaveBeenCalledOnce();
+      expect(consoleErrorSpy).toHaveBeenCalledOnce();
+    });
+  });
+});

--- a/quiz-app/src/utils/logger.ts
+++ b/quiz-app/src/utils/logger.ts
@@ -1,0 +1,122 @@
+// 前端 Logger
+//
+// 設計原則：
+// - DEV 模式（vite dev / vitest）：所有 level 都寫到 console
+// - PROD 模式（vite build）：info/warn 靜默；error 仍 console.error 並寫入 ring buffer
+// - 不送外部 service（避免 dep + 隱私問題）；如未來想加，hook getRecentErrors()
+//
+// Usage:
+//   import { logger } from '../utils/logger';
+//   logger.info('user clicked start');
+//   logger.error('quiz load failed', err);
+//
+//   // settings 頁可顯示最近錯誤：
+//   logger.getRecentErrors();
+
+export type LogLevel = 'info' | 'warn' | 'error';
+
+export interface LogEntry {
+  level: LogLevel;
+  message: string;
+  /** 序列化後的 error（含 stack）— Error 物件不適合直接序列化到 localStorage */
+  error?: string;
+  context?: Record<string, unknown>;
+  timestamp: number;
+}
+
+interface LoggerOptions {
+  /** 預設讀 import.meta.env.DEV；test 可注入 */
+  isDev?: boolean;
+  /** Ring buffer 大小，預設 20 */
+  bufferSize?: number;
+  /** 最低 log level，預設 isDev ? 'info' : 'error' */
+  level?: LogLevel;
+}
+
+const LEVEL_RANK: Record<LogLevel, number> = { info: 0, warn: 1, error: 2 };
+
+function serializeError(err: unknown): string | undefined {
+  if (err === undefined || err === null) return undefined;
+  if (err instanceof Error) {
+    return err.stack ?? `${err.name}: ${err.message}`;
+  }
+  if (typeof err === 'string') return err;
+  try {
+    return JSON.stringify(err);
+  } catch {
+    return String(err);
+  }
+}
+
+export class Logger {
+  private readonly isDev: boolean;
+  private readonly bufferSize: number;
+  private readonly minLevel: LogLevel;
+  private buffer: LogEntry[] = [];
+
+  constructor(opts: LoggerOptions = {}) {
+    // 在 vitest 環境也視為 dev — 預設讀 import.meta.env.DEV，但 vitest 把它設成 false
+    this.isDev = opts.isDev ?? Boolean(import.meta.env?.DEV);
+    this.bufferSize = opts.bufferSize ?? 20;
+    this.minLevel = opts.level ?? (this.isDev ? 'info' : 'error');
+  }
+
+  private shouldLog(level: LogLevel): boolean {
+    return LEVEL_RANK[level] >= LEVEL_RANK[this.minLevel];
+  }
+
+  private format(level: LogLevel, message: string): string {
+    return `[${level.toUpperCase()}] ${message}`;
+  }
+
+  info(message: string, context?: Record<string, unknown>): void {
+    if (!this.shouldLog('info')) return;
+    if (context !== undefined) {
+      console.info(this.format('info', message), context);
+    } else {
+      console.info(this.format('info', message));
+    }
+  }
+
+  warn(message: string, context?: Record<string, unknown>): void {
+    if (!this.shouldLog('warn')) return;
+    if (context !== undefined) {
+      console.warn(this.format('warn', message), context);
+    } else {
+      console.warn(this.format('warn', message));
+    }
+  }
+
+  error(message: string, err?: unknown, context?: Record<string, unknown>): void {
+    // error 必寫 buffer 不論 level（讓 production 也能事後查 in-app debug）
+    const entry: LogEntry = {
+      level: 'error',
+      message,
+      error: serializeError(err),
+      context,
+      timestamp: Date.now(),
+    };
+    this.buffer.push(entry);
+    if (this.buffer.length > this.bufferSize) {
+      this.buffer.splice(0, this.buffer.length - this.bufferSize);
+    }
+
+    if (!this.shouldLog('error')) return;
+    const args: unknown[] = [this.format('error', message)];
+    if (err !== undefined) args.push(err);
+    if (context !== undefined) args.push(context);
+    console.error(...args);
+  }
+
+  /** 取最近 buffer 內錯誤（依時序）— 給 in-app debug section 用 */
+  getRecentErrors(): readonly LogEntry[] {
+    return [...this.buffer];
+  }
+
+  clearRecentErrors(): void {
+    this.buffer = [];
+  }
+}
+
+// 全域單例 — App 各處 import 此實例
+export const logger = new Logger();


### PR DESCRIPTION
Replaces #39 (auto-closed after #41 squash-merged its base branch).

Same content as #39, rebased onto new main. See #39 for original review thread.

## Tests
- 21 logger cases (DEV/PROD level、ring buffer、Error 序列化邊界、context arg)
- 6 ErrorBoundary cases (catch + fallback + retry + logger 注入)
- 8 App tests (含 ErrorBoundary passthrough)