### PR TITLE
chore(data+ci): time_sensitive backfill + primary-source URL research + workflow extension (closes #61)

### DIFF
--- a/.github/workflows/quarterly-time-sensitive-verify.yml
+++ b/.github/workflows/quarterly-time-sensitive-verify.yml
@@ -2,6 +2,14 @@
 # 對 quality_flags=time_sensitive 的題目，curl 每條 source URL 看是否仍 200 OK，
 # 失敗時自動開 GitHub issue 列出失效的題目供人工 re-verify。
 #
+# 掃描範圍（2026-05-04 起擴充）：
+# 1. quiz-app/src/data/practice_pool.json — pool items 的 sources[] 陣列
+# 2. quiz-app/src/data/integrated_dataset.json — 主庫
+#    - gist_items[]：透過 metadata.sources[] 陣列（若有）
+#    - our_unique_items[]：透過 source.url (object) + metadata.sources[]
+#    - URL-less gist items 仍可帶 time_sensitive flag 供人工 review，但
+#      workflow 不會 curl 驗證（無 URL 可驗）
+#
 # 觸發：每季 1 號 04:00 UTC（02:00 / 12:00 台北 — 視 dst）跑一次；
 # 也可手動透過 workflow_dispatch 觸發。
 
@@ -35,15 +43,48 @@ jobs:
         id: list
         run: |
           set -euo pipefail
+          : > pairs.tsv
+
+          # Pool items：sources[] 陣列
+          # URL scheme whitelist：只允許 http/https，避免 file:// 等 SSRF 面
           jq -r '
             .items[]
-            | select(.quality_flags | index("time_sensitive"))
+            | select((.quality_flags // []) | index("time_sensitive"))
             | .id as $id
-            | (.sources // [])[] | "\($id)\t\(.)"
-          ' quiz-app/src/data/practice_pool.json > urls.tsv
-          count=$(wc -l < urls.tsv)
-          echo "count=$count" >> "$GITHUB_OUTPUT"
-          echo "Found $count URL(s) to verify"
+            | (.sources // [])[]
+            | select(type=="string" and (startswith("https://") or startswith("http://")))
+            | "\($id)\t\(.)"
+          ' quiz-app/src/data/practice_pool.json >> pairs.tsv
+
+          # Main bank：gist_items + our_unique_items
+          # URL 來源 fallback：source.url (our_unique 結構化)、metadata.sources[] (兩者皆可)
+          # 無 URL 的 gist 題目即使有 time_sensitive flag 也跳過（workflow 不能驗證無 URL 項）
+          jq -r '
+            ([.gist_items // [], .our_unique_items // []] | add)[]
+            | select((.quality_flags // []) | index("time_sensitive"))
+            | (.item_id // ("gist-" + ((.index // 0) | tostring))) as $id
+            | (
+                [(.source | if type=="object" then .url else empty end)]
+                + [(.metadata.sources // [])[]]
+              )
+            | map(select(type=="string" and (startswith("https://") or startswith("http://"))))
+            | unique
+            | .[] as $u
+            | "\($id)\t\($u)"
+          ' quiz-app/src/data/integrated_dataset.json >> pairs.tsv
+
+          # 以 URL 為 key 真正去重 — 同 URL 出現在多題只 curl 一次，
+          # 失敗時報告會列出所有受影響題目 id（合併欄）
+          # 輸出格式：url\tid1,id2,id3
+          awk -F'\t' '
+            { ids[$2] = ids[$2] ? ids[$2]","$1 : $1 }
+            END { for (u in ids) print u "\t" ids[u] }
+          ' pairs.tsv | sort > urls.tsv
+
+          unique_count=$(wc -l < urls.tsv)
+          total_pairs=$(wc -l < pairs.tsv)
+          echo "count=$unique_count" >> "$GITHUB_OUTPUT"
+          echo "Found $unique_count unique URL(s) across $total_pairs (id, url) pairs"
           cat urls.tsv
 
       - name: Curl-check URLs
@@ -51,14 +92,18 @@ jobs:
         run: |
           set -euo pipefail
           : > failures.tsv
-          while IFS=$'\t' read -r id url; do
-            [ -z "$id" ] && continue
+          while IFS=$'\t' read -r url ids; do
+            [ -z "$url" ] && continue
+            # HEAD 先試（省流量）；遇到 CDN/WAF 拒絕 HEAD（403/405/000）再 fallback 到 GET
             status=$(curl -sIL --max-time 15 -A "Mozilla/5.0" -o /dev/null -w "%{http_code}" "$url" || echo "000")
+            if [ "$status" = "403" ] || [ "$status" = "405" ] || [ "$status" = "000" ]; then
+              status=$(curl -sL --max-time 15 -A "Mozilla/5.0" -o /dev/null -w "%{http_code}" "$url" || echo "000")
+            fi
             if [ "$status" != "200" ]; then
-              echo -e "$id\t$url\t$status" >> failures.tsv
-              echo "❌ $id $url → HTTP $status"
+              echo -e "$url\t$ids\t$status" >> failures.tsv
+              echo "❌ $url (ids: $ids) → HTTP $status"
             else
-              echo "✅ $id $url"
+              echo "✅ $url (ids: $ids)"
             fi
           done < urls.tsv
           fail_count=$(wc -l < failures.tsv)
@@ -72,8 +117,9 @@ jobs:
             const fs = require('fs');
             const lines = fs.readFileSync('failures.tsv', 'utf8').trim().split('\n').filter(Boolean);
             const items = lines.map(l => {
-              const [id, url, status] = l.split('\t');
-              return `- \`${id}\` — [${url}](${url}) HTTP ${status}`;
+              const [url, ids, status] = l.split('\t');
+              const idList = (ids || '').split(',').filter(Boolean).map(i => `\`${i}\``).join(', ');
+              return `- [${url}](${url}) HTTP ${status} — affected: ${idList}`;
             }).join('\n');
 
             const today = new Date().toISOString().slice(0, 10);

--- a/.github/workflows/quarterly-time-sensitive-verify.yml
+++ b/.github/workflows/quarterly-time-sensitive-verify.yml
@@ -87,25 +87,40 @@ jobs:
           echo "Found $unique_count unique URL(s) across $total_pairs (id, url) pairs"
           cat urls.tsv
 
-      - name: Curl-check URLs
+      - name: Curl-check URLs (parallel, with HEAD→GET fallback)
         id: curl
         run: |
           set -euo pipefail
-          : > failures.tsv
-          while IFS=$'\t' read -r url ids; do
-            [ -z "$url" ] && continue
-            # HEAD 先試（省流量）；遇到 CDN/WAF 拒絕 HEAD（403/405/000）再 fallback 到 GET
-            status=$(curl -sIL --max-time 15 -A "Mozilla/5.0" -o /dev/null -w "%{http_code}" "$url" || echo "000")
+
+          # Per-URL check 函式：
+          # - HEAD 先試（省流量）；CDN/WAF 拒 HEAD（403/405/000）→ fallback GET
+          # - --connect-timeout 5 + --max-time 10：總耗時上限約 20s/URL（HEAD+GET 兩次）
+          # - stdout：失敗時輸出 TSV（url\tids\tstatus），由 xargs 收集為 failures.tsv
+          # - stderr：人類可讀 log（✅/❌），由 GitHub Actions 顯示在 step output
+          check_url() {
+            local line="$1"
+            local url ids status
+            url="${line%%$'\t'*}"
+            ids="${line#*$'\t'}"
+            [ -z "$url" ] && return
+            status=$(curl -sIL --connect-timeout 5 --max-time 10 -A "Mozilla/5.0" -o /dev/null -w "%{http_code}" "$url" 2>/dev/null || echo "000")
             if [ "$status" = "403" ] || [ "$status" = "405" ] || [ "$status" = "000" ]; then
-              status=$(curl -sL --max-time 15 -A "Mozilla/5.0" -o /dev/null -w "%{http_code}" "$url" || echo "000")
+              status=$(curl -sL --connect-timeout 5 --max-time 10 -A "Mozilla/5.0" -o /dev/null -w "%{http_code}" "$url" 2>/dev/null || echo "000")
             fi
             if [ "$status" != "200" ]; then
-              echo -e "$url\t$ids\t$status" >> failures.tsv
-              echo "❌ $url (ids: $ids) → HTTP $status"
+              printf '%s\t%s\t%s\n' "$url" "$ids" "$status"
+              printf '❌ %s (ids: %s) → HTTP %s\n' "$url" "$ids" "$status" >&2
             else
-              echo "✅ $url (ids: $ids)"
+              printf '✅ %s (ids: %s)\n' "$url" "$ids" >&2
             fi
-          done < urls.tsv
+          }
+          export -f check_url
+
+          # 並行 4 worker：32 URLs ÷ 4 ≈ 8 rounds × 最壞 20s = 160s（job timeout-minutes: 10 充裕）
+          # POSIX 規定 < PIPE_BUF (4096) bytes 的 write 為 atomic，每行遠低於此 → 無交錯風險
+          : > failures.tsv
+          xargs -d '\n' -P 4 -I{} bash -c 'check_url "$@"' _ {} < urls.tsv > failures.tsv
+
           fail_count=$(wc -l < failures.tsv)
           echo "fail_count=$fail_count" >> "$GITHUB_OUTPUT"
 

--- a/quiz-app/src/data/integrated_dataset.json
+++ b/quiz-app/src/data/integrated_dataset.json
@@ -11457,8 +11457,15 @@
         "answer_verified": true,
         "verification_date": "2026-01-23",
         "verification_source": "sync_from_310",
-        "original_id": "c2-141"
-      }
+        "original_id": "c2-141",
+        "sources": [
+          "https://www.ifrs.org/issued-standards/ifrs-sustainability-standards-navigator/ifrs-s1-general-requirements/"
+        ],
+        "sources_verified_date": "2026-05-04"
+      },
+      "quality_flags": [
+        "time_sensitive"
+      ]
     },
     {
       "index": 335,
@@ -11491,8 +11498,15 @@
         "answer_verified": true,
         "verification_date": "2026-01-23",
         "verification_source": "sync_from_310",
-        "original_id": "c2-142"
-      }
+        "original_id": "c2-142",
+        "sources": [
+          "https://www.ifrs.org/issued-standards/ifrs-sustainability-standards-navigator/ifrs-s1-general-requirements/"
+        ],
+        "sources_verified_date": "2026-05-04"
+      },
+      "quality_flags": [
+        "time_sensitive"
+      ]
     },
     {
       "index": 336,
@@ -11525,8 +11539,15 @@
         "answer_verified": true,
         "verification_date": "2026-01-23",
         "verification_source": "sync_from_310",
-        "original_id": "c2-143"
-      }
+        "original_id": "c2-143",
+        "sources": [
+          "https://www.ifrs.org/issued-standards/ifrs-sustainability-standards-navigator/ifrs-s2-climate-related-disclosures/"
+        ],
+        "sources_verified_date": "2026-05-04"
+      },
+      "quality_flags": [
+        "time_sensitive"
+      ]
     },
     {
       "index": 337,
@@ -11559,8 +11580,16 @@
         "answer_verified": true,
         "verification_date": "2026-01-23",
         "verification_source": "sync_from_310",
-        "original_id": "c2-144"
-      }
+        "original_id": "c2-144",
+        "sources": [
+          "https://www.fsc.gov.tw/ch/home.jsp?id=96&parentpath=0,2&mcustomize=news_view.jsp&dataserno=202308170002&dtable=News",
+          "https://isds.tpex.org.tw/"
+        ],
+        "sources_verified_date": "2026-05-04"
+      },
+      "quality_flags": [
+        "time_sensitive"
+      ]
     },
     {
       "index": 338,
@@ -11865,8 +11894,16 @@
         "answer_verified": true,
         "verification_date": "2026-01-23",
         "verification_source": "sync_from_310",
-        "original_id": "c2-153"
-      }
+        "original_id": "c2-153",
+        "sources": [
+          "https://cgc.twse.com.tw/responsibilityRoadMap/listCh",
+          "https://www.fsc.gov.tw/ch/home.jsp?id=2&parentpath=0&mcustomize=news_view.jsp&dataserno=202303280001&dtable=News"
+        ],
+        "sources_verified_date": "2026-05-04"
+      },
+      "quality_flags": [
+        "time_sensitive"
+      ]
     },
     {
       "index": 347,
@@ -11899,8 +11936,15 @@
         "answer_verified": true,
         "verification_date": "2026-01-23",
         "verification_source": "sync_from_310",
-        "original_id": "c2-154"
-      }
+        "original_id": "c2-154",
+        "sources": [
+          "https://www.ifrs.org/issued-standards/ifrs-sustainability-standards-navigator/ifrs-s2-climate-related-disclosures/"
+        ],
+        "sources_verified_date": "2026-05-04"
+      },
+      "quality_flags": [
+        "time_sensitive"
+      ]
     },
     {
       "index": 348,
@@ -12511,8 +12555,16 @@
         "answer_verified": true,
         "verification_date": "2026-01-23",
         "verification_source": "sync_from_310",
-        "original_id": "c2-172"
-      }
+        "original_id": "c2-172",
+        "sources": [
+          "https://www.fsb-tcfd.org/recommendations/",
+          "https://assets.bbhub.io/company/sites/60/2021/10/FINAL-2017-TCFD-Report.pdf"
+        ],
+        "sources_verified_date": "2026-05-04"
+      },
+      "quality_flags": [
+        "time_sensitive"
+      ]
     },
     {
       "index": 366,
@@ -12545,8 +12597,15 @@
         "answer_verified": true,
         "verification_date": "2026-01-23",
         "verification_source": "sync_from_310",
-        "original_id": "c2-173"
-      }
+        "original_id": "c2-173",
+        "sources": [
+          "https://www.fsb-tcfd.org/recommendations/"
+        ],
+        "sources_verified_date": "2026-05-04"
+      },
+      "quality_flags": [
+        "time_sensitive"
+      ]
     },
     {
       "index": 367,
@@ -12579,8 +12638,15 @@
         "answer_verified": true,
         "verification_date": "2026-01-23",
         "verification_source": "sync_from_310",
-        "original_id": "c2-174"
-      }
+        "original_id": "c2-174",
+        "sources": [
+          "https://www.fsb-tcfd.org/recommendations/"
+        ],
+        "sources_verified_date": "2026-05-04"
+      },
+      "quality_flags": [
+        "time_sensitive"
+      ]
     },
     {
       "index": 368,
@@ -12613,8 +12679,16 @@
         "answer_verified": true,
         "verification_date": "2026-01-23",
         "verification_source": "sync_from_310",
-        "original_id": "c2-175"
-      }
+        "original_id": "c2-175",
+        "sources": [
+          "https://www.ifrs.org/issued-standards/ifrs-sustainability-standards-navigator/ifrs-s1-general-requirements/",
+          "https://www.ifrs.org/issued-standards/ifrs-sustainability-standards-navigator/ifrs-s2-climate-related-disclosures/"
+        ],
+        "sources_verified_date": "2026-05-04"
+      },
+      "quality_flags": [
+        "time_sensitive"
+      ]
     },
     {
       "index": 369,
@@ -15068,8 +15142,16 @@
         "answer_verified": true,
         "verification_date": "2026-01-23",
         "verification_source": "sync_from_310",
-        "original_id": "c2-247"
-      }
+        "original_id": "c2-247",
+        "sources": [
+          "https://www.cdp.net/zh",
+          "https://www.cdp.net/"
+        ],
+        "sources_verified_date": "2026-05-04"
+      },
+      "quality_flags": [
+        "time_sensitive"
+      ]
     },
     {
       "index": 441,
@@ -20574,7 +20656,10 @@
         "verification_date": "2026-01-23",
         "verification_source": "batch_verification",
         "confidence": "medium"
-      }
+      },
+      "quality_flags": [
+        "time_sensitive"
+      ]
     },
     {
       "item_id": "S_YAMOL_023-q079",

--- a/quiz-app/src/data/practice_pool.json
+++ b/quiz-app/src/data/practice_pool.json
@@ -279,7 +279,9 @@
         "https://vocus.cc/article/6901a506fd89780001c2a960",
         "https://www.ifrs.org/"
       ],
