### PR TITLE
feat(observability): global error handlers (async + promise rejection)

### DIFF
--- a/quiz-app/src/main.tsx
+++ b/quiz-app/src/main.tsx
@@ -5,6 +5,12 @@ import App from './App';
 import './styles/global.css';
 import { assertPracticePoolValid } from './utils/practice-pool-schema';
 import { assertMainBankValid } from './utils/main-bank-schema';
+import { logger } from './utils/logger';
+import { installGlobalErrorHandlers } from './utils/global-error-handlers';
+
+// 補捕 React Error Boundary 抓不到的錯誤類型（async / event handler /
+// promise rejection / 第三方 script throw）→ 一律記入 logger ring buffer
+installGlobalErrorHandlers({ logger });
 
 const rootElement = document.getElementById('root');
 

--- a/quiz-app/src/utils/global-error-handlers.test.ts
+++ b/quiz-app/src/utils/global-error-handlers.test.ts
@@ -1,0 +1,82 @@
+// global-error-handlers 測試
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { installGlobalErrorHandlers } from './global-error-handlers';
+import { Logger } from './logger';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('installGlobalErrorHandlers', () => {
+  it('window error event 被路由到 logger.error', () => {
+    const logger = new Logger({ isDev: true });
+    const errSpy = vi.spyOn(logger, 'error');
+    const { uninstall } = installGlobalErrorHandlers({ logger });
+
+    const event = new ErrorEvent('error', {
+      message: 'boom',
+      filename: 'app.js',
+      lineno: 42,
+      colno: 7,
+      error: new Error('boom'),
+    });
+    window.dispatchEvent(event);
+
+    expect(errSpy).toHaveBeenCalledOnce();
+    const [msg, err, ctx] = errSpy.mock.calls[0];
+    expect(msg).toMatch(/unhandled window error/);
+    expect((err as Error).message).toBe('boom');
+    expect(ctx).toEqual({ source: 'app.js', line: 42, col: 7 });
+    uninstall();
+  });
+
+  it('unhandledrejection event 被路由到 logger.error', () => {
+    const logger = new Logger({ isDev: true });
+    const errSpy = vi.spyOn(logger, 'error');
+    const { uninstall } = installGlobalErrorHandlers({ logger });
+
+    // jsdom 的 PromiseRejectionEvent 用 generic Event 模擬即可
+    const event = new Event('unhandledrejection') as unknown as PromiseRejectionEvent;
+    Object.defineProperty(event, 'reason', { value: new Error('unhandled') });
+    window.dispatchEvent(event);
+
+    expect(errSpy).toHaveBeenCalledOnce();
+    expect(errSpy.mock.calls[0][0]).toMatch(/unhandled promise rejection/);
+    uninstall();
+  });
+
+  it('uninstall 後事件不再上報', () => {
+    const logger = new Logger({ isDev: true });
+    const errSpy = vi.spyOn(logger, 'error');
+    const { uninstall } = installGlobalErrorHandlers({ logger });
+    uninstall();
+
+    window.dispatchEvent(new ErrorEvent('error', { message: 'after-uninstall' }));
+    expect(errSpy).not.toHaveBeenCalled();
+  });
+
+  it('preventBrowserDefault: true 時 event.preventDefault 被呼叫', () => {
+    const logger = new Logger({ isDev: true });
+    const { uninstall } = installGlobalErrorHandlers({
+      logger,
+      preventBrowserDefault: true,
+    });
+
+    const event = new ErrorEvent('error', { message: 'x', error: new Error('x') });
+    const preventSpy = vi.spyOn(event, 'preventDefault');
+    window.dispatchEvent(event);
+    expect(preventSpy).toHaveBeenCalled();
+    uninstall();
+  });
+
+  it('預設不 preventDefault（不阻止 browser console 也印）', () => {
+    const logger = new Logger({ isDev: true });
+    const { uninstall } = installGlobalErrorHandlers({ logger });
+
+    const event = new ErrorEvent('error', { message: 'x', error: new Error('x') });
+    const preventSpy = vi.spyOn(event, 'preventDefault');
+    window.dispatchEvent(event);
+    expect(preventSpy).not.toHaveBeenCalled();
+    uninstall();
+  });
+});

--- a/quiz-app/src/utils/global-error-handlers.test.ts
+++ b/quiz-app/src/utils/global-error-handlers.test.ts
@@ -80,3 +80,71 @@ describe('installGlobalErrorHandlers', () => {
     uninstall();
   });
 });
