### PR TITLE
refactor: cleanup follow-ups (items 3/4/5/9/10) + 文案精簡

### DIFF
--- a/quiz-app/package.json
+++ b/quiz-app/package.json
@@ -66,5 +66,8 @@
     "overrides": {
       "esbuild": ">=0.25.0"
     }
+  },
+  "bugs": {
+    "url": "https://github.com/thc1006/ipas-net-zero-quiz/discussions/1"
   }
 }

--- a/quiz-app/src/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/quiz-app/src/components/ErrorBoundary/ErrorBoundary.tsx
@@ -2,6 +2,7 @@
 // React 18 沒有 hook 版的 boundary，class component 是唯一手段
 import { Component, type ErrorInfo, type ReactNode } from 'react';
 import { logger as defaultLogger, type Logger } from '../../utils/logger';
+import { BUG_REPORT_URL } from '../../data/app-meta';
 import './ErrorBoundary.css';
 
 interface Props {
@@ -50,7 +51,7 @@ export class ErrorBoundary extends Component<Props, State> {
         </div>
         <p className="error-boundary__message">
           頁面渲染時發生錯誤。請點選「重試」重新載入；若仍持續，
-          請<a href="https://github.com/thc1006/ipas-net-zero-quiz/discussions/1" target="_blank" rel="noopener noreferrer">回報</a>給我們。
+          請<a href={BUG_REPORT_URL} target="_blank" rel="noopener noreferrer">回報</a>給我們。
         </p>
         <div className="error-boundary__actions">
           <button

--- a/quiz-app/src/components/PracticeOptInDialog/PracticeOptInDialog.tsx
+++ b/quiz-app/src/components/PracticeOptInDialog/PracticeOptInDialog.tsx
@@ -76,8 +76,7 @@ export function PracticeOptInDialog({ open, onAccept, onDecline }: PracticeOptIn
         </p>
         <ul>
           <li>
-            <strong>模擬題（{PRACTICE_POOL_COUNTS.externalMock} 題）</strong>：取自 vocus 講師、HackMD、yamol 等公開模擬題，
-            非官方歷屆試題（iPAS 不公開歷屆）。
+            <strong>模擬題（{PRACTICE_POOL_COUNTS.externalMock} 題）</strong>：公開模擬題（非官方歷屆，iPAS 不公開歷屆）。
           </li>
           <li>
             <strong>AI 產題（{PRACTICE_POOL_COUNTS.aiGenerated} 題）</strong>：由語言模型依環境部、CBAM、ISO 等法規與標準

--- a/quiz-app/src/components/PracticePoolHistogram/PracticePoolHistogram.tsx
+++ b/quiz-app/src/components/PracticePoolHistogram/PracticePoolHistogram.tsx
@@ -21,7 +21,9 @@ export function PracticePoolHistogram({
   mainBankCount,
   subject,
 }: PracticePoolHistogramProps): JSX.Element {
-  const poolCounts = POOL_BY_SUBJECT[subject];
+  // POOL_BY_SUBJECT 目前只有 '考科1' / '考科2' / 'all'；未來新增 subject
+  // 若忘了補常數，fallback 到 all 全集（避免 runtime crash）
+  const poolCounts = POOL_BY_SUBJECT[subject] ?? POOL_BY_SUBJECT.all;
   const rows: Row[] = [
     { label: '主題庫', count: mainBankCount, cls: 'main' },
     { label: '模擬題', count: poolCounts.externalMock, cls: 'mock' },

--- a/quiz-app/src/components/SourceBanner/SourceBanner.test.tsx
+++ b/quiz-app/src/components/SourceBanner/SourceBanner.test.tsx
@@ -11,7 +11,7 @@ describe('SourceBanner', () => {
     const banner = screen.getByTestId('source-banner');
     expect(banner.className).toMatch(/source-banner--mock/);
     expect(banner.textContent).toContain('模擬題');
-    expect(banner.textContent).toMatch(/vocus|HackMD|yamol/);
+    expect(banner.textContent).toMatch(/公開模擬題/);
   });
 
   it('ai_generated — 顯示「AI 產題」標籤 + 驗證提醒', () => {

--- a/quiz-app/src/components/SourceBanner/SourceBanner.tsx
+++ b/quiz-app/src/components/SourceBanner/SourceBanner.tsx
@@ -24,7 +24,7 @@ const SOURCE_META: Record<
     tone: 'mock',
     icon: 'menu_book',
     label: '模擬題',
-    hint: '取自 vocus / HackMD / yamol 等公開模擬題；非官方歷屆試題（iPAS 不公開歷屆）。',
+    hint: '公開模擬題（非官方歷屆，iPAS 不公開歷屆）。',
   },
   ai_generated: {
     tone: 'ai',

--- a/quiz-app/src/components/SourceBreakdown/SourceBreakdown.tsx
+++ b/quiz-app/src/components/SourceBreakdown/SourceBreakdown.tsx
@@ -3,8 +3,13 @@
 import type { AnswerRecord } from '../../types/quiz';
 import './SourceBreakdown.css';
 
+/** 池題正確率低於此 threshold (%) 顯示 ⚠ 偏低警示。主題庫不適用。 */
+export const LOW_ACCURACY_THRESHOLD_PCT = 60;
+
 interface SourceBreakdownProps {
   answers: AnswerRecord[];
+  /** 自訂 low-accuracy threshold；預設 60 (%) */
+  lowAccuracyThresholdPct?: number;
 }
 
 interface Group {
@@ -41,7 +46,10 @@ export function computeBreakdown(answers: AnswerRecord[]): Group[] {
     .filter((m) => m.total > 0);
 }
 
-export function SourceBreakdown({ answers }: SourceBreakdownProps): JSX.Element | null {
+export function SourceBreakdown({
+  answers,
+  lowAccuracyThresholdPct = LOW_ACCURACY_THRESHOLD_PCT,
+}: SourceBreakdownProps): JSX.Element | null {
   const groups = computeBreakdown(answers);
 
   // 只有「主題庫」一組（沒啟用練習池或練習池沒抽到）→ 不顯示（避免冗餘）
@@ -53,7 +61,7 @@ export function SourceBreakdown({ answers }: SourceBreakdownProps): JSX.Element 
       <ul className="source-breakdown__rows">
         {groups.map((g) => {
           const pct = g.total > 0 ? Math.round((g.correct / g.total) * 100) : 0;
-          const lowAccuracy = pct < 60 && g.key !== 'main_bank';
+          const lowAccuracy = pct < lowAccuracyThresholdPct && g.key !== 'main_bank';
           return (
             <li
               key={g.key}

--- a/quiz-app/src/data/app-meta.ts
+++ b/quiz-app/src/data/app-meta.ts
@@ -1,0 +1,11 @@
+// 應用程式中繼資料 — 從 package.json 讀取，避免 hardcode 漂移
+import packageJson from '../../package.json';
+
+export const APP_VERSION = packageJson.version;
+export const APP_NAME = '淨零碳備考神器';
+
+/** 問題回報 URL — 來自 package.json `bugs.url`（GitHub Discussions） */
+export const BUG_REPORT_URL = packageJson.bugs.url;
+
+/** GitHub repo URL — 來自 package.json `repository.url`，去掉 .git suffix */
+export const REPO_URL = packageJson.repository.url.replace(/\.git$/, '');

--- a/quiz-app/src/utils/option-prefix.test.ts
+++ b/quiz-app/src/utils/option-prefix.test.ts
@@ -64,4 +64,26 @@ describe('findRedundantPrefix', () => {
     ];
     expect(findRedundantPrefix(stem, opts)).toBeNull();
   });
+
+  it('multi-token: 共享 2 個 token (e.g., GRI 準則)', () => {
+    const stem = 'GRI 準則之系統架構分為三大類';
+    const opts = [
+      'GRI 準則 環境',
+      'GRI 準則 社會',
+      'GRI 準則 治理',
+      'GRI 準則 經濟',
+    ];
+    expect(findRedundantPrefix(stem, opts)).toBe('GRI 準則');
+  });
+
+  it('multi-token: 不超出最短選項長度（防整個選項都是 prefix）', () => {
+    const stem = 'GRI 準則';
+    const opts = [
+      'GRI 準則', // 整個選項就是 prefix
+      'GRI 準則 環境',
+      'GRI 準則 社會',
+    ];
+    // commonLen 會是 2，但第一個選項只有 2 token → reject
+    expect(findRedundantPrefix(stem, opts)).toBeNull();
+  });
 });

--- a/quiz-app/src/utils/option-prefix.ts
+++ b/quiz-app/src/utils/option-prefix.ts
@@ -5,9 +5,14 @@
 // 並僅當該詞同時出現在 stem 才視為冗餘（否則可能是必要 disambiguation）。
 
 /**
- * 找出選項中冗餘的共同首字（首詞）。
+ * 找出選項中冗餘的共同前綴（一或多個 whitespace-separated 詞）。
  *
  * @returns 共同前綴字串（不含 trailing whitespace），若無則 null。
+ *
+ * 演算法：
+ * 1. 把每個選項拆 token（splitting on \s+）
+ * 2. 從左找最長共同 token 序列（multi-token）
+ * 3. 整段 join 後若 ≥2 字元 AND stem 包含該整段 → 回傳；否則 null
  */
 export function findRedundantPrefix(
   stem: string,
@@ -15,23 +20,32 @@ export function findRedundantPrefix(
 ): string | null {
   if (optionTexts.length < 2) return null;
 
-  // 取每個選項的第一個 non-whitespace token
-  const firstWords = optionTexts.map((t) => {
-    const m = t.match(/^(\S+)/);
-    return m ? m[1] : null;
+  // 拆每個選項為 token 陣列；以 leading whitespace 為偏離信號 → reject
+  const tokenized = optionTexts.map((t) => {
+    if (/^\s/.test(t)) return null; // leading whitespace → 視為破壞共享
+    return t.split(/\s+/).filter((tok) => tok.length > 0);
   });
+  if (tokenized.some((toks) => toks === null || toks.length === 0)) return null;
 
-  // 任一選項無法 match（空字串 / 開頭 whitespace） → 不算共享
-  if (firstWords.some((w) => w === null)) return null;
+  const tokens0 = tokenized[0] as string[];
 
-  const candidate = firstWords[0]!;
-  if (candidate.length < 2) return null; // 單字元 prefix 不 dim 避免過度
+  // 找最長共同 token 序列
+  let commonLen = 0;
+  for (let i = 0; i < tokens0.length; i++) {
+    const tok = tokens0[i];
+    const allMatch = tokenized.every((toks) => (toks as string[])[i] === tok);
+    if (!allMatch) break;
+    commonLen = i + 1;
+  }
+  if (commonLen === 0) return null;
 
-  const allShare = firstWords.every((w) => w === candidate);
-  if (!allShare) return null;
+  // 不能整個選項都是 prefix（commonLen === tokens.length 表示某選項只有 prefix 本身）
+  // 若任一選項長度等於 commonLen，說明該選項只有 prefix 沒其他內容 → 不適合 dim
+  if (tokenized.some((toks) => (toks as string[]).length === commonLen)) return null;
 
-  // 僅當 stem 包含此 token 才算冗餘（否則可能是必要 marker）
-  if (!stem.includes(candidate)) return null;
+  const prefix = tokens0.slice(0, commonLen).join(' ');
+  if (prefix.length < 2) return null; // 太短不 dim
+  if (!stem.includes(prefix)) return null; // 必須出現在 stem 才算冗餘
 
-  return candidate;
+  return prefix;
 }


### PR DESCRIPTION
Follow-up cleanup combo（5 in 1）：

- **#3** ErrorBoundary URL hardcode → `BUG_REPORT_URL` 從 package.json bugs.url
- **#4** option-prefix 支援 multi-token (e.g., `GRI 準則` 兩 token)
- **#5** SourceBreakdown 60% magic → `LOW_ACCURACY_THRESHOLD_PCT` const + prop
- **#9** PracticePoolHistogram unknown subject fallback (no crash)
- **#10** 已由 practice-pool-counts.test.ts CI cross-check 守住，無需 dev-startup duplicate
- **同時** user 反饋的文案精簡：'取自 vocus/HackMD/yamol 等公開模擬題' → '公開模擬題'

無新依賴。本地 CI 全綠（28 files / 287 pass + 5 skip）。