### PR TITLE
ci(coverage): align vitest/codecov ignore + ResultPage smoke tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# 淨零碳備考神器 | iPAS 淨零碳規劃管理師考古題
+# 淨零碳規劃管理師備考神器 | iPAS 淨零碳規劃管理師考古題
 
 [![Deploy Quiz App to GitHub Pages](https://github.com/thc1006/ipas-net-zero-quiz/actions/workflows/quiz-app-deploy.yml/badge.svg)](https://github.com/thc1006/ipas-net-zero-quiz/actions/workflows/quiz-app-deploy.yml)
 [![Quiz App CI](https://github.com/thc1006/ipas-net-zero-quiz/actions/workflows/quiz-app-ci.yml/badge.svg?branch=main)](https://github.com/thc1006/ipas-net-zero-quiz/actions/workflows/quiz-app-ci.yml)
@@ -23,7 +23,7 @@
 
 | 來源 | 題數 | 說明 |
 |---|---|---|
-| `external_mock` | 55 | 取自 vocus 講師、HackMD、yamol 等公開模擬題（非官方歷屆，iPAS 不公開歷屆）|
+| `external_mock` | 55 | 取自網路公開之模擬題（非官方歷屆，iPAS 不公開歷屆）|
 | `ai_generated` | 96 | 由 LLM 代理依 ISO/CBAM/環境部等法規與標準產生，每題經獨立驗證代理 cross-check 通過，並附 ≥1 條 primary-source URL（law.moj.gov.tw、EUR-Lex、IPCC、ISO 等，curl 實測可達）|
 
 每題顯示來源徽章（「模擬題」/「AI 產題」），AI 產題用警示色 + 邊框與 quality_flags（時效性 / 爭議 / 低信心）chips。資料 schema 在啟動時於 dev 模式 fail-fast 驗證。

--- a/codecov.yml
+++ b/codecov.yml
@@ -2,6 +2,9 @@
 # - patch coverage threshold: 80% (PR 改動的行)
 # - project coverage threshold: 不退步 (auto)
 # - ignore: 設定檔、測試檔本身、entry-point bootstrap、generated assets
+#
+# 此清單與 quiz-app/vitest.config.ts 的 coverage.exclude 同步維護，
+# 兩邊不對齊會造成 codecov 顯示與本地數字不一致。
 coverage:
   status:
     patch:
@@ -14,20 +17,32 @@ coverage:
         threshold: 1%
 
 ignore:
-  # Vite / Vitest / ESLint 等 build 設定檔不該算 coverage
+  # Vite / Vitest / ESLint / Playwright 等 build & tooling 設定檔
   - "**/*.config.ts"
   - "**/*.config.js"
   - "**/*.config.mjs"
+  - "**/*.config.cjs"
+  - "**/eslint.config.js"
+  - "**/eslint.config.ts"
+  - "**/eslint.config.mjs"
   - "**/.eslintrc*"
+  - "quiz-app/playwright.config.ts"
+  - "quiz-app/vite.config.ts"
+  - "quiz-app/vitest.config.ts"
   # 測試 setup 與測試檔本身
   - "**/test-setup.ts"
   - "**/*.test.ts"
   - "**/*.test.tsx"
+  # E2E spec — Playwright runtime，不在 unit coverage 範疇
+  - "quiz-app/tests/**"
   # Entry point — bootstrap-only side effects；E2E 覆蓋
   - "quiz-app/src/main.tsx"
+  # 純 re-export barrel files（index.ts 無邏輯，覆蓋率無意義）
+  - "quiz-app/src/**/index.ts"
   # 純資料 / 型別宣告
   - "quiz-app/src/data/*.json"
   - "quiz-app/src/types/**"
+  - "**/*.d.ts"
   # ai-helper.ts catch blocks 需要 mock puter.js + puter.ai.chat fail，
   # 屬整合測試範疇，留 follow-up PR 處理
   - "quiz-app/src/utils/ai-helper.ts"

--- a/quiz-app/src/pages/ResultPage.test.tsx
+++ b/quiz-app/src/pages/ResultPage.test.tsx
@@ -1,0 +1,215 @@
+// ResultPage smoke + branch coverage
+// 重點：score 評語分支、stats 渲染、wrongAnswers 分支、handleExport、操作按鈕。
+// AI streaming 路徑需要 puter.js 全 mock，屬整合測試範疇，不在此檔涵蓋。
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import type { QuizResult, QuizQuestion, AnswerRecord } from '../types/quiz';
+
+// 在 import ResultPage 前先 mock 資料層，否則 ResultPage import 時會吃真實題庫
+vi.mock('../data/questions', () => {
+  const fixture: QuizQuestion = {
+    id: 'fx-001',
+    number: 1,
+    stem: '測試題目：下列何者為溫室氣體？',
+    options: [
+      { key: 'A', text: 'CO2' },
+      { key: 'B', text: 'O2' },
+      { key: 'C', text: 'N2' },
+      { key: 'D', text: 'Ar' },
+    ],
+    answer: 'A',
+    subject: '考科1',
+    section: 'fixture',
+    explanation: '二氧化碳為主要溫室氣體',
+  } as unknown as QuizQuestion;
+  return {
+    allQuestions: [fixture],
+    getQuestionById: (id: string) => (id === 'fx-001' ? fixture : undefined),
+    getSimilarQuestions: () => [],
+    stats: { total: 1, subject1: 1, subject2: 0 },
+  };
+});
+
+// ai-helper streaming 函式不執行（不寫 AI 測試）
+vi.mock('../utils/ai-helper', () => ({
+  explainQuestionStream: vi.fn(),
+  generateSimilarQuestionStream: vi.fn(),
+}));
+
+import { ResultPage } from './ResultPage';
+
+afterEach(() => {
+  cleanup();
+  // 還原 prototype spy（如 HTMLAnchorElement.prototype.click），避免跨測試殘留
+  vi.restoreAllMocks();
+});
+
+beforeAll(() => {
+  // jsdom 沒實作 createObjectURL / revokeObjectURL — handleExport 需要
+  if (!URL.createObjectURL) {
+    Object.defineProperty(URL, 'createObjectURL', {
+      value: vi.fn(() => 'blob:mock'),
+      writable: true,
+    });
+  }
+  if (!URL.revokeObjectURL) {
+    Object.defineProperty(URL, 'revokeObjectURL', {
+      value: vi.fn(),
+      writable: true,
+    });
+  }
+});
+
+function makeAnswer(overrides: Partial<AnswerRecord> = {}): AnswerRecord {
+  return {
+    questionId: 'fx-001',
+    selectedAnswer: 'B',
+    correctAnswer: 'A',
+    isCorrect: false,
+    timeSpent: 5000,
+    timestamp: Date.now(),
+    ...overrides,
+  };
+}
+
+function makeResult(overrides: Partial<QuizResult> = {}): QuizResult {
+  return {
+    config: {
+      mode: 'practice',
+      subject: 'all',
+      questionCount: 1,
+      shuffleQuestions: false,
+      shuffleOptions: false,
+      showAnswerImmediately: true,
+    },
+    startTime: 1_700_000_000_000,
+    endTime: 1_700_000_065_000,
+    totalTime: 65_000,
+    answers: [],
+    score: 100,
+    totalAnswerable: 1,
+    correctCount: 1,
+    wrongCount: 0,
+    skippedCount: 0,
+    ...overrides,
+  };
+}
+
+describe('ResultPage', () => {
+  it('renders score, formatted time, and base stats', () => {
+    render(
+      <ResultPage
+        result={makeResult({ score: 88, totalTime: 125_000 })}
+        onGoHome={() => {}}
+        onRetry={() => {}}
+      />
+    );
+    expect(screen.getByText('88')).toBeInTheDocument();
+    expect(screen.getByText(/2 分 5 秒/)).toBeInTheDocument();
+  });
+
+  it.each([
+    [100, /太棒了/],
+    [95, /太棒了/],
+    [90, /太棒了/], // 邊界
+    [89, /不錯喔/], // 邊界（90 邊界另一側）
+    [75, /不錯喔/],
+    [70, /不錯喔/], // 邊界
+    [69, /及格了/], // 邊界（70 邊界另一側）
+    [60, /及格了/], // 邊界
+  ])('score=%i → 顯示對應評語 %s', (score, pattern) => {
+    render(
+      <ResultPage result={makeResult({ score })} onGoHome={() => {}} onRetry={() => {}} />
+    );
+    expect(screen.getByText(pattern)).toBeInTheDocument();
+  });
+
+  it('score < 60 → 再加油 評語', () => {
+    render(
+      <ResultPage result={makeResult({ score: 30 })} onGoHome={() => {}} onRetry={() => {}} />
+    );
+    expect(screen.getByText(/再加油/)).toBeInTheDocument();
+  });
+
+  it('no wrong answers → does not render 錯誤題目 section', () => {
+    render(
+      <ResultPage result={makeResult()} onGoHome={() => {}} onRetry={() => {}} />
+    );
+    expect(screen.queryByText(/錯誤題目/)).toBeNull();
+  });
+
+  it('with wrong answers → renders 錯誤題目 section + AI 免責 + 題庫相似題 toggle', () => {
+    render(
+      <ResultPage
+        result={makeResult({
+          score: 0,
+          correctCount: 0,
+          wrongCount: 1,
+          answers: [makeAnswer()],
+        })}
+        onGoHome={() => {}}
+        onRetry={() => {}}
+      />
+    );
+    expect(screen.getByText(/錯誤題目 \(1 題\)/)).toBeInTheDocument();
+    expect(screen.getByText(/AI 輔助功能說明/)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /AI 解析/ })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /AI 生成相似題/ })).toBeInTheDocument();
+
+    // toggle 題庫相似題（getSimilarQuestions 已 mock 為空陣列，分支仍走過）
+    const bankBtn = screen.getByRole('button', { name: /題庫相似題/ });
+    fireEvent.click(bankBtn);
+    expect(screen.getByRole('button', { name: /收起題庫相似題/ })).toBeInTheDocument();
+  });
+
+  it('onGoHome / onRetry 按鈕觸發 callback', () => {
+    const onGoHome = vi.fn();
+    const onRetry = vi.fn();
+    render(
+      <ResultPage result={makeResult()} onGoHome={onGoHome} onRetry={onRetry} />
+    );
+    fireEvent.click(screen.getByRole('button', { name: /返回首頁/ }));
+    fireEvent.click(screen.getByRole('button', { name: /再測一次/ }));
+    expect(onGoHome).toHaveBeenCalledOnce();
+    expect(onRetry).toHaveBeenCalledOnce();
+  });
+
+  it('匯出結果：呼叫 createObjectURL + a.click + revokeObjectURL', () => {
+    const createSpy = vi.spyOn(URL, 'createObjectURL');
+    const revokeSpy = vi.spyOn(URL, 'revokeObjectURL');
+    const clickSpy = vi
+      .spyOn(HTMLAnchorElement.prototype, 'click')
+      .mockImplementation(() => {});
+
+    render(
+      <ResultPage
+        result={makeResult({
+          wrongCount: 1,
+          answers: [makeAnswer()],
+        })}
+        onGoHome={() => {}}
+        onRetry={() => {}}
+      />
+    );
+    fireEvent.click(screen.getByRole('button', { name: /匯出結果/ }));
+
+    expect(createSpy).toHaveBeenCalled();
+    expect(clickSpy).toHaveBeenCalled();
+    expect(revokeSpy).toHaveBeenCalled();
+  });
+
+  it('wrongAnswers 中找不到題目 → 該項以 null 跳過、不 throw', () => {
+    render(
+      <ResultPage
+        result={makeResult({
+          wrongCount: 1,
+          answers: [makeAnswer({ questionId: 'unknown-id' })],
+        })}
+        onGoHome={() => {}}
+        onRetry={() => {}}
+      />
+    );
+    // section 仍渲染，但內部沒有 wrong-item
+    expect(screen.getByText(/錯誤題目 \(1 題\)/)).toBeInTheDocument();
+  });
+});