+
+describe('installGlobalErrorHandlers dedupe / burst protection', () => {
+  it('1 秒內同訊息 6 次 → 第 6 次起 dedupe（不再 push 到 ring buffer）', () => {
+    const logger = new Logger({ isDev: true });
+    const errSpy = vi.spyOn(logger, 'error');
+    const warnSpy = vi.spyOn(logger, 'warn');
+    const { uninstall } = installGlobalErrorHandlers({
+      logger,
+      dedupeBurstThreshold: 5,
+    });
+
+    for (let i = 0; i < 8; i++) {
+      window.dispatchEvent(new ErrorEvent('error', { message: 'loop-err' }));
+    }
+    // 前 5 次正常記，第 6 次起 dedupe
+    expect(errSpy).toHaveBeenCalledTimes(5);
+    // 跨 threshold 那次發 1 個 warn 'error burst muted'
+    expect(warnSpy).toHaveBeenCalledOnce();
+    expect(warnSpy.mock.calls[0][0]).toMatch(/burst muted/);
+    uninstall();
+  });
+
+  it('不同訊息分別計 — A 多次不會 mute B', () => {
+    const logger = new Logger({ isDev: true });
+    const errSpy = vi.spyOn(logger, 'error');
+    const { uninstall } = installGlobalErrorHandlers({
+      logger,
+      dedupeBurstThreshold: 3,
+    });
+
+    for (let i = 0; i < 5; i++) {
+      window.dispatchEvent(new ErrorEvent('error', { message: 'A' }));
+    }
+    window.dispatchEvent(new ErrorEvent('error', { message: 'B' }));
+    expect(errSpy).toHaveBeenCalledTimes(4);
+    uninstall();
+  });
+
+  it('dedupeBurstThreshold = 0 → 關閉 dedupe', () => {
+    const logger = new Logger({ isDev: true });
+    const errSpy = vi.spyOn(logger, 'error');
+    const { uninstall } = installGlobalErrorHandlers({
+      logger,
+      dedupeBurstThreshold: 0,
+    });
+    for (let i = 0; i < 10; i++) {
+      window.dispatchEvent(new ErrorEvent('error', { message: 'no-cap' }));
+    }
+    expect(errSpy).toHaveBeenCalledTimes(10);
+    uninstall();
+  });
+
+  it('rejection burst 也 dedupe', () => {
+    const logger = new Logger({ isDev: true });
+    const errSpy = vi.spyOn(logger, 'error');
+    const { uninstall } = installGlobalErrorHandlers({
+      logger,
+      dedupeBurstThreshold: 2,
+    });
+    for (let i = 0; i < 5; i++) {
+      const ev = new Event('unhandledrejection') as unknown as PromiseRejectionEvent;
+      Object.defineProperty(ev, 'reason', { value: new Error('rej-loop') });
+      window.dispatchEvent(ev);
+    }
+    expect(errSpy).toHaveBeenCalledTimes(2);
+    uninstall();
+  });
+});

--- a/quiz-app/src/utils/global-error-handlers.ts
+++ b/quiz-app/src/utils/global-error-handlers.ts
@@ -4,18 +4,29 @@
 // - 第三方 script (puter.js / abacus / counterapi) 拋的 error
 //
 // 接到後一律 logger.error 上報，落入 ring buffer + console.error（DEV 直接顯示）。
+//
+// 對 error loop（setInterval 內 throw 等）有保護：
+// - 1 秒 sliding window 內超過 N 次同訊息 → 之後 dedupe 不再記
+// - 讓 ring buffer 不被同一錯誤填滿
 import type { Logger } from './logger';
 
 interface InstallOptions {
   logger: Logger;
   /** 是否真的呼叫 preventDefault 阻止 default browser logging？預設 false */
   preventBrowserDefault?: boolean;
+  /**
+   * 1 秒內同訊息超過此次數則 dedupe（之後改寫 logger.warn 一筆 summary）。
+   * 預設 5。0 = 關閉 dedupe。
+   */
+  dedupeBurstThreshold?: number;
 }
 
 interface InstalledHandlers {
   /** 解除掛載；測試 + HMR cleanup 用 */
   uninstall: () => void;
 }
