### PR TITLE
feat(question-card): dim 選項中冗餘的共享前綴關鍵字

### DIFF
--- a/quiz-app/src/components/QuestionCard/QuestionCard.css
+++ b/quiz-app/src/components/QuestionCard/QuestionCard.css
@@ -386,3 +386,14 @@
     font-size: var(--font-size-xs);
   }
 }
+
+/* 冗餘前綴 dim 化 — 例如題幹說「GRI 準則」，所有選項又重複 "GRI" 前綴 */
+.option-text__redundant {
+  opacity: 0.45;
+  font-weight: 400;
+  margin-right: 0.05em;
+}
+.option-item.correct .option-text__redundant,
+.option-item.incorrect .option-text__redundant {
+  opacity: 0.6;
+}

--- a/quiz-app/src/components/QuestionCard/QuestionCard.test.tsx
+++ b/quiz-app/src/components/QuestionCard/QuestionCard.test.tsx
@@ -218,3 +218,49 @@ describe('QuestionCard 元件', () => {
     });
   });
 });
+
+describe('QuestionCard 冗餘前綴 dim 化', () => {
+  it('當所有選項共享題幹中的 prefix 時 → 渲染 dim span', () => {
+    const griQuestion: QuizQuestion = {
+      id: 'test-gri-67',
+      stem: 'GRI 準則 2021 之系統架構分為三個系列準則，下列何者正確？',
+      options: [
+        { key: 'A', text: 'GRI 環境準則、GRI 社會準則、GRI 治理準則' },
+        { key: 'B', text: 'GRI 環境準則、GRI 社會準則、GRI 經濟準則' },
+        { key: 'C', text: 'GRI 通用準則、GRI 進階準則、GRI 特殊準則' },
+        { key: 'D', text: 'GRI 通用準則、GRI 行業準則、GRI 主題準則' },
+      ],
+      answer: 'D',
+      subject: '考科1',
+      sourceType: 'gist',
+      year: null,
+      hasAnswer: true,
+    };
+    const { container } = render(
+      <QuestionCard
+        question={griQuestion}
+        questionNumber={67}
+        onSelectAnswer={vi.fn()}
+      />
+    );
+    const dimSpans = container.querySelectorAll('.option-text__redundant');
+    // 4 個選項都該有 dim 前綴
+    expect(dimSpans.length).toBe(4);
+    dimSpans.forEach((s) => expect(s.textContent).toBe('GRI'));
+  });
+
+  it('題幹未含共享 prefix 時 → 不 dim（避免誤殺）', () => {
+    const noShareQuestion: QuizQuestion = {
+      ...mockQuestion,
+      // 題幹是溫室氣體，選項首字各不同，沒共享前綴
+    };
+    const { container } = render(
+      <QuestionCard
+        question={noShareQuestion}
+        questionNumber={1}
+        onSelectAnswer={vi.fn()}
+      />
+    );
+    expect(container.querySelectorAll('.option-text__redundant').length).toBe(0);
+  });
+});

--- a/quiz-app/src/components/QuestionCard/QuestionCard.tsx
+++ b/quiz-app/src/components/QuestionCard/QuestionCard.tsx
@@ -5,6 +5,7 @@ import { explainQuestion, type AIResponse } from '../../utils/ai-helper';
 import { SourceBadge } from '../SourceBadge/SourceBadge';
 import { SourceBanner } from '../SourceBanner/SourceBanner';
 import { LAW_PCODE_LABELS } from '../../data/law-pcode-labels';
