### PR TITLE
fix(HomePage): update button text and enhance question count validation

### DIFF
--- a/quiz-app/src/pages/HomePage.css
+++ b/quiz-app/src/pages/HomePage.css
@@ -210,6 +210,21 @@
   box-shadow: 0 0 0 2px rgba(46, 125, 50, 0.2);
 }
 
+.config-item input[aria-invalid='true'] {
+  border-color: var(--color-error, #d32f2f);
+}
+
+.config-item__hint {
+  font-size: var(--font-size-xs);
+  color: var(--color-text-secondary);
+  margin: 0;
+  min-height: 1em;
+}
+
+.config-item__hint--error {
+  color: var(--color-error, #d32f2f);
+}
+
 .checkbox-item label {
   display: flex;
   align-items: center;

--- a/quiz-app/src/pages/HomePage.test.tsx
+++ b/quiz-app/src/pages/HomePage.test.tsx
@@ -48,10 +48,10 @@ describe('HomePage', () => {
     expect(screen.getByText(/加強練習池啟用中/)).toBeInTheDocument();
   });
 
-  it('calls onStartQuiz with current config when 開始 clicked', () => {
+  it('calls onStartQuiz with current config when 開始測驗 clicked', () => {
     const onStartQuiz = vi.fn();
     render(<HomePage onStartQuiz={onStartQuiz} />);
-    const startBtn = screen.getByRole('button', { name: /開始/ });
+    const startBtn = screen.getByRole('button', { name: /開始測驗/ });
     fireEvent.click(startBtn);
     expect(onStartQuiz).toHaveBeenCalledOnce();
     const config = onStartQuiz.mock.calls[0][0];
@@ -182,7 +182,7 @@ describe('HomePage', () => {
     render(<HomePage onStartQuiz={onStartQuiz} />);
     const select = screen.getByLabelText(/考科範圍/) as HTMLSelectElement;
     fireEvent.change(select, { target: { value: '考科1' } });
-    fireEvent.click(screen.getByRole('button', { name: /開始/ }));
+    fireEvent.click(screen.getByRole('button', { name: /開始測驗/ }));
     expect(onStartQuiz.mock.calls[0][0].subject).toBe('考科1');
   });
 
@@ -191,7 +191,7 @@ describe('HomePage', () => {
     render(<HomePage onStartQuiz={onStartQuiz} />);
     const select = screen.getByLabelText(/測驗模式/) as HTMLSelectElement;
     fireEvent.change(select, { target: { value: 'exam' } });
-    fireEvent.click(screen.getByRole('button', { name: /開始/ }));
+    fireEvent.click(screen.getByRole('button', { name: /開始測驗/ }));
     const cfg = onStartQuiz.mock.calls[0][0];
     expect(cfg.mode).toBe('exam');
     expect(cfg.showAnswerImmediately).toBe(false);
@@ -202,17 +202,28 @@ describe('HomePage', () => {
     render(<HomePage onStartQuiz={onStartQuiz} />);
     const input = screen.getByLabelText(/題數/) as HTMLInputElement;
     fireEvent.change(input, { target: { value: '25' } });
-    fireEvent.click(screen.getByRole('button', { name: /開始/ }));
+    fireEvent.click(screen.getByRole('button', { name: /開始測驗/ }));
     expect(onStartQuiz.mock.calls[0][0].questionCount).toBe(25);
   });
 
-  it('count input clamps NaN to default 20', () => {
+  it('count input below minimum (0): 開始測驗 disabled', () => {
     const onStartQuiz = vi.fn();
     render(<HomePage onStartQuiz={onStartQuiz} />);
     const input = screen.getByLabelText(/題數/) as HTMLInputElement;
-    fireEvent.change(input, { target: { value: 'abc' } });
-    fireEvent.click(screen.getByRole('button', { name: /開始/ }));
-    expect(onStartQuiz.mock.calls[0][0].questionCount).toBe(20);
+    const startBtn = screen.getByRole('button', { name: /開始測驗/ });
+    fireEvent.change(input, { target: { value: '0' } });
+    expect(input.value).toBe('0');
+    expect(startBtn).toBeDisabled();
+    fireEvent.click(startBtn);
+    expect(onStartQuiz).not.toHaveBeenCalled();
+  });
+
+  it('count input empty: 開始測驗 disabled', () => {
+    render(<HomePage onStartQuiz={() => {}} />);
+    const input = screen.getByLabelText(/題數/) as HTMLInputElement;
+    const startBtn = screen.getByRole('button', { name: /開始測驗/ });
+    fireEvent.change(input, { target: { value: '' } });
+    expect(startBtn).toBeDisabled();
   });
 
   it('count input clamps over-max to 100', () => {
@@ -220,7 +231,7 @@ describe('HomePage', () => {
     render(<HomePage onStartQuiz={onStartQuiz} />);
     const input = screen.getByLabelText(/題數/) as HTMLInputElement;
     fireEvent.change(input, { target: { value: '500' } });
-    fireEvent.click(screen.getByRole('button', { name: /開始/ }));
+    fireEvent.click(screen.getByRole('button', { name: /開始測驗/ }));
     expect(onStartQuiz.mock.calls[0][0].questionCount).toBe(100);
   });
 
@@ -229,7 +240,7 @@ describe('HomePage', () => {
     render(<HomePage onStartQuiz={onStartQuiz} />);
     const cb = screen.getByRole('checkbox') as HTMLInputElement;
     fireEvent.change(cb, { target: { checked: true } });
-    fireEvent.click(screen.getByRole('button', { name: /開始/ }));
+    fireEvent.click(screen.getByRole('button', { name: /開始測驗/ }));
     expect(onStartQuiz.mock.calls[0][0].shuffleQuestions).toBe(true);
   });
 });

--- a/quiz-app/src/pages/HomePage.test.tsx
+++ b/quiz-app/src/pages/HomePage.test.tsx
@@ -235,6 +235,67 @@ describe('HomePage', () => {
     expect(onStartQuiz.mock.calls[0][0].questionCount).toBe(100);
   });
 
+  it('count input over-max syncs displayed value to 100 on blur', () => {
+    render(<HomePage onStartQuiz={() => {}} />);
+    const input = screen.getByLabelText(/題數/) as HTMLInputElement;
+    fireEvent.change(input, { target: { value: '500' } });
+    expect(input.value).toBe('500');
+    fireEvent.blur(input);
+    expect(input.value).toBe('100');
+  });
+
+  it('count input rejects decimals and trailing text (button disabled)', () => {
+    const onStartQuiz = vi.fn();
+    render(<HomePage onStartQuiz={onStartQuiz} />);
+    const input = screen.getByLabelText(/題數/) as HTMLInputElement;
+    const startBtn = screen.getByRole('button', { name: /開始測驗/ });
+
+    fireEvent.change(input, { target: { value: '1.5' } });
+    expect(startBtn).toBeDisabled();
+
+    fireEvent.change(input, { target: { value: '12abc' } });
+    expect(startBtn).toBeDisabled();
+
+    fireEvent.change(input, { target: { value: '-5' } });
+    expect(startBtn).toBeDisabled();
+
+    fireEvent.click(startBtn);
+    expect(onStartQuiz).not.toHaveBeenCalled();
+  });
+
+  it('count input invalid → aria-invalid=true and hint is a polite live region', () => {
+    render(<HomePage onStartQuiz={() => {}} />);
+    const input = screen.getByLabelText(/題數/) as HTMLInputElement;
+    fireEvent.change(input, { target: { value: '' } });
+    expect(input.getAttribute('aria-invalid')).toBe('true');
+    const hintId = input.getAttribute('aria-describedby');
+    expect(hintId).toBeTruthy();
+    const hint = document.getElementById(hintId!);
+    expect(hint).not.toBeNull();
+    // 常駐 live region：role=status + aria-live=polite，避免 role 切換時 SR 不可靠 announce
+    expect(hint?.getAttribute('role')).toBe('status');
+    expect(hint?.getAttribute('aria-live')).toBe('polite');
+    expect(hint?.textContent).toMatch(/才能開始測驗/);
+  });
+
+  it('count input invalid → valid: aria-invalid recovers to false', () => {
+    render(<HomePage onStartQuiz={() => {}} />);
+    const input = screen.getByLabelText(/題數/) as HTMLInputElement;
+    fireEvent.change(input, { target: { value: '' } });
+    expect(input.getAttribute('aria-invalid')).toBe('true');
+    fireEvent.change(input, { target: { value: '20' } });
+    expect(input.getAttribute('aria-invalid')).toBe('false');
+    expect(screen.getByRole('button', { name: /開始測驗/ })).not.toBeDisabled();
+  });
+
+  it('count input blur normalizes leading zeros', () => {
+    render(<HomePage onStartQuiz={() => {}} />);
+    const input = screen.getByLabelText(/題數/) as HTMLInputElement;
+    fireEvent.change(input, { target: { value: '050' } });
+    fireEvent.blur(input);
+    expect(input.value).toBe('50');
+  });
+
   it('shuffle checkbox toggles config.shuffleQuestions', () => {
     const onStartQuiz = vi.fn();
     render(<HomePage onStartQuiz={onStartQuiz} />);

--- a/quiz-app/src/pages/HomePage.tsx
+++ b/quiz-app/src/pages/HomePage.tsx
@@ -20,14 +20,27 @@ function mainBankCountForSubject(subject: ExamSubject | 'all'): number {
 // 用來避免每次進首頁都自動彈 — 一次就夠
 const DISCLOSURE_SEEN_KEY = 'practice-pool-disclosure-seen';
 
+/** 可開始測驗時回傳 1–100（含超過 100 時夾為 100）；空白或非有效正整數則為 null */
+function parseClampedQuestionCount(raw: string): number | null {
+  const s = raw.trim();
+  if (s === '') return null;
+  const n = Number.parseInt(s, 10);
+  if (!Number.isFinite(n) || n < 1) return null;
+  return Math.min(100, n);
+}
+
 interface HomePageProps {
   onStartQuiz: (config: QuizConfig) => void;
 }
 
 export function HomePage({ onStartQuiz }: HomePageProps) {
   const [config, setConfig] = useState<QuizConfig>(defaultConfig);
+  const [questionCountInput, setQuestionCountInput] = useState(() =>
+    String(defaultConfig.questionCount)
+  );
   const practiceMode = usePracticeMode();
   const [optInDialogOpen, setOptInDialogOpen] = useState(false);
+  const canStartQuiz = parseClampedQuestionCount(questionCountInput) !== null;
 
   // 首次進首頁、尚未 opt-in、尚未看過揭露 → 自動彈 dialog
   // 已 opt-in 過或已 dismissed 過則不彈
@@ -71,8 +84,7 @@ export function HomePage({ onStartQuiz }: HomePageProps) {
 
   const handleCountChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
-      const value = Math.max(1, Math.min(100, parseInt(e.target.value) || 20));
-      setConfig((prev) => ({ ...prev, questionCount: value }));
+      setQuestionCountInput(e.target.value);
     },
     []
   );
@@ -97,8 +109,10 @@ export function HomePage({ onStartQuiz }: HomePageProps) {
   );
 
   const handleStart = useCallback(() => {
-    onStartQuiz(config);
-  }, [config, onStartQuiz]);
+    const n = parseClampedQuestionCount(questionCountInput);
+    if (n === null) return;
+    onStartQuiz({ ...config, questionCount: n });
+  }, [config, onStartQuiz, questionCountInput]);
 
   return (
     <div className="home-page animate-fade-in">
@@ -259,7 +273,7 @@ export function HomePage({ onStartQuiz }: HomePageProps) {
               id="count"
               min={1}
               max={100}
-              value={config.questionCount}
+              value={questionCountInput}
               onChange={handleCountChange}
               aria-label="題數"
             />
@@ -279,7 +293,12 @@ export function HomePage({ onStartQuiz }: HomePageProps) {
         </div>
 
         {/* 開始按鈕 */}
-        <button className="btn btn-primary start-btn" onClick={handleStart}>
+        <button
+          type="button"
+          className="btn btn-primary start-btn"
+          onClick={handleStart}
+          disabled={!canStartQuiz}
+        >
           <span className="material-icons">play_arrow</span>
           開始測驗
         </button>

--- a/quiz-app/src/pages/HomePage.tsx
+++ b/quiz-app/src/pages/HomePage.tsx
@@ -20,27 +20,39 @@ function mainBankCountForSubject(subject: ExamSubject | 'all'): number {
 // 用來避免每次進首頁都自動彈 — 一次就夠
 const DISCLOSURE_SEEN_KEY = 'practice-pool-disclosure-seen';
 
-/** 可開始測驗時回傳 1–100（含超過 100 時夾為 100）；空白或非有效正整數則為 null */
+/** 題數上限 */
+const QUESTION_COUNT_MAX = 100;
+
+/**
+ * 可開始測驗時回傳 1–100（超過 100 夾為 100）；空白、非純整數、< 1 皆為 null。
+ * 嚴格只接受純十進位整數字串，避免 "12abc"、"1.5"、"-5" 等被 parseInt 誤判。
+ */
 function parseClampedQuestionCount(raw: string): number | null {
   const s = raw.trim();
-  if (s === '') return null;
+  if (!/^\d+$/.test(s)) return null;
   const n = Number.parseInt(s, 10);
-  if (!Number.isFinite(n) || n < 1) return null;
-  return Math.min(100, n);
+  if (n < 1) return null;
+  return Math.min(QUESTION_COUNT_MAX, n);
 }
 
 interface HomePageProps {
   onStartQuiz: (config: QuizConfig) => void;
 }
 
+// `questionCount` 在此頁的 source-of-truth 是 questionCountInput（字串），
+// 故從 config state 移除以避免兩個來源並存。送出時才補上 parsed 數值。
+type HomePageConfig = Omit<QuizConfig, 'questionCount'>;
+const { questionCount: _defaultQuestionCount, ...defaultHomeConfig } = defaultConfig;
+
 export function HomePage({ onStartQuiz }: HomePageProps) {
-  const [config, setConfig] = useState<QuizConfig>(defaultConfig);
+  const [config, setConfig] = useState<HomePageConfig>(defaultHomeConfig);
   const [questionCountInput, setQuestionCountInput] = useState(() =>
     String(defaultConfig.questionCount)
   );
   const practiceMode = usePracticeMode();
   const [optInDialogOpen, setOptInDialogOpen] = useState(false);
-  const canStartQuiz = parseClampedQuestionCount(questionCountInput) !== null;
+  const parsedQuestionCount = parseClampedQuestionCount(questionCountInput);
+  const canStartQuiz = parsedQuestionCount !== null;
 
   // 首次進首頁、尚未 opt-in、尚未看過揭露 → 自動彈 dialog
   // 已 opt-in 過或已 dismissed 過則不彈
@@ -89,6 +101,15 @@ export function HomePage({ onStartQuiz }: HomePageProps) {
     []
   );
 
+  // 失焦時把合法輸入正規化（去前後空白、去前導零、超過 100 夾為 100），
+  // 避免「打 500、實際只跑 100」或「  20  」殘留空白的視覺落差
+  const handleCountBlur = useCallback(() => {
+    setQuestionCountInput((prev) => {
+      const n = parseClampedQuestionCount(prev);
+      return n !== null && String(n) !== prev ? String(n) : prev;
+    });
+  }, []);
+
   const handleModeChange = useCallback(
     (e: React.ChangeEvent<HTMLSelectElement>) => {
       const mode = e.target.value as QuizConfig['mode'];
@@ -109,10 +130,11 @@ export function HomePage({ onStartQuiz }: HomePageProps) {
   );
 
   const handleStart = useCallback(() => {
-    const n = parseClampedQuestionCount(questionCountInput);
-    if (n === null) return;
-    onStartQuiz({ ...config, questionCount: n });
-  }, [config, onStartQuiz, questionCountInput]);
+    if (parsedQuestionCount === null) return;
+    onStartQuiz({ ...config, questionCount: parsedQuestionCount });
+  }, [config, onStartQuiz, parsedQuestionCount]);
+
+  const countHintId = 'count-hint';
 
   return (
     <div className="home-page animate-fade-in">
@@ -272,11 +294,25 @@ export function HomePage({ onStartQuiz }: HomePageProps) {
               type="number"
               id="count"
               min={1}
-              max={100}
+              max={QUESTION_COUNT_MAX}
               value={questionCountInput}
               onChange={handleCountChange}
+              onBlur={handleCountBlur}
               aria-label="題數"
+              aria-invalid={!canStartQuiz}
+              aria-describedby={countHintId}
             />
+            <p
+              id={countHintId}
+              className={`config-item__hint${canStartQuiz ? '' : ' config-item__hint--error'}`}
+              role="status"
+              aria-live="polite"
+              aria-atomic="true"
+            >
+              {canStartQuiz
+                ? `請輸入 1–${QUESTION_COUNT_MAX} 之間的整數`
+                : `請輸入 1–${QUESTION_COUNT_MAX} 之間的題數才能開始測驗`}
+            </p>
           </div>
 
           {/* 隨機排序 */}


### PR DESCRIPTION
- Changed button text from "開始" to "開始測驗" in HomePage tests and component.
- Implemented input validation for question count, ensuring it clamps to a minimum of 1 and a maximum of 100.
- Disabled the start button when the question count is invalid (empty or less than 1).
- Updated tests to reflect these changes and ensure proper functionality.