-      "quality_flags": []
+      "quality_flags": [
+        "time_sensitive"
+      ]
     },
     {
       "id": "pool-em-ipas_vocus_mock-007",
@@ -1701,7 +1703,9 @@
       "sources": [
         "https://vocus.cc/article/691f0d31fd897800016ba3c7"
       ],
-      "quality_flags": []
+      "quality_flags": [
+        "time_sensitive"
+      ]
     },
     {
       "id": "pool-em-ipas_vocus_mock-042",
@@ -1744,7 +1748,9 @@
       "sources": [
         "https://vocus.cc/article/691f0d31fd897800016ba3c7"
       ],
-      "quality_flags": []
+      "quality_flags": [
+        "time_sensitive"
+      ]
     },
     {
       "id": "pool-em-ipas_vocus_mock-043",
@@ -1875,7 +1881,9 @@
         "https://vocus.cc/article/6903fd65fd89780001a80f8b",
         "https://www.ifrs.org/"
       ],
-      "quality_flags": []
+      "quality_flags": [
+        "time_sensitive"
+      ]
     },
     {
       "id": "pool-em-ipas_vocus_mock-046",
@@ -2396,7 +2404,9 @@
       "sources": [
         "https://www.fsc.gov.tw/ch/home.jsp?id=96&parentpath=0,2&mcustomize=news_view.jsp&dataserno=202308170002&dtable=News"
       ],
-      "quality_flags": []
+      "quality_flags": [
+        "time_sensitive"
+      ]
     },
     {
       "id": "pool-aig-ind-002",
@@ -2440,7 +2450,9 @@
       "sources": [
         "https://cgc.twse.com.tw/responsibilityRoadMap/listCh"
       ],
-      "quality_flags": []
+      "quality_flags": [
+        "time_sensitive"
+      ]
     },
     {
       "id": "pool-aig-ind-003",
@@ -2484,7 +2496,9 @@
       "sources": [
         "https://dsp.tpex.org.tw/storage/education_event/IFRS%E6%B0%B8%E7%BA%8C%E6%BA%96%E5%89%87%E5%95%8F%E7%AD%94%E9%9B%86.pdf"
       ],
-      "quality_flags": []
+      "quality_flags": [
+        "time_sensitive"
+      ]
     },
     {
       "id": "pool-aig-ind-004",
@@ -2529,7 +2543,9 @@
         "https://www.fsc.gov.tw/ch/home.jsp?id=96&parentpath=0,2&mcustomize=news_view.jsp&dataserno=202505130005&dtable=News",
         "https://www.fsc.gov.tw/ch/home.jsp?id=96&parentpath=0,2&mcustomize=news_view.jsp&dataserno=202510280004&dtable=News"
       ],
