### PR TITLE
feat(practice-pool): tier1+2+3 — histogram + banner + breakdown 直觀化 (replaces #40)

### DIFF
--- a/quiz-app/src/components/PracticePoolHistogram/PracticePoolHistogram.css
+++ b/quiz-app/src/components/PracticePoolHistogram/PracticePoolHistogram.css
@@ -1,0 +1,93 @@
+/* 加強練習池抽題分佈條形 */
+.pool-histogram {
+  margin-top: var(--spacing-md);
+  padding: var(--spacing-md);
+  background: var(--color-surface);
+  border: 1px dashed var(--color-border);
+  border-radius: var(--radius-sm);
+  font-size: var(--font-size-sm);
+}
+
+.pool-histogram__title {
+  font-size: var(--font-size-xs);
+  color: var(--color-text-secondary);
+  margin: 0 0 var(--spacing-sm);
+  font-weight: 500;
+  letter-spacing: 0.04em;
+}
+
+.pool-histogram__rows {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+}
+
+.pool-histogram__row {
+  display: grid;
+  grid-template-columns: 5em 3em 1fr 3em;
+  gap: var(--spacing-sm);
+  align-items: center;
+}
+
+.pool-histogram__label {
+  color: var(--color-text-primary);
+  font-variation-settings: 'wght' 540;
+}
+
+.pool-histogram__count {
+  font-weight: 600;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+.pool-histogram__bar-track {
+  height: 8px;
+  background: var(--color-surface-variant);
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.pool-histogram__bar {
+  height: 100%;
+  border-radius: 4px;
+  transition: width 200ms ease;
+}
+
+.pool-histogram__row--main .pool-histogram__bar { background: var(--color-success); }
+.pool-histogram__row--mock .pool-histogram__bar { background: var(--color-info); }
+.pool-histogram__row--ai .pool-histogram__bar { background: var(--color-warning); }
+
+.pool-histogram__pct {
+  font-size: var(--font-size-xs);
+  color: var(--color-text-quiet);
+  font-variant-numeric: tabular-nums;
+  text-align: right;
+}
+
+.pool-histogram__total {
+  margin: var(--spacing-sm) 0 0;
+  font-size: var(--font-size-xs);
+  color: var(--color-text-secondary);
+  text-align: center;
+}
+
+/* Mobile (≤640px) — 改 2 行布局：label/count 一行、bar/pct 一行 */
+@media (max-width: 640px) {
+  .pool-histogram {
+    padding: var(--spacing-sm);
+  }
+  .pool-histogram__row {
+    grid-template-columns: 1fr auto;
+    grid-template-areas:
+      'label count'
+      'bar   pct';
+    row-gap: 4px;
+  }
+  .pool-histogram__label { grid-area: label; }
+  .pool-histogram__count { grid-area: count; }
+  .pool-histogram__bar-track { grid-area: bar; }
+  .pool-histogram__pct { grid-area: pct; min-width: 3em; }
+}

--- a/quiz-app/src/components/PracticePoolHistogram/PracticePoolHistogram.test.tsx
+++ b/quiz-app/src/components/PracticePoolHistogram/PracticePoolHistogram.test.tsx
@@ -1,0 +1,56 @@
+// PracticePoolHistogram 測試
+import { afterEach, describe, expect, it } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import { PracticePoolHistogram } from './PracticePoolHistogram';
+
+afterEach(cleanup);
+
+describe('PracticePoolHistogram', () => {
+  it('renders 3 rows: 主題庫 / 模擬題 / AI 產題', () => {
+    render(<PracticePoolHistogram mainBankCount={340} subject="考科1" />);
+    expect(screen.getByText('主題庫')).toBeInTheDocument();
+    expect(screen.getByText('模擬題')).toBeInTheDocument();
+    expect(screen.getByText('AI 產題')).toBeInTheDocument();
+  });
+
+  it('shows mainBankCount + pool counts (考科1: 340 + 0 mock + 41 AI)', () => {
+    const { container } = render(
+      <PracticePoolHistogram mainBankCount={340} subject="考科1" />,
+    );
+    const counts = container.querySelectorAll('.pool-histogram__count');
+    expect(counts[0].textContent).toBe('340'); // 主題庫
+    expect(counts[1].textContent).toBe('0');   // 模擬題（考科1 沒 external_mock）
+    expect(counts[2].textContent).toBe('41');  // AI 產題
+  });
+
+  it('shows all subject totals (648 + 55 + 96)', () => {
+    const { container } = render(
+      <PracticePoolHistogram mainBankCount={648} subject="all" />,
+    );
+    const counts = container.querySelectorAll('.pool-histogram__count');
+    expect(counts[0].textContent).toBe('648');
+    expect(counts[1].textContent).toBe('55');
+    expect(counts[2].textContent).toBe('96');
+  });
+
+  it('shows total 題 sum at bottom', () => {
+    const { container } = render(<PracticePoolHistogram mainBankCount={340} subject="考科1" />);
+    // 總計 380 + 41 = 381（broken across <strong> 元素，用 textContent normalize 比對）
+    const total = container.querySelector('.pool-histogram__total');
+    expect(total?.textContent).toMatch(/共\s*381\s*題/);
+  });
+
+  it('handles 0 mainBank gracefully (no NaN%)', () => {
+    render(<PracticePoolHistogram mainBankCount={0} subject="考科2" />);
+    // total = 0 + 0 + 24 = 24，% 應該都是有效數字
+    const pctTexts = screen.getAllByText(/\d+%/);
+    pctTexts.forEach((el) => {
+      expect(el.textContent).toMatch(/^\d+%$/);
+    });
+  });
+
+  it('test-id attribute for outer container', () => {
+    render(<PracticePoolHistogram mainBankCount={340} subject="考科1" />);
+    expect(screen.getByTestId('pool-histogram')).toBeInTheDocument();
+  });
+});

--- a/quiz-app/src/components/PracticePoolHistogram/PracticePoolHistogram.tsx
+++ b/quiz-app/src/components/PracticePoolHistogram/PracticePoolHistogram.tsx
@@ -1,0 +1,63 @@
+// 加強練習池抽題分佈預覽
+// 啟用後讓使用者看到「下一場測驗的抽題範圍」實際組成（主題庫 + 模擬 + AI 產題）
+import { POOL_BY_SUBJECT } from '../../data/practice-pool-counts';
+import type { ExamSubject } from '../../types/quiz';
+import './PracticePoolHistogram.css';
+
+interface PracticePoolHistogramProps {
+  /** 主題庫題數（已套用 subject filter） */
+  mainBankCount: number;
+  /** 使用者選的科目 */
+  subject: ExamSubject | 'all';
+}
+
+interface Row {
+  label: string;
+  count: number;
+  cls: string;
+}
+
+export function PracticePoolHistogram({
+  mainBankCount,
+  subject,
+}: PracticePoolHistogramProps): JSX.Element {
+  const poolCounts = POOL_BY_SUBJECT[subject];
+  const rows: Row[] = [
+    { label: '主題庫', count: mainBankCount, cls: 'main' },
+    { label: '模擬題', count: poolCounts.externalMock, cls: 'mock' },
+    { label: 'AI 產題', count: poolCounts.aiGenerated, cls: 'ai' },
+  ];
+  const total = rows.reduce((s, r) => s + r.count, 0);
+  const maxCount = Math.max(...rows.map((r) => r.count), 1);
+
+  return (
+    <div className="pool-histogram" data-testid="pool-histogram">
+      <p className="pool-histogram__title">
+        本次抽題範圍（已套用考科 filter）
+      </p>
+      <ul className="pool-histogram__rows">
+        {rows.map((r) => {
+          const pct = total > 0 ? Math.round((r.count / total) * 100) : 0;
+          return (
+            <li key={r.label} className={`pool-histogram__row pool-histogram__row--${r.cls}`}>
+              <span className="pool-histogram__label">{r.label}</span>
+              <span className="pool-histogram__count">{r.count}</span>
+              <div className="pool-histogram__bar-track" aria-hidden="true">
+                <div
+                  className="pool-histogram__bar"
+                  style={{ width: `${(r.count / maxCount) * 100}%` }}
+                />
+              </div>
+              <span className="pool-histogram__pct">{pct}%</span>
+            </li>
+          );
+        })}
+      </ul>
+      <p className="pool-histogram__total">
+        共 <strong>{total}</strong> 題池中抽出本場測驗
+      </p>
+    </div>
+  );
+}
+
+export default PracticePoolHistogram;

--- a/quiz-app/src/components/QuestionCard/QuestionCard.tsx
+++ b/quiz-app/src/components/QuestionCard/QuestionCard.tsx
@@ -3,6 +3,7 @@ import { useCallback, useId, useMemo, useState } from 'react';
 import type { QuizQuestion, QuizOption } from '../../types/quiz';
 import { explainQuestion, type AIResponse } from '../../utils/ai-helper';
 import { SourceBadge } from '../SourceBadge/SourceBadge';
+import { SourceBanner } from '../SourceBanner/SourceBanner';
 import { LAW_PCODE_LABELS } from '../../data/law-pcode-labels';
 import './QuestionCard.css';
 
@@ -135,6 +136,15 @@ export function QuestionCard({
           />
         )}
       </header>
+
+      {/* 練習池來源 banner — 主題庫題不顯示 */}
+      {question.provenance && (
+        <SourceBanner
+          sourceType={question.provenance.source_type}
+          qualityFlags={question.qualityFlags ?? []}
+          sourceCount={question.sources?.length ?? 0}
+        />
+      )}
 
       {/* 題幹 */}
       <div className="question-stem" id={labelId}>

--- a/quiz-app/src/components/SourceBanner/SourceBanner.css
+++ b/quiz-app/src/components/SourceBanner/SourceBanner.css
@@ -1,0 +1,101 @@
+/* 練習池題目來源 banner — 顯眼但不打斷閱讀 */
+.source-banner {
+  display: flex;
+  gap: var(--spacing-sm);
+  padding: var(--spacing-sm) var(--spacing-md);
+  margin-bottom: var(--spacing-md);
+  border-radius: var(--radius-sm);
+  border-left: 4px solid;
+  align-items: flex-start;
+}
+
+.source-banner--mock {
+  background: var(--color-info-bg);
+  border-left-color: var(--color-info);
+  color: var(--color-text-primary);
+}
+
+.source-banner--ai {
+  background: var(--color-warning-bg);
+  border-left-color: var(--color-warning);
+  color: var(--color-text-primary);
+}
+
+.source-banner--flagged {
+  border-left-color: var(--color-error);
+  background: var(--color-error-bg);
+}
+
+.source-banner__icon {
+  font-size: 22px;
+  flex-shrink: 0;
+  margin-top: 2px;
+}
+
+.source-banner--mock .source-banner__icon { color: var(--color-info); }
+.source-banner--ai .source-banner__icon { color: var(--color-warning); }
+.source-banner--flagged .source-banner__icon { color: var(--color-error); }
+
+.source-banner__body {
+  flex: 1;
+  min-width: 0;
+}
+
+.source-banner__label {
+  font-weight: 600;
+  font-size: var(--font-size-sm);
+  display: block;
+  line-height: 1.4;
+}
+
+.source-banner__hint {
+  font-size: var(--font-size-xs);
+  color: var(--color-text-secondary);
+  line-height: 1.55;
+  margin: var(--spacing-xs) 0 0;
+}
+
+.source-banner__sources {
+  color: var(--color-text-quiet);
+}
+
+.source-banner__flags {
+  list-style: none;
+  margin: var(--spacing-sm) 0 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+}
+
+.source-banner__flag {
+  display: flex;
+  gap: var(--spacing-xs);
+  font-size: var(--font-size-xs);
+  color: var(--color-error);
+  align-items: flex-start;
+  line-height: 1.55;
+}
+
+.source-banner__flag .material-icons.sm {
+  font-size: 16px;
+  flex-shrink: 0;
+  margin-top: 1px;
+}
+
+@media (max-width: 640px) {
+  .source-banner {
+    padding: var(--spacing-sm);
+    gap: var(--spacing-xs);
+  }
+  .source-banner__icon {
+    font-size: 20px;
+  }
+  .source-banner__label {
+    font-size: var(--font-size-xs);
+  }
+  .source-banner__hint {
+    font-size: 0.78rem;
+    line-height: 1.5;
+  }
+}

--- a/quiz-app/src/components/SourceBanner/SourceBanner.test.tsx
+++ b/quiz-app/src/components/SourceBanner/SourceBanner.test.tsx
@@ -1,0 +1,68 @@
+// SourceBanner 測試
+import { afterEach, describe, expect, it } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import { SourceBanner } from './SourceBanner';
+
+afterEach(cleanup);
+
+describe('SourceBanner', () => {
+  it('external_mock — 顯示「模擬題」標籤 + 出處 hint', () => {
+    render(<SourceBanner sourceType="external_mock" />);
+    const banner = screen.getByTestId('source-banner');
+    expect(banner.className).toMatch(/source-banner--mock/);
+    expect(banner.textContent).toContain('模擬題');
+    expect(banner.textContent).toMatch(/vocus|HackMD|yamol/);
+  });
+
+  it('ai_generated — 顯示「AI 產題」標籤 + 驗證提醒', () => {
+    render(<SourceBanner sourceType="ai_generated" />);
+    const banner = screen.getByTestId('source-banner');
+    expect(banner.className).toMatch(/source-banner--ai/);
+    expect(banner.textContent).toContain('AI 產題');
+    expect(banner.textContent).toMatch(/cross-check|驗證|官方教材/);
+  });
+
+  it('quality_flag = time_sensitive — 顯示時效警告 + flagged 樣式', () => {
+    render(
+      <SourceBanner sourceType="ai_generated" qualityFlags={['time_sensitive']} />,
+    );
+    const banner = screen.getByTestId('source-banner');
+    expect(banner.className).toMatch(/source-banner--flagged/);
+    expect(banner.textContent).toMatch(/時效性|RE100|官方資料/);
+  });
+
+  it('quality_flag = ambiguous — 顯示爭議警告', () => {
+    render(<SourceBanner sourceType="ai_generated" qualityFlags={['ambiguous']} />);
+    const banner = screen.getByTestId('source-banner');
+    expect(banner.textContent).toMatch(/爭議|多方來源/);
+  });
+
+  it('sourceCount > 0 — 文案附上「N 條 primary-source URL」', () => {
+    render(<SourceBanner sourceType="ai_generated" sourceCount={3} />);
+    const banner = screen.getByTestId('source-banner');
+    expect(banner.textContent).toMatch(/3 條 primary-source/);
+  });
+
+  it('sourceCount = 0 不顯示 URL 文案', () => {
+    render(<SourceBanner sourceType="ai_generated" />);
+    const banner = screen.getByTestId('source-banner');
+    expect(banner.textContent).not.toMatch(/primary-source URL/);
+  });
+
+  it('a11y: role="note" + aria-label 描述題目來源', () => {
+    render(<SourceBanner sourceType="external_mock" />);
+    const banner = screen.getByRole('note');
+    expect(banner.getAttribute('aria-label')).toMatch(/模擬題/);
+  });
+
+  it('multiple quality flags 全部顯示', () => {
+    render(
+      <SourceBanner
+        sourceType="ai_generated"
+        qualityFlags={['time_sensitive', 'low_confidence']}
+      />,
+    );
+    const flags = screen.getByTestId('source-banner').querySelectorAll('.source-banner__flag');
+    expect(flags.length).toBe(2);
+  });
+});

--- a/quiz-app/src/components/SourceBanner/SourceBanner.tsx
+++ b/quiz-app/src/components/SourceBanner/SourceBanner.tsx
@@ -1,0 +1,87 @@
+// SourceBanner — 練習池題目的「閱讀題目前」整合式來源說明 + 信任提示
+// 比 SourceBadge chip 更顯眼，目的是讓使用者在作答前對題目來源有明確認知。
+//
+// 顯示策略：
+// - 主題庫題（無 provenance）：不顯示
+// - external_mock：藍底，提示「非官方模擬題」
+// - ai_generated：黃底，提示「AI 產題已驗證；以官方教材為最終依據」
+// - 帶 quality_flag：紅邊警示
+import type { PracticePoolSourceType, PracticePoolQualityFlag } from '../../types/practicePool';
+import './SourceBanner.css';
+
+interface SourceBannerProps {
+  sourceType: PracticePoolSourceType;
+  qualityFlags?: PracticePoolQualityFlag[];
+  /** primary-source URL 數量，0 不顯示 */
+  sourceCount?: number;
+}
+
+const SOURCE_META: Record<
+  PracticePoolSourceType,
+  { tone: string; icon: string; label: string; hint: string }
+> = {
+  external_mock: {
+    tone: 'mock',
+    icon: 'menu_book',
+    label: '模擬題',
+    hint: '取自 vocus / HackMD / yamol 等公開模擬題；非官方歷屆試題（iPAS 不公開歷屆）。',
+  },
+  ai_generated: {
+    tone: 'ai',
+    icon: 'auto_awesome',
+    label: 'AI 產題',
+    hint: '由 LLM 依環境部 / CBAM / ISO 等法規產生，並經獨立驗證代理 cross-check 通過。請以官方教材為最終依據。',
+  },
+};
+
+const FLAG_HINT: Partial<Record<PracticePoolQualityFlag, string>> = {
+  time_sensitive: '時效性 — 答案會隨時間變動（如 RE100 名單），建議查最新官方資料',
+  ambiguous: '爭議 — 不同教材可能給出不同答案，請參考多方來源',
+  low_confidence: '低信心 — 自動驗證信心較低，建議多方核對',
+};
+
+export function SourceBanner({
+  sourceType,
+  qualityFlags = [],
+  sourceCount = 0,
+}: SourceBannerProps): JSX.Element {
+  const meta = SOURCE_META[sourceType];
+  const flagsToShow = qualityFlags.filter((f): f is keyof typeof FLAG_HINT => f in FLAG_HINT);
+  const hasFlag = flagsToShow.length > 0;
+
+  return (
+    <aside
+      className={`source-banner source-banner--${meta.tone} ${hasFlag ? 'source-banner--flagged' : ''}`}
+      data-testid="source-banner"
+      role="note"
+      aria-label={`本題為${meta.label}`}
+    >
+      <span className="material-icons source-banner__icon" aria-hidden="true">
+        {meta.icon}
+      </span>
+      <div className="source-banner__body">
+        <span className="source-banner__label">本題為「{meta.label}」</span>
+        <p className="source-banner__hint">
+          {meta.hint}
+          {sourceCount > 0 && (
+            <span className="source-banner__sources">
+              （附 {sourceCount} 條 primary-source URL，見下方參考來源）
+            </span>
+          )}
+        </p>
+        {hasFlag && (
+          <ul className="source-banner__flags">
+            {flagsToShow.map((f) => (
+              <li key={f} className={`source-banner__flag source-banner__flag--${f}`}>
+                <span className="material-icons sm" aria-hidden="true">warning</span>
+                <span>{FLAG_HINT[f]}</span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </aside>
+  );
+}
+
+export default SourceBanner;

--- a/quiz-app/src/components/SourceBreakdown/SourceBreakdown.css
+++ b/quiz-app/src/components/SourceBreakdown/SourceBreakdown.css
@@ -1,0 +1,104 @@
+/* ResultPage 按題目來源的正確率分組 */
+.source-breakdown {
+  margin: var(--spacing-lg) 0;
+  padding: var(--spacing-md);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+}
+
+.source-breakdown__title {
+  font-size: var(--font-size-base);
+  font-weight: 600;
+  margin: 0 0 var(--spacing-sm);
+  color: var(--color-text-primary);
+}
+
+.source-breakdown__rows {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+}
+
+.source-breakdown__row {
+  display: grid;
+  grid-template-columns: 6em 5em 1fr 4em auto;
+  gap: var(--spacing-sm);
+  align-items: center;
+  font-size: var(--font-size-sm);
+}
+
+.source-breakdown__label {
+  font-variation-settings: 'wght' 540;
+  color: var(--color-text-primary);
+}
+
+.source-breakdown__count {
+  font-variant-numeric: tabular-nums;
+  color: var(--color-text-secondary);
+  text-align: right;
+}
+
+.source-breakdown__bar-track {
+  height: 10px;
+  background: var(--color-surface-variant);
+  border-radius: 5px;
+  overflow: hidden;
+}
+
+.source-breakdown__bar {
+  height: 100%;
+  border-radius: 5px;
+  transition: width 220ms ease;
+}
+
+.source-breakdown__row--main .source-breakdown__bar { background: var(--color-success); }
+.source-breakdown__row--mock .source-breakdown__bar { background: var(--color-info); }
+.source-breakdown__row--ai .source-breakdown__bar { background: var(--color-warning); }
+.source-breakdown__row--low .source-breakdown__bar { background: var(--color-error); }
+
+.source-breakdown__pct {
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+  text-align: right;
+  color: var(--color-text-primary);
+}
+
+.source-breakdown__note {
+  font-size: var(--font-size-xs);
+  color: var(--color-error);
+}
+
+.source-breakdown__hint {
+  font-size: var(--font-size-xs);
+  color: var(--color-text-secondary);
+  line-height: 1.55;
+  margin: var(--spacing-md) 0 0;
+  padding-top: var(--spacing-sm);
+  border-top: 1px dashed var(--color-border);
+}
+
+@media (max-width: 640px) {
+  .source-breakdown {
+    padding: var(--spacing-sm);
+  }
+  .source-breakdown__row {
+    grid-template-columns: 1fr auto;
+    grid-template-areas:
+      'label count'
+      'bar pct'
+      'note note';
+    row-gap: 4px;
+  }
+  .source-breakdown__label { grid-area: label; }
+  .source-breakdown__count { grid-area: count; text-align: right; }
+  .source-breakdown__bar-track { grid-area: bar; height: 8px; }
+  .source-breakdown__pct { grid-area: pct; min-width: 3em; }
+  .source-breakdown__note { grid-area: note; font-size: 0.7rem; }
+  .source-breakdown__title {
+    font-size: var(--font-size-sm);
+  }
+}

--- a/quiz-app/src/components/SourceBreakdown/SourceBreakdown.test.tsx
+++ b/quiz-app/src/components/SourceBreakdown/SourceBreakdown.test.tsx
@@ -1,0 +1,136 @@
+// SourceBreakdown 測試
+import { afterEach, describe, expect, it } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import { SourceBreakdown, computeBreakdown } from './SourceBreakdown';
+import type { AnswerRecord } from '../../types/quiz';
+
+afterEach(cleanup);
+
+function ans(
+  isCorrect: boolean,
+  cat?: AnswerRecord['sourceCategory'],
+): AnswerRecord {
+  return {
+    questionId: Math.random().toString(),
+    selectedAnswer: 'A',
+    correctAnswer: isCorrect ? 'A' : 'B',
+    isCorrect,
+    timeSpent: 1000,
+    timestamp: Date.now(),
+    sourceCategory: cat,
+  };
+}
+
+describe('computeBreakdown', () => {
+  it('groups by sourceCategory + counts correct/total', () => {
+    const groups = computeBreakdown([
+      ans(true, 'main_bank'),
+      ans(true, 'main_bank'),
+      ans(false, 'main_bank'),
+      ans(true, 'external_mock'),
+      ans(false, 'ai_generated'),
+      ans(false, 'ai_generated'),
+    ]);
+    const main = groups.find((g) => g.key === 'main_bank');
+    expect(main?.total).toBe(3);
+    expect(main?.correct).toBe(2);
+    const ai = groups.find((g) => g.key === 'ai_generated');
+    expect(ai?.total).toBe(2);
+    expect(ai?.correct).toBe(0);
+  });
+
+  it('skips empty groups', () => {
+    const groups = computeBreakdown([ans(true, 'main_bank')]);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].key).toBe('main_bank');
+  });
+
+  it('skips answers with isCorrect=null (skipped questions)', () => {
+    const skipped: AnswerRecord = {
+      ...ans(false, 'main_bank'),
+      isCorrect: null,
+    };
+    const groups = computeBreakdown([ans(true, 'main_bank'), skipped]);
+    expect(groups[0].total).toBe(1);
+  });
+
+  it('defaults missing sourceCategory to main_bank', () => {
+    const noCategoryAns: AnswerRecord = {
+      questionId: 'x',
+      selectedAnswer: 'A',
+      correctAnswer: 'A',
+      isCorrect: true,
+      timeSpent: 100,
+      timestamp: 0,
+      // no sourceCategory
+    };
+    const groups = computeBreakdown([noCategoryAns]);
+    expect(groups[0].key).toBe('main_bank');
+  });
+});
+
+describe('SourceBreakdown', () => {
+  it('renders section when ≥2 source groups', () => {
+    render(
+      <SourceBreakdown
+        answers={[ans(true, 'main_bank'), ans(true, 'ai_generated')]}
+      />,
+    );
+    expect(screen.getByText('分項正確率')).toBeInTheDocument();
+    expect(screen.getByText('主題庫')).toBeInTheDocument();
+    expect(screen.getByText('AI 產題')).toBeInTheDocument();
+  });
+
+  it('renders nothing when only 1 source group', () => {
+    const { container } = render(
+      <SourceBreakdown answers={[ans(true, 'main_bank')]} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders nothing when no answers', () => {
+    const { container } = render(<SourceBreakdown answers={[]} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('flags low accuracy (<60%) on pool groups', () => {
+    const { container } = render(
+      <SourceBreakdown
+        answers={[
+          // main_bank 100%
+          ans(true, 'main_bank'),
+          ans(true, 'main_bank'),
+          // ai_generated 50% (1/2) → flagged low
+          ans(true, 'ai_generated'),
+          ans(false, 'ai_generated'),
+        ]}
+      />,
+    );
+    expect(container.querySelector('.source-breakdown__row--low')).toBeTruthy();
+    expect(screen.getByText(/⚠ 偏低/)).toBeInTheDocument();
+  });
+
+  it('does NOT flag main_bank low accuracy (no special warning for main)', () => {
+    const { container } = render(
+      <SourceBreakdown
+        answers={[
+          ans(false, 'main_bank'),
+          ans(false, 'main_bank'),
+          ans(true, 'external_mock'),
+        ]}
+      />,
+    );
+    // main 0% but no --low class on main row
+    const mainRow = container.querySelector('.source-breakdown__row--main');
+    expect(mainRow?.className).not.toMatch(/source-breakdown__row--low/);
+  });
+
+  it('shows learning hint when main_bank present', () => {
+    render(
+      <SourceBreakdown
+        answers={[ans(true, 'main_bank'), ans(true, 'ai_generated')]}
+      />,
+    );
+    expect(screen.getByText(/真實 iPAS 模擬考水準/)).toBeInTheDocument();
+  });
+});

--- a/quiz-app/src/components/SourceBreakdown/SourceBreakdown.tsx
+++ b/quiz-app/src/components/SourceBreakdown/SourceBreakdown.tsx
@@ -1,0 +1,93 @@
+// SourceBreakdown — ResultPage 顯示「按題目來源分組的正確率」
+// 讓使用者識別「我的主題庫真實水準」 vs 池題練習表現
+import type { AnswerRecord } from '../../types/quiz';
+import './SourceBreakdown.css';
+
+interface SourceBreakdownProps {
+  answers: AnswerRecord[];
+}
+
+interface Group {
+  key: 'main_bank' | 'external_mock' | 'ai_generated';
+  label: string;
+  cls: string;
+  total: number;
+  correct: number;
+}
+
+export function computeBreakdown(answers: AnswerRecord[]): Group[] {
+  const groups: Record<string, { total: number; correct: number }> = {
+    main_bank: { total: 0, correct: 0 },
+    external_mock: { total: 0, correct: 0 },
+    ai_generated: { total: 0, correct: 0 },
+  };
+
+  for (const a of answers) {
+    if (a.isCorrect === null) continue; // 跳過無答案題（exam mode skip）
+    const cat = a.sourceCategory ?? 'main_bank';
+    if (!groups[cat]) continue;
+    groups[cat].total += 1;
+    if (a.isCorrect) groups[cat].correct += 1;
+  }
+
+  const meta: Group[] = [
+    { key: 'main_bank', label: '主題庫', cls: 'main', total: 0, correct: 0 },
+    { key: 'external_mock', label: '模擬題', cls: 'mock', total: 0, correct: 0 },
+    { key: 'ai_generated', label: 'AI 產題', cls: 'ai', total: 0, correct: 0 },
+  ];
+
+  return meta
+    .map((m) => ({ ...m, total: groups[m.key].total, correct: groups[m.key].correct }))
+    .filter((m) => m.total > 0);
+}
+
+export function SourceBreakdown({ answers }: SourceBreakdownProps): JSX.Element | null {
+  const groups = computeBreakdown(answers);
+
+  // 只有「主題庫」一組（沒啟用練習池或練習池沒抽到）→ 不顯示（避免冗餘）
+  if (groups.length <= 1) return null;
+
+  return (
+    <section className="source-breakdown" aria-label="按題目來源的正確率">
+      <h3 className="source-breakdown__title">分項正確率</h3>
+      <ul className="source-breakdown__rows">
+        {groups.map((g) => {
+          const pct = g.total > 0 ? Math.round((g.correct / g.total) * 100) : 0;
+          const lowAccuracy = pct < 60 && g.key !== 'main_bank';
+          return (
+            <li
+              key={g.key}
+              className={`source-breakdown__row source-breakdown__row--${g.cls}${
+                lowAccuracy ? ' source-breakdown__row--low' : ''
+              }`}
+            >
+              <span className="source-breakdown__label">{g.label}</span>
+              <span className="source-breakdown__count">
+                <strong>{g.correct}</strong> / {g.total}
+              </span>
+              <div className="source-breakdown__bar-track" aria-hidden="true">
+                <div
+                  className="source-breakdown__bar"
+                  style={{ width: `${pct}%` }}
+                />
+              </div>
+              <span className="source-breakdown__pct">{pct}%</span>
+              {lowAccuracy && (
+                <span className="source-breakdown__note" aria-label="正確率偏低提示">
+                  ⚠ 偏低
+                </span>
+              )}
+            </li>
+          );
+        })}
+      </ul>
+      {groups.some((g) => g.key === 'main_bank') && (
+        <p className="source-breakdown__hint">
+          ➜ 主題庫正確率代表你的真實 iPAS 模擬考水準；模擬 / AI 產題僅作補充練習。
+        </p>
+      )}
+    </section>
+  );
+}
+
+export default SourceBreakdown;

--- a/quiz-app/src/data/practice-pool-counts.test.ts
+++ b/quiz-app/src/data/practice-pool-counts.test.ts
@@ -1,7 +1,7 @@
-// 驗證 PRACTICE_POOL_COUNTS 跟 practice_pool.json _meta.totals 一致
+// 驗證 PRACTICE_POOL_COUNTS / POOL_BY_SUBJECT 跟 practice_pool.json 一致
 // 防止常數漂移 — 任何一邊改了，CI 會擋下
 import { describe, it, expect } from 'vitest';
-import { PRACTICE_POOL_COUNTS } from './practice-pool-counts';
+import { PRACTICE_POOL_COUNTS, POOL_BY_SUBJECT } from './practice-pool-counts';
 import practicePool from './practice_pool.json';
 
 interface PoolMeta {
@@ -12,17 +12,74 @@ interface PoolMeta {
   };
 }
 
+interface PoolItem {
+  subject?: string;
+  provenance: { source_type: 'external_mock' | 'ai_generated' };
+  quality_flags?: string[];
+}
+
+interface Pool {
+  _meta: PoolMeta;
+  items: PoolItem[];
+}
+
+const pool = practicePool as Pool;
+
 describe('PRACTICE_POOL_COUNTS', () => {
   it('matches practice_pool.json _meta.totals', () => {
-    const meta = (practicePool as { _meta: PoolMeta })._meta;
-    expect(PRACTICE_POOL_COUNTS.externalMock).toBe(meta.totals.external_mock);
-    expect(PRACTICE_POOL_COUNTS.aiGenerated).toBe(meta.totals.ai_generated);
-    expect(PRACTICE_POOL_COUNTS.total).toBe(meta.totals.total);
+    expect(PRACTICE_POOL_COUNTS.externalMock).toBe(pool._meta.totals.external_mock);
+    expect(PRACTICE_POOL_COUNTS.aiGenerated).toBe(pool._meta.totals.ai_generated);
+    expect(PRACTICE_POOL_COUNTS.total).toBe(pool._meta.totals.total);
   });
 
   it('total equals externalMock + aiGenerated', () => {
     expect(PRACTICE_POOL_COUNTS.total).toBe(
       PRACTICE_POOL_COUNTS.externalMock + PRACTICE_POOL_COUNTS.aiGenerated,
     );
+  });
+});
+
+describe('POOL_BY_SUBJECT', () => {
+  // 計算實際 pool 內每個 subject 的可抽題數
+  // 規則：subject filter '考科1' 排除 unmapped_subject flag 題目；'all' 包含
+  function actualBreakdown(filter: 'all' | '考科一' | '考科二'): {
+    externalMock: number;
+    aiGenerated: number;
+  } {
+    const filtered = pool.items.filter((q) => {
+      const flags = q.quality_flags ?? [];
+      const hasUnmapped = flags.includes('unmapped_subject');
+      if (filter === 'all') return true;
+      if (hasUnmapped) return false;
+      return q.subject?.startsWith(filter);
+    });
+    return {
+      externalMock: filtered.filter((q) => q.provenance.source_type === 'external_mock').length,
+      aiGenerated: filtered.filter((q) => q.provenance.source_type === 'ai_generated').length,
+    };
+  }
+
+  it('all matches PRACTICE_POOL_COUNTS', () => {
+    expect(POOL_BY_SUBJECT.all.total).toBe(PRACTICE_POOL_COUNTS.total);
+    expect(POOL_BY_SUBJECT.all.externalMock).toBe(PRACTICE_POOL_COUNTS.externalMock);
+    expect(POOL_BY_SUBJECT.all.aiGenerated).toBe(PRACTICE_POOL_COUNTS.aiGenerated);
+  });
+
+  it('考科1 matches actual filtered pool', () => {
+    const actual = actualBreakdown('考科一');
+    expect(POOL_BY_SUBJECT['考科1'].externalMock).toBe(actual.externalMock);
+    expect(POOL_BY_SUBJECT['考科1'].aiGenerated).toBe(actual.aiGenerated);
+  });
+
+  it('考科2 matches actual filtered pool', () => {
+    const actual = actualBreakdown('考科二');
+    expect(POOL_BY_SUBJECT['考科2'].externalMock).toBe(actual.externalMock);
+    expect(POOL_BY_SUBJECT['考科2'].aiGenerated).toBe(actual.aiGenerated);
+  });
+
+  it('each entry total = externalMock + aiGenerated', () => {
+    for (const [, entry] of Object.entries(POOL_BY_SUBJECT)) {
+      expect(entry.total).toBe(entry.externalMock + entry.aiGenerated);
+    }
   });
 });

--- a/quiz-app/src/data/practice-pool-counts.ts
+++ b/quiz-app/src/data/practice-pool-counts.ts
@@ -1,11 +1,30 @@
 // Practice pool 數量單一事實來源
 // UI 揭露文案禁止漂移到不同數字（EU AI Act Art.50 揭露對象需與實際 pool 一致）
 //
-// 來源：src/data/practice_pool.json `_meta.totals`（2026-04-25 版）
+// 來源：src/data/practice_pool.json `_meta.totals` + group-by subject
 // 若 practice_pool.json 內容變動需同步更新此處（dev 啟動的 schema validator
-// assert 內容形狀，但不 cross-check 此常數 — 所以人工同步）
+// assert 內容形狀，cross-check test 驗證此常數與 _meta.totals 一致）
 export const PRACTICE_POOL_COUNTS = {
   externalMock: 55,
   aiGenerated: 96,
   total: 151,
+} as const;
+
+/**
+ * Pool 題依 subject filter 後的可抽題數
+ *
+ * - `考科1` / `考科2`: 該考科 mapped 的題目（不含 `unmapped_subject` flag）
+ * - `all`: 全部 151 題（含 unmapped_subject）
+ *
+ * 來源計算（jq）：
+ *   group_by(subject + "|" + provenance.source_type)
+ *   - 考科一/ai_generated: 41
+ *   - 考科二/ai_generated: 24
+ *   - unknown/ai_generated: 31  (unmapped_subject flag — 只在 all 出現)
+ *   - unknown/external_mock: 55 (unmapped_subject flag — 只在 all 出現)
+ */
+export const POOL_BY_SUBJECT = {
+  '考科1': { externalMock: 0, aiGenerated: 41, total: 41 },
+  '考科2': { externalMock: 0, aiGenerated: 24, total: 24 },
+  all: { externalMock: 55, aiGenerated: 96, total: 151 },
 } as const;

--- a/quiz-app/src/hooks/useQuiz.ts
+++ b/quiz-app/src/hooks/useQuiz.ts
@@ -171,6 +171,11 @@ export function useQuiz() {
       const isCorrect =
         question.answer !== null ? selectedAnswer === question.answer : null;
 
+      const sourceCategory: AnswerRecord['sourceCategory'] =
+        question.sourceType === 'practice_pool'
+          ? question.provenance?.source_type ?? 'main_bank'
+          : 'main_bank';
+
       const record: AnswerRecord = {
         questionId: question.id,
         selectedAnswer,
@@ -178,6 +183,7 @@ export function useQuiz() {
         isCorrect,
         timeSpent,
         timestamp: Date.now(),
+        sourceCategory,
       };
 
       setState((prev) => ({

--- a/quiz-app/src/pages/HomePage.tsx
+++ b/quiz-app/src/pages/HomePage.tsx
@@ -5,9 +5,16 @@ import { PRACTICE_POOL_COUNTS } from '../data/practice-pool-counts';
 import { defaultConfig } from '../hooks/useQuiz';
 import { usePracticeMode } from '../hooks/usePracticeMode';
 import { PracticeOptInDialog } from '../components/PracticeOptInDialog/PracticeOptInDialog';
+import { PracticePoolHistogram } from '../components/PracticePoolHistogram/PracticePoolHistogram';
 import { readBool, writeBool } from '../utils/local-storage';
 import type { QuizConfig, ExamSubject } from '../types/quiz';
 import './HomePage.css';
+
+function mainBankCountForSubject(subject: ExamSubject | 'all'): number {
+  if (subject === '考科1') return stats.subject1;
+  if (subject === '考科2') return stats.subject2;
+  return stats.total;
+}
 
 // localStorage key：使用者是否曾看過揭露 dialog（accept/decline 都算看過）
 // 用來避免每次進首頁都自動彈 — 一次就夠
@@ -186,6 +193,12 @@ export function HomePage({ onStartQuiz }: HomePageProps) {
                 {title}
               </h3>
               <p className="practice-pool-tip__desc">{desc}</p>
+              {enabled && (
+                <PracticePoolHistogram
+                  mainBankCount={mainBankCountForSubject(config.subject)}
+                  subject={config.subject}
+                />
+              )}
               <button
                 type="button"
                 className={`btn ${enabled ? 'btn-secondary' : 'btn-primary'} practice-pool-tip__cta`}

--- a/quiz-app/src/pages/ResultPage.tsx
+++ b/quiz-app/src/pages/ResultPage.tsx
@@ -6,6 +6,7 @@ import {
   generateSimilarQuestionStream,
   type AIResponse,
 } from '../utils/ai-helper';
+import { SourceBreakdown } from '../components/SourceBreakdown/SourceBreakdown';
 import type { QuizResult, QuizQuestion } from '../types/quiz';
 import './ResultPage.css';
 
@@ -203,6 +204,9 @@ export function ResultPage({ result, onGoHome, onRetry }: ResultPageProps) {
           <span className="stat-label">用時</span>
         </div>
       </section>
+
+      {/* 按題目來源分組的正確率（僅啟用練習池且抽到池題時顯示） */}
+      <SourceBreakdown answers={answers} />
 
       {/* 錯題列表 */}
       {wrongAnswers.length > 0 && (

--- a/quiz-app/src/types/quiz.ts
+++ b/quiz-app/src/types/quiz.ts
@@ -130,6 +130,9 @@ export interface QuizConfig {
   showAnswerImmediately: boolean;
 }
 
+/** 答題來源分類 — ResultPage 用來分組統計，主題庫 vs 模擬 vs AI 產題 */
+export type AnswerSourceCategory = 'main_bank' | 'external_mock' | 'ai_generated';
+
 /** 答題紀錄 */
 export interface AnswerRecord {
   questionId: string;
@@ -138,6 +141,11 @@ export interface AnswerRecord {
   isCorrect: boolean | null;
   timeSpent: number;
   timestamp: number;
+  /**
+   * 題目來源分類（記錄當下從題目推導，避免 ResultPage 反查時找不到 pool 題目）
+   * 'main_bank' = 主題庫；'external_mock' / 'ai_generated' = 練習池
+   */
+  sourceCategory?: AnswerSourceCategory;
 }
 
 /** 測驗結果 */


### PR DESCRIPTION
Replaces #40 (auto-closed after #42 squash-merged its base branch).

Same content as #40, rebased onto new main. See #40 for original review thread.

## 3 Tiers
- **T1** HomePage tip card 抽題分佈 histogram (PracticePoolHistogram)
- **T2** QuestionCard 來源 banner (SourceBanner) — actionable hint 取代隱微 chip
- **T3** ResultPage 分項正確率 (SourceBreakdown) — 識別主題庫真實水準