--- a/quiz-app/vitest.config.ts
+++ b/quiz-app/vitest.config.ts
@@ -11,13 +11,34 @@ export default defineConfig({
     include: ['src/**/*.test.ts', 'src/**/*.test.tsx'],
     coverage: {
       provider: 'v8',
-      reporter: ['text', 'json', 'html'],
+      reporter: ['text', 'json', 'html', 'lcov'],
+      // 注意：自訂 exclude 會「取代」vitest 預設的 exclude（不是 merge），
+      // 所以必須把 build/lint config、E2E spec、type-only 宣告等明確列出，
+      // 否則它們會被 v8 provider 偵測為 0% 拉低分母。
+      // 此清單與 codecov.yml 的 ignore 同步維護。
       exclude: [
         'node_modules/',
+        'dist/',
+        'coverage/',
+        // Build / lint / test configs
+        '**/*.config.{js,ts,mjs,cjs}',
+        '**/eslint.config.{js,ts,mjs}',
+        // E2E spec 走 Playwright，不該算 unit coverage
+        'tests/**',
+        // Test setup / 測試檔本身
         'src/test-setup.ts',
-        // Entry point — bootstrap-only side effects (createRoot + DEV-mode
-        // schema validate dynamic imports)；由 E2E 整合測試覆蓋
+        '**/*.test.{ts,tsx}',
+        // Entry point：bootstrap-only side effects；由 E2E 整合測試覆蓋
         'src/main.tsx',
+        // 純 re-export barrel files（無邏輯，覆蓋率無意義）
+        'src/**/index.ts',
+        // Type-only 宣告
+        'src/types/**',
+        '**/*.d.ts',
+        // 資料 fixtures
+        'src/data/*.json',
+        // 需要 puter.js + puter.ai.chat mock，屬整合測試範疇（codecov.yml 同步 ignore）
+        'src/utils/ai-helper.ts',
       ],
     },
   },


### PR DESCRIPTION
## Summary

讓 codecov 顯示的覆蓋率與本地一致，並補上長期被忽略的 ResultPage.tsx 測試。

| 指標 | Before | After |
|---|---|---|
| 本地行覆蓋（vitest） | 79.25% | **85.64%** |
| codecov（main）顯示 | 73.7% | 預計 ~85% |
| `src/pages/` | 59.04% | **81.04%** |
| `ResultPage.tsx` | 0.86% | ~80% |
| 測試總數 | 321 | **336**（HomePage 29 + ResultPage 15 + 其他 292） |

## 為何 codecov 顯示 73.7% 而本地 80%

- `vitest.config.ts` 設了自訂 `coverage.exclude` → **取代**（非合併）vitest 預設清單，導致 `eslint.config.js`、e2e specs 等被 v8 provider 偵測為 0% 拉低分母
- `codecov.yml` 與 vitest 不對齊（缺 `quiz-app/tests/**`、`index.ts` barrels、`playwright.config.ts` 顯式列舉）

## 改動

1. **`quiz-app/vitest.config.ts`**：明列完整 `coverage.exclude`（build/lint configs、tests/、re-export barrels、types、ai-helper.ts），加 `lcov` reporter 給 codecov 解析
2. **`codecov.yml`**：與 vitest exclude 同步、檔頭加上「兩邊同步維護」提示
3. **`quiz-app/src/pages/ResultPage.test.tsx`**（新檔，15 個測試）：
   - score 評語 8 段邊界（`it.each`：100/95/90/89/75/70/69/60，覆蓋 ≥90/≥70/≥60 三閾）
   - 有/無 wrong answers 兩種 render 路徑
   - 題庫相似題 toggle、onGoHome / onRetry callback
   - 匯出 JSON 流程（spy `URL.createObjectURL` + `a.click` + `revokeObjectURL`）
   - `getQuestionById` 找不到題目時不 throw
   - `afterEach` 加 `vi.restoreAllMocks()` 還原 `HTMLAnchorElement.prototype.click` 等 prototype spy
   - AI streaming 路徑需 puter.js 全 mock，屬整合測試範疇，不在此檔涵蓋
4. **`README.md`**：主標題改為「淨零碳規劃管理師備考神器」（與 SEO PR / 套件描述對齊）；模擬題來源說明改用較中性的「網路公開之模擬題」

## Test plan

- [x] `pnpm exec vitest run`：336/336 passed
- [x] `pnpm exec tsc --noEmit -p tsconfig.json`：clean
- [x] `pnpm lint`：無新警告（既有 6 個 `Unused eslint-disable directive` 為 pre-existing）
- [x] `pnpm exec vitest run --coverage`：85.64% lines
- [ ] codecov 上傳後確認 patch coverage ≥ 80% 達標