+import { findRedundantPrefix } from '../../utils/option-prefix';
 import './QuestionCard.css';
 
 /**
@@ -59,6 +60,10 @@ export function QuestionCard({
     () =>
       (question.sources ?? []).map((url) => ({ url, label: prettifySourceUrl(url) })),
     [question.sources]
+  );
+  const redundantPrefix = useMemo(
+    () => findRedundantPrefix(question.stem, question.options.map((o) => o.text)),
+    [question.stem, question.options],
   );
   const [isLoadingAI, setIsLoadingAI] = useState(false);
 
@@ -164,6 +169,7 @@ export function QuestionCard({
             status={getOptionStatus(option.key)}
             isSelected={selectedAnswer === option.key}
             isDisabled={showAnswer}
+            redundantPrefix={redundantPrefix}
             onClick={() => handleOptionClick(option.key)}
             onKeyDown={(e) => handleKeyDown(e, option.key)}
           />
@@ -304,6 +310,8 @@ interface OptionButtonProps {
   status: 'default' | 'selected' | 'correct' | 'incorrect';
   isSelected: boolean;
   isDisabled: boolean;
+  /** 全選項共有的冗餘前綴關鍵字（例如「GRI」），UI 渲染時 dim 化 */
+  redundantPrefix?: string | null;
   onClick: () => void;
   onKeyDown: (e: React.KeyboardEvent) => void;
 }