-      "quality_flags": []
+      "quality_flags": [
+        "time_sensitive"
+      ]
     },
     {
       "id": "pool-aig-ind-005",
@@ -3106,7 +3122,9 @@
       "sources": [
         "https://www.fsc.gov.tw/ch/home.jsp?id=96&parentpath=0,2&mcustomize=news_view.jsp&dataserno=202412310005&dtable=News"
       ],
-      "quality_flags": []
+      "quality_flags": [
+        "time_sensitive"
+      ]
     },
     {
       "id": "pool-aig-ind-020",
@@ -3372,7 +3390,9 @@
       "sources": [
         "https://www.ifrs.org/issued-standards/ifrs-sustainability-standards-navigator/ifrs-s2-climate-related-disclosures.html"
       ],
-      "quality_flags": []
+      "quality_flags": [
+        "time_sensitive"
+      ]
     },
     {
       "id": "pool-aig-ind-026",
@@ -3416,7 +3436,9 @@
       "sources": [
         "https://www.ifrs.org/issued-standards/ifrs-sustainability-standards-navigator/ifrs-s2-climate-related-disclosures.html"
       ],
-      "quality_flags": []
+      "quality_flags": [
+        "time_sensitive"
+      ]
     },
     {
       "id": "pool-aig-ind-027",
@@ -3460,7 +3482,9 @@
       "sources": [
         "https://www.iea.org/reports/net-zero-by-2050"
       ],
-      "quality_flags": []
+      "quality_flags": [
+        "time_sensitive"
+      ]
     },
     {
       "id": "pool-aig-ind-029",
@@ -3682,7 +3706,9 @@
       "sources": [
         "https://ghg.tgpf.org.tw/"
       ],
-      "quality_flags": []
+      "quality_flags": [
+        "time_sensitive"
+      ]
     },
     {
       "id": "pool-aig-ind-034",
@@ -3726,7 +3752,9 @@
       "sources": [
         "https://www.iaasb.org/publications/international-standard-assurance-engagements-isae-3410-assurance-engagements-greenhouse-gas-statements"
       ],
-      "quality_flags": []
+      "quality_flags": [
+        "time_sensitive"
+      ]
     },
     {
       "id": "pool-aig-ind-035",
@@ -4363,7 +4391,9 @@
         "https://www.ifrs.org/issued-standards/ifrs-sustainability-standards-navigator/ifrs-s2-climate-related-disclosures/",
         "https://www.fsb.org/2023/07/fsb-welcomes-issb-standards-as-culmination-of-its-work-on-climate-related-disclosures/"
       ],
