### PR TITLE
ci: quarterly time-sensitive source verify (auto-open issue)

### DIFF
--- a/.github/workflows/quarterly-time-sensitive-verify.yml
+++ b/.github/workflows/quarterly-time-sensitive-verify.yml
@@ -1,0 +1,103 @@
+# Quarterly time-sensitive 題目 source URL 健康檢查
+# 對 quality_flags=time_sensitive 的題目，curl 每條 source URL 看是否仍 200 OK，
+# 失敗時自動開 GitHub issue 列出失效的題目供人工 re-verify。
+#
+# 觸發：每季 1 號 04:00 UTC（02:00 / 12:00 台北 — 視 dst）跑一次；
+# 也可手動透過 workflow_dispatch 觸發。
+
+name: Quarterly Time-Sensitive Source Verify
+
+on:
+  schedule:
+    # 每季 1 號 04:00 UTC = 1/1, 4/1, 7/1, 10/1 凌晨
+    - cron: '0 4 1 1,4,7,10 *'
+  workflow_dispatch:
+    inputs:
+      open_issue:
+        description: '失敗時是否自動開 issue (true/false)'
+        required: false
+        default: 'true'
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  verify:
+    name: Verify time-sensitive sources
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Find time-sensitive 題目 + URLs
+        id: list
+        run: |
+          set -euo pipefail
+          jq -r '
+            .items[]
+            | select(.quality_flags | index("time_sensitive"))
+            | .id as $id
+            | (.sources // [])[] | "\($id)\t\(.)"
+          ' quiz-app/src/data/practice_pool.json > urls.tsv
+          count=$(wc -l < urls.tsv)
+          echo "count=$count" >> "$GITHUB_OUTPUT"
+          echo "Found $count URL(s) to verify"
+          cat urls.tsv
+
+      - name: Curl-check URLs
+        id: curl
+        run: |
+          set -euo pipefail
+          : > failures.tsv
+          while IFS=$'\t' read -r id url; do
+            [ -z "$id" ] && continue
+            status=$(curl -sIL --max-time 15 -A "Mozilla/5.0" -o /dev/null -w "%{http_code}" "$url" || echo "000")
+            if [ "$status" != "200" ]; then
+              echo -e "$id\t$url\t$status" >> failures.tsv
+              echo "❌ $id $url → HTTP $status"
+            else
+              echo "✅ $id $url"
+            fi
+          done < urls.tsv
+          fail_count=$(wc -l < failures.tsv)
+          echo "fail_count=$fail_count" >> "$GITHUB_OUTPUT"
+
+      - name: Open issue if failures
+        if: steps.curl.outputs.fail_count != '0' && (github.event_name == 'schedule' || github.event.inputs.open_issue == 'true')
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const lines = fs.readFileSync('failures.tsv', 'utf8').trim().split('\n').filter(Boolean);
+            const items = lines.map(l => {
+              const [id, url, status] = l.split('\t');
+              return `- \`${id}\` — [${url}](${url}) HTTP ${status}`;
+            }).join('\n');
+            const body = `自動 quarterly verify 偵測到 \`time_sensitive\` 題目的 source URL 失效：
+
+            ${items}
+
+            **動作項目**（依 \`feedback_citation_policy\` memory）：
+            1. 對每筆 URL 確認原 source 是否搬遷 / 內容變動
+            2. 比對題目選項是否仍與最新 source 一致
+            3. 不一致 → 修正答案 + 更新 \`provenance.verified_date\` + 附新 source URL（curl 實測 200 OK）
+            4. URL 已失效且找不到替代 → 移除題目（同時更新 \`_meta.totals\` + \`practice-pool-counts.ts\`）
+
+            Run: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `[quarterly verify] ${lines.length} time-sensitive URL 失效`,
+              body,
+              labels: ['data-maintenance', 'time-sensitive'],
+            });
+
+      - name: Summary
+        if: always()
+        run: |
+          echo "## Quarterly time-sensitive verify summary" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "- URLs checked: ${{ steps.list.outputs.count }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Failures: ${{ steps.curl.outputs.fail_count }}" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/quarterly-time-sensitive-verify.yml
+++ b/.github/workflows/quarterly-time-sensitive-verify.yml
@@ -64,7 +64,7 @@ jobs:
           fail_count=$(wc -l < failures.tsv)
           echo "fail_count=$fail_count" >> "$GITHUB_OUTPUT"
 
-      - name: Open issue if failures
+      - name: Open / update issue if failures
         if: steps.curl.outputs.fail_count != '0' && (github.event_name == 'schedule' || github.event.inputs.open_issue == 'true')
         uses: actions/github-script@v7
         with:
@@ -75,7 +75,10 @@ jobs:
               const [id, url, status] = l.split('\t');
               return `- \`${id}\` — [${url}](${url}) HTTP ${status}`;
             }).join('\n');