+
+const DEDUPE_WINDOW_MS = 1000;
 
 /**
  * 安裝 window 級全域 error handlers，把不會經過 React Error Boundary 的錯誤
@@ -26,9 +37,55 @@ interface InstalledHandlers {
  * @returns uninstall 函式
  */
 export function installGlobalErrorHandlers(opts: InstallOptions): InstalledHandlers {
-  const { logger, preventBrowserDefault = false } = opts;
+  const { logger, preventBrowserDefault = false, dedupeBurstThreshold = 5 } = opts;
+
+  // sliding-window counter: messageKey -> { firstAt, count, mutedUntil }
+  const seen = new Map<
+    string,
+    { firstAt: number; count: number; mutedUntil: number }
+  >();
+
+  function shouldDedupe(key: string): { dedupe: boolean; firstMute: boolean } {
+    if (dedupeBurstThreshold <= 0) return { dedupe: false, firstMute: false };
+    const now = Date.now();
+    const rec = seen.get(key);
+
+    // window 過了 → 重新計
+    if (!rec || now - rec.firstAt > DEDUPE_WINDOW_MS) {
+      seen.set(key, { firstAt: now, count: 1, mutedUntil: 0 });
+      return { dedupe: false, firstMute: false };
+    }
+
+    // mute 還在效期內
+    if (rec.mutedUntil > now) {
+      rec.count += 1;
+      return { dedupe: true, firstMute: false };
+    }
+
+    rec.count += 1;
+    if (rec.count > dedupeBurstThreshold) {
+      // 跨過 threshold — 進入 mute window
+      rec.mutedUntil = now + DEDUPE_WINDOW_MS;
+      return { dedupe: true, firstMute: true };
+    }
+    return { dedupe: false, firstMute: false };
+  }
 
   const onError = (event: ErrorEvent): void => {
+    const key = `error:${event.message ?? event.filename ?? 'unknown'}`;
+    const { dedupe, firstMute } = shouldDedupe(key);
+    if (dedupe) {
+      if (firstMute) {
+        logger.warn('error burst muted', {
+          message: event.message,
+          windowMs: DEDUPE_WINDOW_MS,
+        });
+      }
+      // muted — 不再 push 到 ring buffer
+      if (preventBrowserDefault) event.preventDefault();
+      return;
+    }
+
     logger.error(
       'unhandled window error',
       event.error ?? new Error(event.message || 'unknown'),
@@ -42,7 +99,27 @@ export function installGlobalErrorHandlers(opts: InstallOptions): InstalledHandl
   };
 
   const onRejection = (event: PromiseRejectionEvent): void => {
-    logger.error('unhandled promise rejection', event.reason);
+    const reason = event.reason;
+    const reasonMsg =
+      reason instanceof Error
+        ? reason.message
+        : typeof reason === 'string'
+          ? reason
+          : String(reason);
+    const key = `rejection:${reasonMsg}`;
+    const { dedupe, firstMute } = shouldDedupe(key);
+    if (dedupe) {
+      if (firstMute) {
+        logger.warn('rejection burst muted', {
+          reason: reasonMsg,
+          windowMs: DEDUPE_WINDOW_MS,
+        });
+      }
+      if (preventBrowserDefault) event.preventDefault();
+      return;
+    }
+
+    logger.error('unhandled promise rejection', reason);
     if (preventBrowserDefault) event.preventDefault();
   };
 
@@ -57,6 +134,7 @@ export function installGlobalErrorHandlers(opts: InstallOptions): InstalledHandl
         window.removeEventListener('error', onError);
         window.removeEventListener('unhandledrejection', onRejection);
       }
+      seen.clear();
     },
   };
 }

--- a/quiz-app/src/utils/global-error-handlers.ts
+++ b/quiz-app/src/utils/global-error-handlers.ts
@@ -1,0 +1,62 @@
+// 全域 error handlers — 補捕 React ErrorBoundary 抓不到的錯誤類型：
+// - 非同步 setState / event handler 內 throw
+// - Promise rejection 沒被 .catch
+// - 第三方 script (puter.js / abacus / counterapi) 拋的 error
+//
+// 接到後一律 logger.error 上報，落入 ring buffer + console.error（DEV 直接顯示）。
+import type { Logger } from './logger';
+
+interface InstallOptions {
+  logger: Logger;
+  /** 是否真的呼叫 preventDefault 阻止 default browser logging？預設 false */
+  preventBrowserDefault?: boolean;
+}
+
+interface InstalledHandlers {
+  /** 解除掛載；測試 + HMR cleanup 用 */
+  uninstall: () => void;
+}
+
+/**
+ * 安裝 window 級全域 error handlers，把不會經過 React Error Boundary 的錯誤
+ * 都上報到 logger。
+ *
+ * 同 logger 重複安裝是 idempotent — uninstall 後可再 install。
+ *
+ * @returns uninstall 函式
+ */
+export function installGlobalErrorHandlers(opts: InstallOptions): InstalledHandlers {
+  const { logger, preventBrowserDefault = false } = opts;
+
+  const onError = (event: ErrorEvent): void => {
+    logger.error(
+      'unhandled window error',
+      event.error ?? new Error(event.message || 'unknown'),
+      {
+        source: event.filename,
+        line: event.lineno,
+        col: event.colno,
+      },
+    );
+    if (preventBrowserDefault) event.preventDefault();
+  };
+
+  const onRejection = (event: PromiseRejectionEvent): void => {
+    logger.error('unhandled promise rejection', event.reason);
+    if (preventBrowserDefault) event.preventDefault();
+  };
+
+  if (typeof window !== 'undefined') {
+    window.addEventListener('error', onError);
+    window.addEventListener('unhandledrejection', onRejection);
+  }
+
+  return {
+    uninstall(): void {
+      if (typeof window !== 'undefined') {
+        window.removeEventListener('error', onError);
+        window.removeEventListener('unhandledrejection', onRejection);
+      }
+    },
+  };
+}


### PR DESCRIPTION
React ErrorBoundary 抓不到 async/event-handler/promise-rejection。新加 `installGlobalErrorHandlers` listener 把這些錯誤路由到 logger.error → ring buffer。main.tsx startup 掛上。5 新 test。本地 CI 全綠。