### PR TITLE
ci(labeler): switch to pull_request_target so fork PRs can be labeled

### DIFF
--- a/.github/workflows/quiz-app-labeler.yml
+++ b/.github/workflows/quiz-app-labeler.yml
@@ -1,11 +1,23 @@
 # 自動標籤
 # 根據檔案變更自動為 PR 加上標籤
-# 最後更新：2026-01-22
+# 最後更新：2026-05-03
+#
+# 為何使用 pull_request_target：
+# - 從 fork 來的 PR 在 `pull_request` 事件下，GITHUB_TOKEN 會被 GitHub 強制降為唯讀，
+#   即使 workflow 宣告 `pull-requests: write` 也不生效，labeler 會回 403
+#   「Resource not accessible by integration」。
+# - 改用 pull_request_target 讓此 workflow 在 base repo 權限下執行 → labeler 可加 label。
+#
+# ⚠️ 安全注意：pull_request_target 會以 base repo 的高權限執行。
+# - 此 workflow **故意不 checkout PR 程式碼**（actions/labeler 只透過 GitHub API 讀
+#   changed-files metadata，不需要原始碼），所以不會執行任何 fork 提供的程式碼。
+# - 若未來新增 step，**禁止**做 `actions/checkout` ref 指向 PR HEAD
+#   （`github.event.pull_request.head.sha` 或類似），那會把 fork 的程式碼以高權限執行。
 
 name: Quiz App Labeler
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened]
     paths:
       - 'quiz-app/**'


### PR DESCRIPTION
## Summary
- Fork PR 在 `pull_request` 事件下，GitHub 會強制把 `GITHUB_TOKEN` 降為唯讀（即使 workflow 宣告 `pull-requests: write` 也無效），導致 `actions/labeler` 回 403 `Resource not accessible by integration`。實例：#56 的 `Label PR` job 失敗。
- 改用 `pull_request_target`：workflow 在 base repo 權限下執行，labeler 可正常加 label。
- 此 workflow **不 checkout PR 程式碼**，`actions/labeler` 僅透過 GitHub API 讀 changed-files metadata，**不執行任何 fork 提供的程式碼**，安全模型 OK。
- 在檔頭註解加上安全防護告示：未來新增 step **禁止** checkout PR HEAD（`github.event.pull_request.head.sha`）—— 那會在 base 權限下執行 fork 程式碼，是公認的供應鏈攻擊面。

## 為何 `pull_request_target` 是安全的（給未來 reviewer 參考）
| 風險面 | 此 workflow 是否觸及 |
|---|---|
| 執行 fork 程式碼 | ❌ 無 `actions/checkout`、無 `run:` 跑 PR scripts |
| 讀取 secrets 並回吐 PR | ❌ 僅用 `secrets.GITHUB_TOKEN` 呼叫 labels API，無回吐 |
| 用 PR-controlled config 跑 action | ❌ `configuration-path: .github/labeler.yml` 從 base repo 載入，非 PR |

## Test plan
- [ ] 合併後在下一支 fork PR（例如 #56 的下一次 sync）觀察 `Label PR` job 由紅轉綠
- [ ] 觀察 PR 被自動依 `quiz-app/**` 規則加上對應 label
- [ ] 確認其他 workflow（`quiz-app-ci.yml`、`quiz-app-codeql.yml` 等）行為不變