### PR TITLE
fix(useQuiz): dedupe answers by questionId on re-submit (closes #59)

### DIFF
--- a/quiz-app/src/hooks/useQuiz.test.ts
+++ b/quiz-app/src/hooks/useQuiz.test.ts
@@ -111,6 +111,87 @@ describe('useQuiz Hook', () => {
         1000
       );
     });
+
+    // === Regression: GH issue #59 — 回到上一題重新作答時不可重複新增紀錄 ===
+    it('重新作答同一題應覆蓋舊紀錄、不應追加（GH #59）', () => {
+      const { result } = renderHook(() => useQuiz());
+      act(() => {
+        result.current.startQuiz({ ...defaultConfig, questionCount: 3, shuffleQuestions: false });
+      });
+
+      // 第 1 題答 A → 下一題答 B → 回上一題改答 C
+      act(() => { result.current.submitAnswer('A'); });
+      act(() => { result.current.nextQuestion(); });
+      act(() => { result.current.submitAnswer('B'); });
+      act(() => { result.current.prevQuestion(); });
+      act(() => { result.current.submitAnswer('C'); });
+
+      // useQuiz 不直接公開 answers — 透過 progress.answered 與 finishQuiz() 驗證
+      expect(result.current.progress.answered).toBe(2);
+
+      let quizResult: ReturnType<typeof result.current.finishQuiz> = null;
+      act(() => {
+        quizResult = result.current.finishQuiz();
+      });
+      expect(quizResult!.answers).toHaveLength(2);
+
+      // 第 1 題保留最新的 C
+      const q1Record = quizResult!.answers.find(
+        (a) => a.selectedAnswer === 'C'
+      );
+      expect(q1Record).toBeDefined();
+      // 「A」紀錄應已被 C 覆蓋、不存在於最終結果
+      expect(quizResult!.answers.some((a) => a.selectedAnswer === 'A')).toBe(false);
+    });
+
+    it('currentAnswer 在重新作答後應反映最新選擇而非首次選擇（GH #59）', () => {
+      const { result } = renderHook(() => useQuiz());
+      act(() => {
+        result.current.startQuiz({ ...defaultConfig, questionCount: 3, shuffleQuestions: false });
+      });
+
+      // 第 1 題答 A
+      act(() => { result.current.submitAnswer('A'); });
+      expect(result.current.currentAnswer?.selectedAnswer).toBe('A');
+
+      // 移到 Q2 再回 Q1，改答 'C'
+      act(() => { result.current.nextQuestion(); });
+      act(() => { result.current.prevQuestion(); });
+      act(() => { result.current.submitAnswer('C'); });
+
+      // currentAnswer 應顯示 'C'（最新），而非 'A'（首次）。修法前 .find() 會回第一個 match → 'A'
+      expect(result.current.currentAnswer?.selectedAnswer).toBe('C');
+    });
+
+    it('finishQuiz 在重新作答後計分不應重複計算（GH #59）', () => {
+      const { result } = renderHook(() => useQuiz());
+      act(() => {
+        result.current.startQuiz({ ...defaultConfig, questionCount: 3, shuffleQuestions: false });
+      });
+
+      // 三題都先答錯（用一個不可能對的字串），再回去把第 1 題改成正解
+      act(() => { result.current.submitAnswer('Z'); });
+      act(() => { result.current.nextQuestion(); });
+      act(() => { result.current.submitAnswer('Z'); });
+      act(() => { result.current.nextQuestion(); });
+      act(() => { result.current.submitAnswer('Z'); });
+
+      // 回第 1 題，改答正解
+      act(() => { result.current.goToQuestion(0); });
+      const correctAnswer = result.current.currentQuestion?.answer;
+      if (correctAnswer == null) return; // 該題無答案則略過此 assertion
+      act(() => { result.current.submitAnswer(correctAnswer); });
+
+      let quizResult: ReturnType<typeof result.current.finishQuiz> = null;
+      act(() => {
+        quizResult = result.current.finishQuiz();
+      });
+
+      // 重點：3 題測驗作答 4 次（其中 1 題被覆蓋），最終 answers 應為 3 筆
+      expect(quizResult!.answers).toHaveLength(3);
+      // skippedCount 不應為負（修法前的 questions.length - answers.length 會算成負數）
+      expect(quizResult!.skippedCount).toBeGreaterThanOrEqual(0);
+    });
   });
 
   describe('nextQuestion / prevQuestion', () => {
@@ -234,12 +315,11 @@ describe('useQuiz Hook', () => {
         result.current.startQuiz({ ...defaultConfig, questionCount: 3 });
       });
 
-      // 作答幾題
-      act(() => {
-        result.current.submitAnswer('A');
-        result.current.nextQuestion();
-        result.current.submitAnswer('B');
-      });
+      // 注意：必須拆成獨立 act() — 同一個 act 內的多次呼叫會共享 stale closure，
+      // 兩次 submitAnswer 都會打到 questions[0]（currentIndex 還沒 flush）。
+      act(() => { result.current.submitAnswer('A'); });
+      act(() => { result.current.nextQuestion(); });
+      act(() => { result.current.submitAnswer('B'); });
 
       let quizResult: ReturnType<typeof result.current.finishQuiz> = null;
       act(() => {

--- a/quiz-app/src/hooks/useQuiz.ts
+++ b/quiz-app/src/hooks/useQuiz.ts
@@ -186,10 +186,17 @@ export function useQuiz() {
         sourceCategory,
       };
 
-      setState((prev) => ({
-        ...prev,
-        answers: [...prev.answers, record],
-      }));
+      // 同一題重新作答（使用者點「上一題」回到已作答題目改答案）時，
+      // 用 questionId 去重 — 覆蓋舊紀錄而非追加。否則 finishQuiz 的
+      // correctCount / wrongCount / skippedCount 都會把同一題算多次。
+      setState((prev) => {
+        const idx = prev.answers.findIndex((a) => a.questionId === record.questionId);
+        const answers =
+          idx >= 0
+            ? prev.answers.map((a, i) => (i === idx ? record : a))
+            : [...prev.answers, record];
+        return { ...prev, answers };
+      });
 
       // 練習模式下立即顯示答案
       if (config?.showAnswerImmediately) {


### PR DESCRIPTION
Closes #59

## 問題嚴重度：🔴 Product-killer

對「考試備考工具」而言**分數錯誤直接破壞核心承諾**。重現極易：使用者點「上一題」改答案 → 答案陣列重複追加 → `finishQuiz` 三個計數（`correctCount` / `wrongCount` / `skippedCount`）全部失真。

實例（20 題測驗、改 1 題答案）：
- `answers.length = 21`
- `skippedCount = questions.length(20) - 21 = -1`（負數！）
- 分數比例分母錯亂

## 修法

`useQuiz.ts:189-200` write-time dedup — `submitAnswer` 用 `questionId` 找既有紀錄，存在則覆蓋、不存在則 append。

```ts
setState((prev) => {
  const idx = prev.answers.findIndex((a) => a.questionId === record.questionId);
  const answers = idx >= 0
    ? prev.answers.map((a, i) => (i === idx ? record : a))
    : [...prev.answers, record];
  return { ...prev, answers };
});
```

選 write-time dedup 而非 finishQuiz-time dedup 的原因：
- source-of-truth 始終乾淨；下游所有讀者（`currentAnswer` derived、`progress.answered`、`finishQuiz`）天然受惠，不必各自去重
- `currentAnswer` 在重新作答後會自動更新（既有 derived state 不需改）

## 順手修的 pre-existing 測試缺陷

原 `finishQuiz` 測試「應回傳測驗結果」把 `submitAnswer + nextQuestion + submitAnswer` 塞同一個 `act()`，但 `submitAnswer` 的 `useCallback` closure 拍到 stale state（`currentIndex` 還沒 flush），**實際上兩次 submit 都打到 Q1**。舊行為純 append → 湊巧 `length=2` 通過，但測的是 bug 不是功能。

修法：拆成獨立 `act()` 區塊讓 closure 正確 refresh。

## Regression tests

1. **覆蓋語意**：Q1='A' → Q2='B' → 回 Q1='C' → `progress.answered === 2`、最終 answers 不含 'A'、含 'C'
2. **計分正確性**：3 題測驗作答 4 次（含 1 次覆蓋）→ `answers.length === 3`、`skippedCount >= 0`

## Test plan

- [x] `pnpm exec vitest run` — 338/338 pass
- [x] `pnpm exec tsc --noEmit -p tsconfig.json` — clean
- [x] `pnpm lint` — 無新警告
- [ ] 部署後手動 smoke：開測驗、回上一題改答案、完成 → 分數正確