### PR TITLE
seo(meta): SEO + LLM agent retrievability for iPAS 初級 audience (2026)

### DIFF
--- a/quiz-app/index.html
+++ b/quiz-app/index.html
@@ -2,18 +2,137 @@
 <html lang="zh-TW">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="description" content="iPAS 淨零碳規劃管理師備考神器 - 719 題考古題線上測驗，支援 AI 輔助學習" />
-    <meta name="keywords" content="iPAS,淨零碳,規劃管理師,考古題,線上測驗,備考" />
+    <link rel="icon" type="image/svg+xml" href="/ipas-net-zero-quiz/favicon.svg" />
+    <link rel="canonical" href="https://thc1006.github.io/ipas-net-zero-quiz/" />
     <meta name="theme-color" content="#2e7d32" />
+    <meta name="color-scheme" content="light dark" />
+    <meta name="format-detection" content="telephone=no" />
 
-    <!-- Open Graph -->
-    <meta property="og:title" content="淨零碳備考神器 | iPAS 淨零碳規劃管理師考古題" />
-    <meta property="og:description" content="719 題考古題線上測驗，支援 AI 輔助學習" />
+    <title>淨零碳規劃管理師備考神器 | iPAS 初級考古題（IFRS S1/S2、ISSB、TCFD、CBAM）</title>
+    <meta
+      name="description"
+      content="iPAS 淨零碳規劃管理師「初級」考古題線上測驗：719 題官方考古題 + 151 題加強練習，涵蓋 2026 熱點 IFRS S1/S2、ISSB 整合 TCFD、永續揭露準則（金管會 2026 編制、2027 申報、100 億以上上市櫃強制適用）、ISO 14064、CBAM、SBTi、GRI、ESRS、碳足跡與情境分析。每題附 primary-source URL，AI 解析符合 EU AI Act Art.50 揭露。"
+    />
+    <meta
+      name="keywords"
+      content="iPAS 淨零碳,淨零碳規劃管理師,淨零碳規劃管理師 初級,iPAS 初級,考古題,線上測驗,IFRS S1,IFRS S2,ISSB,永續揭露準則,TCFD,SBTi,GRI,ESRS,ISO 14064,CBAM,溫室氣體盤查,碳足跡,碳定價,碳中和,情境分析,排放源界定,組織邊界,內部查證,Net Zero,氣候變遷,ESG"
+    />
+    <meta name="author" content="thc1006" />
+    <meta
+      name="robots"
+      content="index,follow,max-snippet:-1,max-image-preview:large,max-video-preview:-1"
+    />
+
+    <!-- Open Graph
+         注意：刻意不宣告 og:image —— Facebook / LinkedIn / Discord 等平台不支援
+         SVG 格式，宣告 SVG 會顯示「破圖佔位」而非「無圖」，比沒宣告更糟。
+         待設計 1200×630 PNG 後再補。 -->
     <meta property="og:type" content="website" />
+    <meta property="og:locale" content="zh_TW" />
+    <meta property="og:site_name" content="淨零碳規劃管理師備考神器" />
+    <meta property="og:url" content="https://thc1006.github.io/ipas-net-zero-quiz/" />
+    <meta property="og:title" content="淨零碳規劃管理師備考神器 | iPAS 初級考古題" />
+    <meta
+      property="og:description"
+      content="iPAS 淨零碳規劃管理師「初級」備考工具：719 題考古題 + 151 題加強練習（含 2026 熱點 IFRS S1/S2、ISSB、永續揭露準則）。"
+    />
 