-      "quality_flags": []
+      "quality_flags": [
+        "time_sensitive"
+      ]
     },
     {
       "id": "pool-aig-intl-014",
@@ -4462,7 +4492,9 @@
         "https://www.efrag.org/en/sustainability-reporting/esrs-workstreams/european-sustainability-reporting-standards-1st-set",
         "https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=OJ:L_202302772"
       ],
-      "quality_flags": []
+      "quality_flags": [
+        "time_sensitive"
+      ]
     },
     {
       "id": "pool-aig-intl-016",
@@ -4953,7 +4985,9 @@
         "https://www.ifrs.org/content/dam/ifrs/publications/pdf-standards-issb/english/2023/issued/part-a/issb-2023-a-ifrs-s2-climate-related-disclosures.pdf",
         "https://ghgprotocol.org/corporate-standard"
       ],
-      "quality_flags": []
+      "quality_flags": [
+        "time_sensitive"
+      ]
     },
     {
       "id": "pool-aig-intl-028",
@@ -5051,7 +5085,9 @@
         "https://www.efrag.org/Assets/Download?assetUrl=%2Fsites%2Fwebpublishing%2FSiteAssets%2FESRS-ISSB%2520Standards%2520Interoperability%2520Guidance.pdf",
         "https://www.ifrs.org/issued-standards/ifrs-sustainability-standards-navigator/ifrs-s2-climate-related-disclosures/"
       ],
