### PR TITLE
test(integration): 解封 5 個 skipped pool tests (item 1)

### DIFF
--- a/quiz-app/src/hooks/startQuizWithPool.test.tsx
+++ b/quiz-app/src/hooks/startQuizWithPool.test.tsx
@@ -1,11 +1,25 @@
 // startQuizWithPool 測試 — async 開始測驗、混入練習池
-import { describe, it, expect, beforeEach } from 'vitest';
+//
+// 之前的 it.skip 因為動態 import('../data/practice_pool.json') 在 jsdom 環境
+// 有時序敏感性 → flaky CI。改用 __setPracticePoolForTesting 注入小型 fixture，
+// 直接測 hook 整合層而不依賴實際 200KB JSON 動態載入。
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 import { useQuiz } from './useQuiz';
-import { __resetPracticePoolCacheForTesting } from '../utils/practice-pool';
+import {
+  __resetPracticePoolCacheForTesting,
+  __setPracticePoolForTesting,
+} from '../utils/practice-pool';
+import { buildFixturePool } from '../utils/__fixtures__/practice-pool-fixture';
 
 describe('useQuiz.startQuizWithPool', () => {
-  beforeEach(() => __resetPracticePoolCacheForTesting());
+  beforeEach(() => {
+    __setPracticePoolForTesting(buildFixturePool());
+  });
+
+  afterEach(() => {
+    __resetPracticePoolCacheForTesting();
+  });
 
   it('without includePracticePool behaves like startQuiz (uses main bank)', async () => {
     const { result } = renderHook(() => useQuiz());
@@ -28,29 +42,39 @@ describe('useQuiz.startQuizWithPool', () => {
     }
   });
 
-  it.skip('with includePracticePool can mix in pool items (integration; covered by practice-pool.test)', async () => {
+  it('with includePracticePool can mix in pool items (questionCount 對 + 機率高足以抽到 pool)', async () => {
     const { result } = renderHook(() => useQuiz());
+    // 抽 600 題（接近主題庫總量 648 + fixture pool 6 = 654）→ 接近全抽，
+    // 高機率包含 pool 題（隨機抽樣，機率 = 1 - C(648, 600)/C(654, 600) ≈ 100%）
     await act(async () => {
       await result.current.startQuizWithPool({
         mode: 'practice',
         subject: 'all',
-        questionCount: 30,
-        shuffleQuestions: false, // ordered: mainBank first then pool
+        questionCount: 600,
+        shuffleQuestions: true,
         shuffleOptions: false,
         showAnswerImmediately: true,
         includePracticePool: true,
       });
     });
-    expect(result.current.questions).toHaveLength(30);
+    expect(result.current.questions).toHaveLength(600);
+    expect(result.current.isActive).toBe(true);
+    // 600 picks 從 654 抽 → 至少 (600+6-654) = ≥0；用 hasAnswer fixture 推估
+    // fixture-1 / fixture-2 / fixture-3 / fixture-4 / fixture-5 都有答案
+    // 600/654 ≈ 91.7% 機率每題被抽，期望 5-6 fixture 入選
+    const poolCount = result.current.questions.filter(
+      (q) => q.sourceType === 'practice_pool',
+    ).length;
+    expect(poolCount).toBeGreaterThan(0);
   });
 
-  it.skip('exam mode filters out questions without answer (integration)', async () => {
+  it('exam mode filters out questions without answer', async () => {
     const { result } = renderHook(() => useQuiz());
     await act(async () => {
       await result.current.startQuizWithPool({
         mode: 'exam',
         subject: 'all',
-        questionCount: 10,
+        questionCount: 30,
         shuffleQuestions: false,
         shuffleOptions: false,
         showAnswerImmediately: false,
@@ -60,9 +84,11 @@ describe('useQuiz.startQuizWithPool', () => {
     for (const q of result.current.questions) {
       expect(q.hasAnswer).toBe(true);
     }
+    // fixture 中 item-6 沒答案 → 不應出現在 picked questions
+    expect(result.current.questions.find((q) => q.id === 'fixture-6')).toBeUndefined();
   });
 
-  it.skip('subject filter excludes unmapped_subject pool items (integration)', async () => {
+  it('subject filter excludes unmapped_subject pool items', async () => {
     const { result } = renderHook(() => useQuiz());
     await act(async () => {
       await result.current.startQuizWithPool({

--- a/quiz-app/src/hooks/useQuizSource.test.tsx
+++ b/quiz-app/src/hooks/useQuizSource.test.tsx
@@ -2,7 +2,11 @@
 import { afterEach, beforeAll, describe, expect, it, beforeEach } from 'vitest';
 import { renderHook, waitFor, cleanup } from '@testing-library/react';
 import { useQuizSource } from './useQuizSource';
-import { __resetPracticePoolCacheForTesting } from '../utils/practice-pool';
+import {
+  __resetPracticePoolCacheForTesting,
+  __setPracticePoolForTesting,
+} from '../utils/practice-pool';
+import { buildFixturePool } from '../utils/__fixtures__/practice-pool-fixture';
 
 
 // 還原真實 localStorage 行為（test-setup.ts 把它 mock 成空函式）
@@ -47,11 +51,9 @@ describe('useQuizSource', () => {
     expect(result.current.combined.length).toBe(result.current.mainBank.length);
   });
 
-  // useQuizSource 內含 dynamic import('../data/practice_pool.json')；
-  // vitest jsdom 環境對此互動有時序敏感性。練習池載入邏輯本身已由
-  // practice-pool.test.ts 的 loadPracticePool 測試覆蓋；此處 skip 避免
-  // CI flakiness，留 it.skip 作 placeholder 提示後續可改 mock 直接注入 pool。
-  it.skip('loads pool when practice mode enabled (integration; covered by practice-pool.test)', async () => {
+  // 之前 it.skip 因 dynamic import flaky；改用 fixture 注入直接測 hook 整合層
+  it('loads pool when practice mode enabled', async () => {
+    __setPracticePoolForTesting(buildFixturePool());
     localStorage.setItem('practice-pool-enabled', '1');
     const { result } = renderHook(() => useQuizSource('all'));
     await waitFor(() => {
@@ -63,7 +65,8 @@ describe('useQuizSource', () => {
     );
   });
 
-  it.skip('excludes unmapped_subject items from specific subject query (integration)', async () => {
+  it('excludes unmapped_subject items from specific subject query', async () => {
+    __setPracticePoolForTesting(buildFixturePool());
     localStorage.setItem('practice-pool-enabled', '1');
     const { result } = renderHook(() => useQuizSource('考科1'));
     await waitFor(() => {

--- a/quiz-app/src/utils/__fixtures__/practice-pool-fixture.ts
+++ b/quiz-app/src/utils/__fixtures__/practice-pool-fixture.ts
@@ -1,0 +1,103 @@
+// 測試用 practice pool fixture
+// 提供小型穩定資料集給整合測試（startQuizWithPool / useQuizSource），
+// 避免依賴 dynamic import('../data/practice_pool.json') 的時序敏感性。
+//
+// 結構保持與 practice_pool.json 一致（PracticePool type）；
+// 內容刻意涵蓋三種 subject 邊界 + 兩種 source_type + 一筆 unmapped_subject。
+import type { PracticePool, PracticePoolItem } from '../../types/practicePool';
+
+const aiMeta = {
+  model_family: 'unspecified' as const,
+  generation_date: '2026-04-25',
+  verifier_round: 1 as const,
+};
+
+function item(
+  i: number,
+  overrides: Partial<PracticePoolItem>,
+): PracticePoolItem {
+  return {
+    id: `fixture-${i}`,
+    stem: `Fixture 題目 ${i}：請選擇正確答案`,
+    options: [
+      { key: 'A', text: '選 A' },
+      { key: 'B', text: '選 B' },
+      { key: 'C', text: '選 C' },
+      { key: 'D', text: '選 D' },
+    ],
+    answer: 'A',
+    explanation: 'fixture explanation',
+    subject: '考科一',
+    topic_tags: [],
+    difficulty: 'medium',
+    provenance: {
+      source_type: 'external_mock',
+      source_origin: 'fixture',
+      verified_date: '2026-04-25',
+      verifier: 'fixture',
+      verify_verdict: 'CONFIRMED',
+      original_id: `fix-${i}`,
+    },
+    sources: [],
+    quality_flags: [],
+    ...overrides,
+  };
+}
+
+export function buildFixturePool(): PracticePool {
+  const items: PracticePoolItem[] = [
+    // 考科一 mapped, external_mock, 有答案
+    item(1, { subject: '考科一' }),
+    item(2, { subject: '考科一' }),
+    // 考科二 mapped, ai_generated, 有答案
+    item(3, {
+      subject: '考科二',
+      provenance: {
+        source_type: 'ai_generated',
+        source_origin: 'fixture-ai',
+        verified_date: '2026-04-25',
+        verifier: 'fixture',
+        verify_verdict: 'CONFIRMED',
+        original_id: 'fix-ai-3',
+        ai_metadata: aiMeta,
+      },
+    }),
+    item(4, {
+      subject: '考科二',
+      provenance: {
+        source_type: 'ai_generated',
+        source_origin: 'fixture-ai',
+        verified_date: '2026-04-25',
+        verifier: 'fixture',
+        verify_verdict: 'CONFIRMED',
+        original_id: 'fix-ai-4',
+        ai_metadata: aiMeta,
+      },
+    }),
+    // unmapped subject → 取得 unmapped_subject flag
+    item(5, {
+      subject: null,
+      quality_flags: ['unmapped_subject'],
+    }),
+    // 無答案題（exam mode 應排除）
+    item(6, {
+      subject: '考科一',
+      answer: null,
+    }),
+  ];
+  return {
+    _meta: {
+      version: 'fixture',
+      generated_at: '2026-04-25',
+      description: 'test fixture',
+      source_types: ['external_mock', 'ai_generated'],
+      compliance: {
+        eu_ai_act_art50_effective: '2026-08-02',
+        ai_generated_disclosure: 'fixture',
+      },
+      totals: { external_mock: 4, ai_generated: 2, total: 6 },
+      policy: 'fixture',
+    },
+    items,
+  };
+}

--- a/quiz-app/src/utils/practice-pool.ts
+++ b/quiz-app/src/utils/practice-pool.ts
@@ -161,3 +161,22 @@ export function __resetPracticePoolCacheForTesting(): void {
   poolPromise = null;
   poolCached = null;
 }
+
+/**
+ * 測試專用：直接注入 fixture pool，跳過 dynamic import('../data/practice_pool.json')。
+ * jsdom 對 200KB JSON 動態 import 有時序敏感性（race / flaky CI）；用此 helper
+ * 注入小型 fixture 即可乾淨測 hook 整合層而不依賴實際 JSON 載入。
+ *
+ * 傳 null 等同 __resetPracticePoolCacheForTesting()
+ */
+export function __setPracticePoolForTesting(pool: PracticePool | null): void {
+  const env = (import.meta as ImportMeta).env;
+  if (env?.PROD) return;
+  if (pool === null) {
+    poolPromise = null;
+    poolCached = null;
+    return;
+  }
+  poolCached = pool;
+  poolPromise = Promise.resolve(pool);
+}


### PR DESCRIPTION
之前 startQuizWithPool / useQuizSource 整合測試因 dynamic import('../data/practice_pool.json') 在 jsdom 時序敏感（CI flaky）全部 `it.skip`。

新加 `__setPracticePoolForTesting(pool)` 注入點，搭配 6 題 fixture（涵蓋 mock/ai/unmapped/no-answer 邊界），整合層測試直接乾淨跑。

**全 project skipped count: 5 → 0**。本地 CI: 290 pass + 0 skip。