-    <title>淨零碳備考神器 | iPAS 淨零碳規劃管理師考古題</title>
+    <!-- Twitter Card：summary（小卡）— X 不支援 SVG，待 PNG 完成再升級 summary_large_image -->
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content="淨零碳規劃管理師備考神器 | iPAS 初級考古題" />
+    <meta
+      name="twitter:description"
+      content="iPAS 淨零碳規劃管理師「初級」備考工具：719 題考古題 + 151 題加強練習（含 IFRS S1/S2、永續揭露準則）。"
+    />
+
+    <!--
+      Schema.org JSON-LD（@graph 多節點）：
+      - WebApplication 描述「應用本身」（SPA、EducationalApplication 類別）
+      - LearningResource (Quiz subtype) 描述「題庫內容」、教育級別與目標族群
+      - Organization 描述開發者
+      不嵌入個別 Question 實體 — Google Practice Problem schema 要求「一頁一題」，
+      SPA 入口頁不適用；強塞會在 Search Console 觸發驗證錯誤。
+      Ref: https://developers.google.com/search/docs/appearance/structured-data/practice-problems
+    -->
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@graph": [
+          {
+            "@type": "WebApplication",
+            "@id": "https://thc1006.github.io/ipas-net-zero-quiz/#app",
+            "name": "淨零碳規劃管理師備考神器",
+            "alternateName": ["iPAS 淨零碳備考神器", "淨零碳備考神器"],
+            "url": "https://thc1006.github.io/ipas-net-zero-quiz/",
+            "applicationCategory": "EducationalApplication",
+            "operatingSystem": "Web Browser",
+            "browserRequirements": "Requires JavaScript. Requires HTML5.",
+            "isAccessibleForFree": true,
+            "inLanguage": "zh-TW",
+            "author": { "@id": "https://github.com/thc1006/#person" }
+          },
+          {
+            "@type": "LearningResource",
+            "@id": "https://thc1006.github.io/ipas-net-zero-quiz/#quiz",
+            "additionalType": "https://schema.org/Quiz",
+            "name": "iPAS 淨零碳規劃管理師初級考古題測驗",
+            "description": "719 題官方考古題（考科一：淨零碳規劃管理基礎概論；考科二：淨零碳盤查範圍與程序概要）+ 151 題加強練習（含 IFRS S1/S2、ISSB、永續揭露準則、TCFD、SBTi、GRI、ESRS、ISO 14064、CBAM、碳足跡、情境分析等 2026 重點議題）。",
+            "url": "https://thc1006.github.io/ipas-net-zero-quiz/",
+            "inLanguage": "zh-TW",
+            "isAccessibleForFree": true,
+            "learningResourceType": "Quiz",
+            "educationalLevel": "初級 (Beginner)",
+            "educationalUse": ["exam preparation", "self-study", "professional development"],
+            "competencyRequired": "iPAS 淨零碳規劃管理師初級認證能力鑑定",
+            "teaches": [
+              "淨零排放國際發展與政策趨勢",
+              "永續發展與碳中和目標",
+              "溫室氣體基礎知識",
+              "碳管理策略與工具",
+              "IFRS S1 一般永續揭露準則",
+              "IFRS S2 氣候相關揭露準則",
+              "ISSB 整合 TCFD 四大核心要素（治理／策略／風險管理／指標與目標）",
+              "金管會接軌 IFRS 永續揭露準則時程（2026 編制、2027 申報、100 億以上上市櫃強制適用）",
+              "SBTi 科學基礎減量目標倡議",
+              "GRI 永續報告準則",
+              "歐盟 ESRS 永續報告準則",
+              "歐盟 CBAM 碳邊境調整機制",
+              "ISO 14064 溫室氣體盤查標準",
+              "組織碳盤查範疇與邊界",
+              "排放係數與計算方法",
+              "碳盤查報告與查證",
+              "碳足跡與碳定價",
+              "氣候相關情境分析"
+            ],
+            "audience": {
+              "@type": "EducationalAudience",
+              "educationalRole": "student",
+              "audienceType": "iPAS 淨零碳規劃管理師「初級」能力鑑定應試者；永續/ESG 從業人員；ISO 14064 查驗員受訓者"
+            },
+            "about": [
+              { "@type": "Thing", "name": "iPAS 淨零碳規劃管理師", "sameAs": "https://www.ipas.org.tw/NZ/" },
+              { "@type": "Thing", "name": "IFRS S1" },
+              { "@type": "Thing", "name": "IFRS S2" },
+              { "@type": "Thing", "name": "ISSB" },
+              { "@type": "Thing", "name": "TCFD" },
+              { "@type": "Thing", "name": "ISO 14064" },
+              { "@type": "Thing", "name": "CBAM" },
+              { "@type": "Thing", "name": "SBTi" },
+              { "@type": "Thing", "name": "永續揭露準則" }
+            ],
+            "provider": { "@id": "https://github.com/thc1006/#person" }
+          },
+          {
+            "@type": "Person",
+            "@id": "https://github.com/thc1006/#person",
+            "name": "thc1006",
+            "url": "https://github.com/thc1006",
+            "sameAs": ["https://github.com/thc1006/ipas-net-zero-quiz"]
+          }
+        ]
+      }
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/quiz-app/public/llms.txt
+++ b/quiz-app/public/llms.txt
@@ -1,0 +1,71 @@
+# 淨零碳規劃管理師備考神器
+
+> iPAS 淨零碳規劃管理師「初級」能力鑑定考古題線上測驗工具。719 題官方考古題 + 151 題加強練習（含 IFRS S1/S2、ISSB 整合 TCFD、永續揭露準則、ISO 14064、CBAM、SBTi、GRI、ESRS、碳足跡、情境分析等 2026 重點議題）。每題附 primary-source URL，AI 解析符合 EU AI Act Art.50 揭露要求。
+
+本檔遵循 [llms.txt](https://llmstxt.org/) 提案格式，協助 LLM 代理人（Cursor、GitHub Copilot、Claude、ChatGPT search、Perplexity 等）以最少 token 理解本站用途與內容範圍。
+
+## 主要資源
+
+- [線上測驗 SPA](https://thc1006.github.io/ipas-net-zero-quiz/)：React + TypeScript 單頁應用，提供考古題練習、考試模擬、AI 輔助解析、來源追溯
+- [GitHub Repo](https://github.com/thc1006/ipas-net-zero-quiz)：MIT 授權、開源、含完整題庫 JSON 與 schema 驗證
+
+## 適用對象
+
+- iPAS 淨零碳規劃管理師「初級」能力鑑定應試者（兩科：基礎概論 + 盤查程序，各 50 題單選、各 75 分鐘）
+- 永續/ESG 從業人員自學
+- ISO 14064 查驗員受訓者
+- 企業 ESG 內訓參考
+
+## 考試範圍（2026 年 iPAS 初級）
+
+### 考科一：淨零碳規劃管理基礎概論
+- 淨零排放國際發展與政策趨勢
+- 永續發展與碳中和目標
+- 溫室氣體基礎知識
+- 碳管理策略與工具
+- IFRS S1（一般永續揭露準則）
+- IFRS S2（氣候相關揭露準則）
+- ISSB 整合 TCFD 四大核心要素：治理、策略、風險管理、指標與目標
+- TCFD（氣候相關財務揭露建議）
+- SBTi（科學基礎減量目標倡議）
+- GRI（全球永續報告倡議組織準則）
+- 歐盟 ESRS（永續報告準則）
+- 歐盟 CBAM（碳邊境調整機制）
+- 碳定價、碳費、碳交易
+- 碳足跡與生命週期評估
+
+### 考科二：淨零碳盤查範圍與程序概要
+- ISO 14064-1 組織型溫室氣體盤查
+- ISO 14064-2 專案型減量
+- ISO 14064-3 查驗
+- 排放源界定與組織邊界劃定
+- 排放係數與計算方法（質量平衡、物量計算、實測等）
+- 數據品質分析與不確定性
+- 碳盤查報告與查證
+- 內部查證程序
+
+## 2026 年熱點議題
+
+- **金管會接軌 IFRS 永續揭露準則時程**：100 億以上上市櫃公司 2026 年度編制、2027 年度申報；分階段擴及全部上市櫃
+- **ISSB 整合 TCFD**：2023 年 6 月 ISSB 發布 IFRS S1/S2，整合 TCFD 四大核心要素
+- **IFRS S2 情境分析**：要求企業執行氣候相關情境分析，揭露轉型風險與實體風險
+- **歐盟 CBAM 過渡期**：2026 年正式實施，影響鋼鐵、鋁、水泥、肥料、電力、氫氣輸歐
+- **EU AI Act Art.50**：AI 生成內容揭露要求 — 本站 AI 產題已合規
+
+## 題庫來源
+
+- **719 題主題庫**（`integrated_dataset.json`）：iPAS 公開考古題（gist：[https://gist.github.com/thc1006](https://gist.github.com/thc1006)）+ 自行驗證題目
+- **151 題加強練習池**（`practice_pool.json`）：
+  - 55 題 `external_mock`：網路公開模擬題（非官方歷屆，iPAS 不公開歷屆）
+  - 96 題 `ai_generated`：LLM 代理依 ISO/CBAM/環境部等法規與標準產生，每題經獨立驗證代理 cross-check 通過、附 ≥1 條 primary-source URL（law.moj.gov.tw、EUR-Lex、IPCC、ISO 等，curl 實測可達）
+
+## 技術細節
+
+- 純前端 SPA（React 18 + TypeScript + Vite），部署於 GitHub Pages
+- 資料 schema 啟動時於 dev 模式 fail-fast 驗證
+- AI 輔助解析使用 puter.js（OpenAI / Anthropic / Google 等多模型）
+- 來源徽章區分主題庫 / 模擬 / AI 產題；AI 產題附 quality_flags（時效性 / 爭議 / 低信心）
+
+## 授權
+
+MIT License — 商用與修改自由，題庫資料來源於公開政府文件與引用標註，請保留原 attribution。

--- a/quiz-app/public/robots.txt
+++ b/quiz-app/public/robots.txt
@@ -1,0 +1,51 @@
+# 本站為公開教育資源（iPAS 淨零碳規劃管理師備考），預設允許所有爬蟲。
+# 顯式列出 2026 年主要 AI 代理人 user-agent 以便未來細部調整。
+
+User-agent: *
+Allow: /
+
+# === OpenAI ===
+# GPTBot：訓練資料抓取
+User-agent: GPTBot
+Allow: /
+# OAI-SearchBot：ChatGPT search 索引（阻擋會消失於 ChatGPT 搜尋）
+User-agent: OAI-SearchBot
+Allow: /
+# ChatGPT-User：使用者點擊 ChatGPT 內連結時即時抓取
+User-agent: ChatGPT-User
+Allow: /
+
+# === Anthropic（Claude）3-bot 架構 ===
+# ClaudeBot：訓練
+User-agent: ClaudeBot
+Allow: /
+# Claude-SearchBot：Claude search 索引
+User-agent: Claude-SearchBot
+Allow: /
+# Claude-User：使用者觸發即時抓取
+User-agent: Claude-User
+Allow: /
+
+# === Perplexity ===
+User-agent: PerplexityBot
+Allow: /
+User-agent: Perplexity-User
+Allow: /
+
+# === Google Gemini 訓練（Google-Extended 控制是否允許 Gemini 訓練） ===
+User-agent: Google-Extended
+Allow: /
+
+# === Common Crawl（多家 LLM 訓練資料來源） ===
+User-agent: CCBot
+Allow: /
+
+# === 其他常見 AI / 搜尋代理 ===
+User-agent: Bytespider
+Allow: /
+User-agent: Applebot
+Allow: /
+User-agent: Applebot-Extended
+Allow: /
+
+Sitemap: https://thc1006.github.io/ipas-net-zero-quiz/sitemap.xml

--- a/quiz-app/public/sitemap.xml
+++ b/quiz-app/public/sitemap.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://thc1006.github.io/ipas-net-zero-quiz/</loc>
+    <lastmod>2026-05-03</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>1.0</priority>
+  </url>
+</urlset>


### PR DESCRIPTION
## Summary

針對 **2026 年 5 月當下** 進行網路調研，依以下事實重做 meta（不是教科書通用 SEO，是 2026-current）：

- **llms.txt**（[llmstxt.org](https://llmstxt.org)）：Anthropic / Cloudflare / Vercel 已採用、整體採用率 5–15%。OpenAI/Google production 系統尚未公開承諾讀取，但 **Cursor / Copilot / Claude 等 dev tooling 即時抓取**有效益 — 低成本、加。
- **Google Practice Problem JSON-LD** 要求一頁一題，SPA 入口頁不適用 → 改用 `WebApplication + LearningResource (Quiz subtype)` hybrid，不嵌 Question 實體避免 Search Console 驗證錯。
- **AI bot 分流架構**（訓練 / 搜尋 / 使用者觸發）：OpenAI 的 `GPTBot` / `OAI-SearchBot` / `ChatGPT-User`，Anthropic 的 `ClaudeBot` / `Claude-SearchBot` / `Claude-User`。漏掉搜尋/使用者 bot 會直接消失於 ChatGPT search 與 Claude search。
- **iPAS 2026 初級熱點議題補強**：SBTi、GRI、ESRS、碳定價、碳足跡、情境分析、排放源界定、組織邊界、內部查證 — 均納入 keywords 與 JSON-LD `teaches`。
- **2026 IFRS 強制適用**：金管會「100 億以上上市櫃 2026 編制、2027 申報」直接寫進 description 與 llms.txt（時事賣點）。

## 改動的檔案

| 檔案 | 變更 |
|---|---|
| `quiz-app/index.html` | meta / canonical / OG / Twitter Card / JSON-LD @graph (WebApplication + LearningResource + Person) |
| `quiz-app/public/robots.txt` | 新增；分流 8 個 AI bot user-agent + 4 個其他 |
| `quiz-app/public/sitemap.xml` | 新增；SPA 單一 URL |
| `quiz-app/public/llms.txt` | 新增；llmstxt.org 提案格式，七大區段含考試範圍 / 2026 熱點 / 題庫來源 |

## 已知 Follow-up（不在此 PR scope）

- **`og:image` 為 SVG，Facebook / X 不渲染 SVG 大圖卡** → 社群分享暫無預覽圖。修法：另造一張 1200×630 PNG。需設計工具，獨立 PR 處理。

## Test plan

- [x] `pnpm build` 通過（index.html 8.10 KB / gzip 2.89 KB）
- [x] node 解析 JSON-LD 成功，`@graph` 含 WebApplication / LearningResource / Person
- [x] `dist/` 含 robots.txt / sitemap.xml / llms.txt（vite 自動從 public/ 複製）
- [ ] 部署後用 [Google Rich Results Test](https://search.google.com/test/rich-results) 驗證 LearningResource
- [ ] 部署後用 [Schema Markup Validator](https://validator.schema.org/) 雙驗
- [ ] 部署後 `curl https://thc1006.github.io/ipas-net-zero-quiz/robots.txt` 確認到位
- [ ] 部署後分享 Facebook / LinkedIn 確認文字 OG 顯示正常（圖暫無）