-      "quality_flags": []
+      "quality_flags": [
+        "time_sensitive"
+      ]
     },
     {
       "id": "pool-aig-intl-030",
@@ -6236,7 +6272,9 @@
         "https://www.fsc.gov.tw/ch/home.jsp?id=130&parentpath=0,2",
         "https://law.moj.gov.tw/LawClass/LawSingle.aspx?pcode=O0020098&flno=36"
       ],
-      "quality_flags": []
+      "quality_flags": [
+        "time_sensitive"
+      ]
     },
     {
       "id": "pool-aig-tw_regs_35-v2",
@@ -6632,7 +6670,8 @@
         "https://www.ifrs.org/issued-standards/ifrs-sustainability-standards-navigator/ifrs-s2-climate-related-disclosures/"
       ],
       "quality_flags": [
-        "low_confidence"
+        "low_confidence",
+        "time_sensitive"
       ]
     },
     {


### PR DESCRIPTION
Closes #61

## 為什麼這個 PR 比原 #61 範圍更大

原 #61 描述「給 28 題打 time_sensitive flag」。Deeper review 發現一個更嚴重的 silent decay：**主庫 12 個 IFRS 相關題目中，11 題完全沒有可被 curl 驗證的 source URL** — 只有 `source: "gist"` 字面量 + `verification_source: "sync_from_310"` 文字。打 flag 但無 URL = 季度 workflow 永遠無法把關。

Per 「謹慎 + 最佳實踐」原則：**實際上網調研 11 個 gist 題目的 authoritative primary source、curl 實測 200 後才寫入**，而非僅機械地打 flag。

## 三件事，2 個 commits

### `chore(data)` — Pool + 主庫 backfill + URL research
| 變更 | 影響 |
|---|---|
| 20 個 pool items 加 `time_sensitive` flag | 已有 URL，workflow 之後會 curl |
| 11 個 gist 主庫題加 `quality_flags` + `metadata.sources` (16 URLs) + `metadata.sources_verified_date` | **這是核心改動** — 從「無 URL 可驗」變成「有 IFRS 官方 / 金管會 / TCFD 等 primary source」 |
| 1 個 our_unique (S_YAMOL_023-q078) 加 `time_sensitive` flag | 已有 source.url |

### URL → 題目映射（11 個全 curl HTTP 200 驗 2026-05-04）

| gist | 題目主題 | URL |
|---|---|---|
| 334–335 | ISSB S1 描述 / 揭露要求 | [ifrs.org S1](https://www.ifrs.org/issued-standards/ifrs-sustainability-standards-navigator/ifrs-s1-general-requirements/) |
| 336 | IFRS S2 氣候揭露 | [ifrs.org S2](https://www.ifrs.org/issued-standards/ifrs-sustainability-standards-navigator/ifrs-s2-climate-related-disclosures/) |
| 337 | 我國接軌時程（100 億 / 2026 / 2027） | [金管會藍圖](https://www.fsc.gov.tw/ch/home.jsp?id=96&parentpath=0,2&mcustomize=news_view.jsp&dataserno=202308170002&dtable=News) + [isds.tpex 接軌專區](https://isds.tpex.org.tw/) |
| 346 | 主管機關範疇 1+2 揭露 | [cgc.twse 路徑圖](https://cgc.twse.com.tw/responsibilityRoadMap/listCh) + [fsc 路徑圖原啟動](https://www.fsc.gov.tw/ch/home.jsp?id=2&parentpath=0&mcustomize=news_view.jsp&dataserno=202303280001&dtable=News) |
| 347 | 永續揭露準則 S2 範疇排放 | [ifrs.org S2](https://www.ifrs.org/issued-standards/ifrs-sustainability-standards-navigator/ifrs-s2-climate-related-disclosures/) |
| 365 | TCFD 四大核心要素 | [fsb-tcfd recommendations](https://www.fsb-tcfd.org/recommendations/) + [2017 PDF](https://assets.bbhub.io/company/sites/60/2021/10/FINAL-2017-TCFD-Report.pdf) |
| 366–367 | TCFD 治理 / 投資人關注 | [fsb-tcfd recommendations](https://www.fsb-tcfd.org/recommendations/) |
| 368 | IFRS S1/S2 規定 | S1 + S2 official |
| 440 | CDP 領先監管 | [cdp.net/zh](https://www.cdp.net/zh) + [cdp.net/](https://www.cdp.net/) |

### `ci(quarterly)` — 擴充季度 workflow
- jq 第一段 scan 同 pool（不變）
- 新增第二段 scan 主庫，URL fallback chain：`source.url || metadata.sources[]`
- ID 命名：`item_id`（our_unique）/ `gist-{index}`（gist）
- `sort -u` dedup

**本地 dry-run**：47 URLs 涵蓋 33 questions（12 main + 20 pool + 1 our_unique）。

## Test plan
- [x] 342/342 unit tests pass（含 main-bank-schema、practice-pool-schema、integrity）
- [x] tsc --noEmit clean
- [x] 11 個新增 gist URLs 全 curl HTTP 200
- [x] Workflow jq pipeline 本地 dry-run 通過
- [ ] 合併後手動觸發 `workflow_dispatch` 確認 production 也能跑（不等 7/1 季度 schedule）

## Follow-ups（不在此 PR scope）
- TS types `GistQuestion.quality_flags` / `metadata.sources` 擴充（runtime JSON 已寫入但 TS code 看不到）— 開 issue 追蹤
- `verification_source` text 欄位裡的 "Regulation 2025/XXX" 等 placeholder 需另外清理（CBAM 相關 7 題）