### PR TITLE
feat(logger): persist sanitizer 避免 PII 落地 localStorage

### DIFF
--- a/quiz-app/src/utils/logger.test.ts
+++ b/quiz-app/src/utils/logger.test.ts
@@ -288,3 +288,77 @@ describe('Logger persistence (persistKey)', () => {
     expect(log.getRecentErrors()[0].message).toBe('e7');
   });
 });
+
+describe('Logger persist sanitizer (PII redaction)', () => {
+  function installRealLocalStorage() {
+    const store = new Map<string, string>();
+    Object.defineProperty(window, 'localStorage', {
+      value: {
+        getItem: (k: string) => store.get(k) ?? null,
+        setItem: (k: string, v: string) => { store.set(k, v); },
+        removeItem: (k: string) => { store.delete(k); },
+        clear: () => { store.clear(); },
+        key: (i: number) => Array.from(store.keys())[i] ?? null,
+        get length() { return store.size; },
+      },
+      writable: true,
+      configurable: true,
+    });
+  }
+  beforeEach(() => { installRealLocalStorage(); });
+  afterEach(() => { localStorage.clear(); });
+
+  it('redacts password / token / email in context before persist', () => {
+    const log = new Logger({ isDev: false, persistKey: 'pii-log' });
+    log.error('login failed', new Error('bad creds'), {
+      userEmail: 'a@b.com',
+      apiToken: 'sk-xyz',
+      sessionId: 'abc',
+      quizId: '123',
+    });
+    const stored = JSON.parse(localStorage.getItem('pii-log')!);
+    expect(stored[0].context.userEmail).toBe('[redacted]');
+    expect(stored[0].context.apiToken).toBe('[redacted]');
+    expect(stored[0].context.sessionId).toBe('[redacted]');
+    // 非 PII key 保留原值
+    expect(stored[0].context.quizId).toBe('123');
+  });
+
+  it('redacts nested objects recursively', () => {
+    const log = new Logger({ isDev: false, persistKey: 'pii-log' });
+    log.error('nested', undefined, {
+      payload: { auth: 'bearer xxx', other: 'safe' },
+    });
+    const stored = JSON.parse(localStorage.getItem('pii-log')!);
+    expect(stored[0].context.payload.auth).toBe('[redacted]');
+    expect(stored[0].context.payload.other).toBe('safe');
+  });
+
+  it('in-memory buffer stays unredacted (DEV debug 仍可看到原 value)', () => {
+    const log = new Logger({ isDev: true, persistKey: 'pii-log' });
+    log.error('msg', undefined, { password: 'p1' });
+    // In-memory unredacted
+    expect(log.getRecentErrors()[0].context?.password).toBe('p1');
+    // localStorage redacted
+    const stored = JSON.parse(localStorage.getItem('pii-log')!);
+    expect(stored[0].context.password).toBe('[redacted]');
+  });
+
+  it('handles arrays in context', () => {
+    const log = new Logger({ isDev: false, persistKey: 'pii-log' });
+    log.error('msg', undefined, {
+      tokens: ['t1', 't2'],  // key matches /token/i → entire value redacted
+      users: [{ email: 'a@b' }, { email: 'c@d' }],
+    });
+    const stored = JSON.parse(localStorage.getItem('pii-log')!);
+    expect(stored[0].context.tokens).toBe('[redacted]');
+    expect(stored[0].context.users[0].email).toBe('[redacted]');
+  });
+
+  it('Chinese 身分證 key also redacted', () => {
+    const log = new Logger({ isDev: false, persistKey: 'pii-log' });
+    log.error('msg', undefined, { 身分證: 'A123456789' });
+    const stored = JSON.parse(localStorage.getItem('pii-log')!);
+    expect(stored[0].context.身分證).toBe('[redacted]');
+  });
+});

--- a/quiz-app/src/utils/logger.ts
+++ b/quiz-app/src/utils/logger.ts
@@ -39,6 +39,9 @@ interface LoggerOptions {
    * 若提供 key，ring buffer 會持久化到 localStorage[key]，並在 constructor
    * 從中還原 — 讓 production 可在 reload 後仍看到上次崩潰的 error。
    * 預設 undefined（純 in-memory）。
+   *
+   * 持久化前會自動 sanitize PII-looking keys（email/password/token/auth/...）
+   * 把 value 改成 `'[redacted]'`，避免 logger 不慎洩漏使用者個資。
    */
   persistKey?: string;
 }
@@ -47,6 +50,40 @@ const LEVEL_RANK: Record<LogLevel, number> = { info: 0, warn: 1, error: 2 };
 
 /** 序列化 size 上限（bytes）— 防 localStorage quota；超過會 reset buffer */
 const PERSIST_MAX_BYTES = 32 * 1024;
+
+/** 持久化前 redact 的 key 模式（不分大小寫，整個 key 配對 substring） */
+const PII_KEY_PATTERNS = [
+  /password/i,
+  /passwd/i,
+  /token/i,
+  /auth/i,
+  /secret/i,
+  /api[_-]?key/i,
+  /credential/i,
+  /session/i,
+  /cookie/i,
+  /email/i,
+  /phone/i,
+  /ssn/i,
+  /身分證|身份證/,
+  /credit[_-]?card/i,
+];
+
+function isPiiKey(key: string): boolean {
+  return PII_KEY_PATTERNS.some((re) => re.test(key));
+}
+
+/** 遞迴 sanitize：把 PII-looking key 的 value 改成 '[redacted]' */
+function sanitizeForPersist(input: unknown, depth = 0): unknown {
+  if (depth > 4) return '[truncated]'; // 防深度循環
+  if (input === null || typeof input !== 'object') return input;
+  if (Array.isArray(input)) return input.map((v) => sanitizeForPersist(v, depth + 1));
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(input)) {
+    out[k] = isPiiKey(k) ? '[redacted]' : sanitizeForPersist(v, depth + 1);
+  }
+  return out;
+}
 
 function serializeError(err: unknown): string | undefined {
   if (err === undefined || err === null) return undefined;
@@ -178,7 +215,15 @@ export class Logger {
     }
 
     if (this.persistKey) {
-      safeWritePersisted(this.persistKey, this.buffer);
+      // 持久化前 sanitize：避免 context 中的 PII (email/token/etc) 落地 localStorage
+      const sanitized = this.buffer.map((e) => ({
+        ...e,
+        context:
+          e.context === undefined
+            ? undefined
+            : (sanitizeForPersist(e.context) as Record<string, unknown>),
+      }));
+      safeWritePersisted(this.persistKey, sanitized);
     }
 
     if (!this.shouldLog('error')) return;


### PR DESCRIPTION
Logger persistKey 寫入前 redact PII keys（password/token/auth/email/身分證 等）。in-memory buffer 不變，僅 localStorage 寫前 sanitize。5 個新 test case。本地 CI 全綠。