@@ -313,6 +321,7 @@ function OptionButton({
   status,
   isSelected,
   isDisabled,
+  redundantPrefix,
   onClick,
   onKeyDown,
 }: OptionButtonProps) {
@@ -334,7 +343,18 @@ function OptionButton({
         aria-label={`${option.key}: ${option.text}`}
       />
       <span className="option-key">{option.key}</span>
-      <span className="option-text">{option.text}</span>
+      <span className="option-text">
+        {redundantPrefix && option.text.startsWith(redundantPrefix) ? (
+          <>
+            <span className="option-text__redundant" aria-hidden="true">
+              {redundantPrefix}
+            </span>
+            {option.text.slice(redundantPrefix.length)}
+          </>
+        ) : (
+          option.text
+        )}
+      </span>
       {status === 'correct' && (
         <span className="option-icon material-icons" aria-label="正確答案">
           check_circle

--- a/quiz-app/src/utils/option-prefix.test.ts
+++ b/quiz-app/src/utils/option-prefix.test.ts
@@ -1,0 +1,67 @@
+// option-prefix util 測試
+import { describe, it, expect } from 'vitest';
+import { findRedundantPrefix } from './option-prefix';
+
+describe('findRedundantPrefix', () => {
+  it('returns shared first word when all options share it AND stem contains it', () => {
+    const stem = 'GRI 準則 2021 之系統架構分為三個系列準則，下列何者正確？';
+    const opts = [
+      'GRI 環境準則、GRI 社會準則、GRI 治理準則',
+      'GRI 環境準則、GRI 社會準則、GRI 經濟準則',
+      'GRI 通用準則、GRI 進階準則、GRI 特殊準則',
+      'GRI 通用準則、GRI 行業準則、GRI 主題準則',
+    ];
+    expect(findRedundantPrefix(stem, opts)).toBe('GRI');
+  });
+
+  it('returns null when options first words differ', () => {
+    const stem = '某題目';
+    const opts = ['ABC 內容', 'XYZ 內容', 'ABC 不一樣', 'XYZ 又不同'];
+    expect(findRedundantPrefix(stem, opts)).toBeNull();
+  });
+
+  it('returns null when prefix not present in stem (not redundant)', () => {
+    const stem = '請選出符合要求的選項';
+    const opts = ['GRI A', 'GRI B', 'GRI C', 'GRI D'];
+    expect(findRedundantPrefix(stem, opts)).toBeNull();
+  });
+
+  it('returns null for single-char prefix (avoid over-dimming)', () => {
+    const stem = '某 X 題目';
+    const opts = ['X 選 A', 'X 選 B', 'X 選 C'];
+    expect(findRedundantPrefix(stem, opts)).toBeNull();
+  });
+
+  it('returns null with fewer than 2 options', () => {
+    expect(findRedundantPrefix('any', ['only one'])).toBeNull();
+    expect(findRedundantPrefix('any', [])).toBeNull();
+  });
+
+  it('handles options with leading whitespace gracefully', () => {
+    const stem = 'GRI 是什麼？';
+    const opts = [
+      'GRI 是治理',
+      ' GRI 是社會', // leading space
+      'GRI 是環境',
+    ];
+    // 第二個選項首字非 GRI（而是 space），不算共享 → null
+    expect(findRedundantPrefix(stem, opts)).toBeNull();
+  });
+
+  it('works for SASB / TCFD / 其他常見 prefix', () => {
+    const stem = 'TCFD 架構分為四大支柱';
+    const opts = ['TCFD 治理', 'TCFD 策略', 'TCFD 風險管理', 'TCFD 指標與目標'];
+    expect(findRedundantPrefix(stem, opts)).toBe('TCFD');
+  });
+
+  it('does NOT dim when one option lacks the prefix (genuine difference)', () => {
+    const stem = 'GRI 與 SASB 比較';
+    const opts = [
+      'GRI 著重利害關係人',
+      'GRI 為通用準則',
+      'SASB 著重投資人', // 缺 GRI
+      'GRI 採行業差異化',
+    ];
+    expect(findRedundantPrefix(stem, opts)).toBeNull();
+  });
+});

--- a/quiz-app/src/utils/option-prefix.ts
+++ b/quiz-app/src/utils/option-prefix.ts
@@ -1,0 +1,37 @@
+// 偵測選項中冗餘的共同前綴關鍵字（例如題幹已說「GRI 準則」，每個選項又重複
+// 以「GRI ...」開頭）。讓 UI 把這個前綴 dim 化降低視覺噪音。
+//
+// 設計：保守取「所有選項的第一個 whitespace-separated 詞」作為 prefix，
+// 並僅當該詞同時出現在 stem 才視為冗餘（否則可能是必要 disambiguation）。
+
+/**
+ * 找出選項中冗餘的共同首字（首詞）。
+ *
+ * @returns 共同前綴字串（不含 trailing whitespace），若無則 null。
+ */
+export function findRedundantPrefix(
+  stem: string,
+  optionTexts: readonly string[],
+): string | null {
+  if (optionTexts.length < 2) return null;
+
+  // 取每個選項的第一個 non-whitespace token
+  const firstWords = optionTexts.map((t) => {
+    const m = t.match(/^(\S+)/);
+    return m ? m[1] : null;
+  });
+
+  // 任一選項無法 match（空字串 / 開頭 whitespace） → 不算共享
+  if (firstWords.some((w) => w === null)) return null;
+
+  const candidate = firstWords[0]!;
+  if (candidate.length < 2) return null; // 單字元 prefix 不 dim 避免過度
+
+  const allShare = firstWords.every((w) => w === candidate);
+  if (!allShare) return null;
+
+  // 僅當 stem 包含此 token 才算冗餘（否則可能是必要 marker）
+  if (!stem.includes(candidate)) return null;
+
+  return candidate;
+}


### PR DESCRIPTION
## Summary
題目 #67 之類「題幹說 GRI、4 個選項都 prefix GRI」的視覺冗餘 — 用 UI 層 visual normalization 解決，**不動資料**。

## 例子（PR 後）
題幹：「GRI 準則 2021 之系統架構分為三個系列準則...」
- A. <span style="opacity:0.45">GRI</span> 環境準則、<span style="opacity:0.45">GRI</span> 社會準則、<span style="opacity:0.45">GRI</span> 治理準則

dim 後 user 視覺聚焦在「環境/社會/治理 vs 通用/行業/主題」的真實差異點。

## 演算法
`findRedundantPrefix(stem, optionTexts)`：
- 取每個選項首個 whitespace-separated token
- 若全部共享同一 token AND token ≥2 字元 AND stem 包含此 token → 回傳該 prefix
- 保守條件（一個選項缺前綴 → null；不在 stem → null；單字元 → null）

## 不動資料原因
題目原文是 gist 來源整理；改文字會破壞 verification trail。UI 層處理：
- 對其他類似題目（CDP / SBTi / TCFD / SASB 比較題）自動生效
- aria-hidden 在 dim span，螢幕閱讀器仍唸完整文字（a11y 不退步）
- 若資料更新導致前綴不再共享，自動關閉

## TDD
- `option-prefix.test.ts` 8 case 涵蓋共享/不共享/不在 stem/單字/小於 2 個選項/有空白/SASB-TCFD 對稱
- `QuestionCard.test.tsx` +2 case 驗證 dim span DOM 存在與否
紅 → 綠流程完整。

## 本地 CI
- lint: 0 errors
- tsc: clean
- vitest: 28 files / 285 pass + 5 skip
- vite build: 879ms