-            const body = `自動 quarterly verify 偵測到 \`time_sensitive\` 題目的 source URL 失效：
+
+            const today = new Date().toISOString().slice(0, 10);
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const body = `自動 quarterly verify 偵測到 \`time_sensitive\` 題目的 source URL 失效（${today}）：
 
             ${items}
 
@@ -85,14 +88,37 @@ jobs:
             3. 不一致 → 修正答案 + 更新 \`provenance.verified_date\` + 附新 source URL（curl 實測 200 OK）
             4. URL 已失效且找不到替代 → 移除題目（同時更新 \`_meta.totals\` + \`practice-pool-counts.ts\`）
 
-            Run: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
-            await github.rest.issues.create({
+            Run: ${runUrl}`;
+
+            // dedup：先找有沒有同 prefix open issue，有就 comment 更新而非新開
+            const titlePrefix = '[quarterly verify]';
+            const { data: existing } = await github.rest.issues.listForRepo({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              title: `[quarterly verify] ${lines.length} time-sensitive URL 失效`,
-              body,
-              labels: ['data-maintenance', 'time-sensitive'],
+              state: 'open',
+              labels: 'time-sensitive',
+              per_page: 100,
             });
+            const dup = existing.find((i) => i.title.startsWith(titlePrefix));
+
+            if (dup) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: dup.number,
+                body: `### 新一輪自動 verify (${today})\n\n${body}`,
+              });
+              console.log(`已 comment 到既有 issue #${dup.number}`);
+            } else {
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title: `${titlePrefix} ${lines.length} time-sensitive URL 失效`,
+                body,
+                labels: ['data-maintenance', 'time-sensitive'],
+              });
+              console.log('已開新 issue');
+            }
 
       - name: Summary
         if: always()

--- a/README.md
+++ b/README.md
@@ -112,6 +112,12 @@ jq '.items[] | select(.quality_flags | index("time_sensitive")) | {id, stem: (.s
 3. 不一致時：更新 `provenance.verified_date` + 修正答案（並照 commit policy 附 source URL）
 4. 若 source 已失效：移除題目（同時更新 `_meta.totals` 與 `practice-pool-counts.ts`）
 
+#### 自動季度 verify (GitHub Action)
+
+`.github/workflows/quarterly-time-sensitive-verify.yml` 每季 1/1, 4/1, 7/1, 10/1 04:00 UTC 自動跑：jq 抓 `time_sensitive` 題目 → curl 每條 URL → 失敗自動開 / 更新 issue。也可手動觸發：`gh workflow run quarterly-time-sensitive-verify.yml`。
+
+需在 repo Settings → Actions → General → Workflow permissions 啟用 **Read and write permissions**（否則 workflow 無法開 issue）。
+
 ## 授權
 
 本工具僅供練習參考；題庫資料為個人整理，非官方發布。


### PR DESCRIPTION
新加 cron workflow 每季 1 號 04:00 UTC 跑：jq 抓 time_sensitive 題目 → curl 每條 source URL → 失敗自動開 issue。RE100 名單 (ind-014) 是首要追蹤對象。也支援 workflow_dispatch 手動觸發。