### PR TITLE
fix(ResultPage): 題庫相似題顯示選項與作答互動 (#74)

### DIFF
--- a/quiz-app/src/components/BankSimilarQuestionItem/BankSimilarQuestionItem.css
+++ b/quiz-app/src/components/BankSimilarQuestionItem/BankSimilarQuestionItem.css
@@ -1,0 +1,56 @@
+/* 題庫相似題 — 選項區與揭曉區（沿用 QuestionCard 的 .option-item） */
+
+.bank-similar-options {
+  margin-top: var(--spacing-sm);
+}
+
+.bank-similar-option.option-item {
+  padding: var(--spacing-sm) var(--spacing-md);
+}
+
+.similar-meta--top {
+  margin-bottom: var(--spacing-xs);
+}
+
+.bank-similar-reveal {
+  margin-top: var(--spacing-sm);
+  padding: var(--spacing-sm);
+  background: var(--color-surface);
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--color-divider);
+}
+
+.bank-similar-reveal-text {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--spacing-xs);
+  margin: 0;
+  font-size: var(--font-size-sm);
+  line-height: 1.5;
+  color: var(--color-text-primary);
+}
+
+.bank-similar-reveal-text.muted {
+  color: var(--color-text-secondary);
+}
+
+.bank-similar-reveal-text .material-icons.sm {
+  flex-shrink: 0;
+  margin-top: 2px;
+}
+
+.bank-similar-result.ok {
+  color: var(--color-success);
+  font-weight: 500;
+}
+
+.bank-similar-result.bad {
+  color: var(--color-error);
+  font-weight: 500;
+}
+
+.bank-similar-no-options {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
+  margin: var(--spacing-xs) 0;
+}

--- a/quiz-app/src/components/BankSimilarQuestionItem/BankSimilarQuestionItem.test.tsx
+++ b/quiz-app/src/components/BankSimilarQuestionItem/BankSimilarQuestionItem.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent, within } from '@testing-library/react';
 import type { QuizQuestion } from '../../types/quiz';
 import { BankSimilarQuestionItem } from './BankSimilarQuestionItem';
 
@@ -16,6 +16,25 @@ function questionWithoutOptions(): QuizQuestion {
   };
 }
 
+/** 完整可作答的題庫相似題 */
+function makeQuestion(overrides: Partial<QuizQuestion> = {}): QuizQuestion {
+  return {
+    id: 'sim-1',
+    stem: '下列何者屬於再生能源？',
+    options: [
+      { key: 'A', text: '燃煤' },
+      { key: 'B', text: '太陽能' },
+      { key: 'C', text: '天然氣' },
+      { key: 'D', text: '核能' },
+    ],
+    answer: 'B',
+    subject: '考科1',
+    sourceType: 'gist',
+    hasAnswer: true,
+    ...overrides,
+  };
+}
+
 describe('BankSimilarQuestionItem', () => {
   it('options 為 undefined 時不崩潰並顯示 fallback UI', () => {
     render(<BankSimilarQuestionItem question={questionWithoutOptions()} index={1} />);
@@ -28,5 +47,66 @@ describe('BankSimilarQuestionItem', () => {
     q.options = null as unknown as QuizQuestion['options'];
     render(<BankSimilarQuestionItem question={q} index={2} />);
     expect(screen.getByText(/此題無選項資料/)).toBeInTheDocument();
+  });
+
+  it('渲染題幹、序號與所有選項，作答前不顯示揭曉區', () => {
+    render(<BankSimilarQuestionItem question={makeQuestion()} index={3} />);
+    expect(screen.getByText('3.')).toBeInTheDocument();
+    expect(screen.getByText(/下列何者屬於再生能源/)).toBeInTheDocument();
+    (['A', 'B', 'C', 'D'] as const).forEach((k) => {
+      expect(screen.getByTestId(`bank-similar-option-${k}`)).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId('bank-similar-reveal')).not.toBeInTheDocument();
+  });
+
+  it('選到正解 → 揭曉顯示「答對了」並禁用所有選項', () => {
+    render(<BankSimilarQuestionItem question={makeQuestion()} index={1} />);
+    fireEvent.click(screen.getByTestId('bank-similar-option-B'));
+
+    const reveal = screen.getByTestId('bank-similar-reveal');
+    expect(within(reveal).getByText(/正確答案/)).toBeInTheDocument();
+    expect(within(reveal).getByText(/答對了/)).toBeInTheDocument();
+    expect(screen.getByTestId('bank-similar-option-B').className).toMatch(/correct/);
+    screen.getAllByRole('radio').forEach((r) => expect(r).toBeDisabled());
+  });
+
+  it('選到錯誤選項 → 顯示正解與「您選擇了」，錯選標記 incorrect', () => {
+    render(<BankSimilarQuestionItem question={makeQuestion()} index={1} />);
+    fireEvent.click(screen.getByTestId('bank-similar-option-A'));
+
+    const reveal = screen.getByTestId('bank-similar-reveal');
+    expect(within(reveal).getByText(/您選擇了 A/)).toBeInTheDocument();
+    expect(screen.getByTestId('bank-similar-option-A').className).toMatch(/incorrect/);
+    expect(screen.getByTestId('bank-similar-option-B').className).toMatch(/correct/);
+  });
+
+  it('題庫未標示標準答案（hasAnswer=false）→ 揭曉僅回放使用者選擇', () => {
+    render(
+      <BankSimilarQuestionItem
+        question={makeQuestion({ hasAnswer: false, answer: null })}
+        index={1}
+      />
+    );
+    fireEvent.click(screen.getByTestId('bank-similar-option-C'));
+
+    const reveal = screen.getByTestId('bank-similar-reveal');
+    expect(within(reveal).getByText(/未標示標準答案/)).toBeInTheDocument();
+    expect(within(reveal).getByText('C')).toBeInTheDocument();
+    // 沒有標準答案時不應標出 correct
+    expect(screen.getByTestId('bank-similar-option-C').className).not.toMatch(/correct/);
+  });
+
+  it('鍵盤 Enter 可選取選項並觸發揭曉', () => {
+    render(<BankSimilarQuestionItem question={makeQuestion()} index={1} />);
+    const radioB = within(screen.getByTestId('bank-similar-option-B')).getByRole('radio');
+    fireEvent.keyDown(radioB, { key: 'Enter' });
+    expect(screen.getByTestId('bank-similar-reveal')).toBeInTheDocument();
+  });
+
+  it('考科2 題目顯示「考科二」標籤', () => {
+    render(
+      <BankSimilarQuestionItem question={makeQuestion({ subject: '考科2' })} index={1} />
+    );
+    expect(screen.getByText('考科二')).toBeInTheDocument();
   });
 });

--- a/quiz-app/src/components/BankSimilarQuestionItem/BankSimilarQuestionItem.test.tsx
+++ b/quiz-app/src/components/BankSimilarQuestionItem/BankSimilarQuestionItem.test.tsx
@@ -66,7 +66,8 @@ describe('BankSimilarQuestionItem', () => {
     const reveal = screen.getByTestId('bank-similar-reveal');
     expect(within(reveal).getByText(/正確答案/)).toBeInTheDocument();
     expect(within(reveal).getByText(/答對了/)).toBeInTheDocument();
-    expect(screen.getByTestId('bank-similar-option-B').className).toMatch(/correct/);
+    // classList.contains 精確比對：避免 /correct/ 子字串也命中 "incorrect"
+    expect(screen.getByTestId('bank-similar-option-B').classList.contains('correct')).toBe(true);
     screen.getAllByRole('radio').forEach((r) => expect(r).toBeDisabled());
   });
 
@@ -76,8 +77,11 @@ describe('BankSimilarQuestionItem', () => {
 
     const reveal = screen.getByTestId('bank-similar-reveal');
     expect(within(reveal).getByText(/您選擇了 A/)).toBeInTheDocument();
-    expect(screen.getByTestId('bank-similar-option-A').className).toMatch(/incorrect/);
-    expect(screen.getByTestId('bank-similar-option-B').className).toMatch(/correct/);
+    const optA = screen.getByTestId('bank-similar-option-A');
+    const optB = screen.getByTestId('bank-similar-option-B');
+    expect(optA.classList.contains('incorrect')).toBe(true);
+    expect(optA.classList.contains('correct')).toBe(false);
+    expect(optB.classList.contains('correct')).toBe(true);
   });
 
   it('題庫未標示標準答案（hasAnswer=false）→ 揭曉僅回放使用者選擇', () => {
@@ -92,8 +96,11 @@ describe('BankSimilarQuestionItem', () => {
     const reveal = screen.getByTestId('bank-similar-reveal');
     expect(within(reveal).getByText(/未標示標準答案/)).toBeInTheDocument();
     expect(within(reveal).getByText('C')).toBeInTheDocument();
-    // 沒有標準答案時不應標出 correct
-    expect(screen.getByTestId('bank-similar-option-C').className).not.toMatch(/correct/);
+    // 沒有標準答案時：選取項標 selected，不標 correct/incorrect
+    const optC = screen.getByTestId('bank-similar-option-C');
+    expect(optC.classList.contains('selected')).toBe(true);
+    expect(optC.classList.contains('correct')).toBe(false);
+    expect(optC.classList.contains('incorrect')).toBe(false);
   });
 
   it('鍵盤 Enter 可選取選項並觸發揭曉', () => {
@@ -101,6 +108,35 @@ describe('BankSimilarQuestionItem', () => {
     const radioB = within(screen.getByTestId('bank-similar-option-B')).getByRole('radio');
     fireEvent.keyDown(radioB, { key: 'Enter' });
     expect(screen.getByTestId('bank-similar-reveal')).toBeInTheDocument();
+  });
+
+  it('鍵盤空白鍵可選取選項並觸發揭曉', () => {
+    render(<BankSimilarQuestionItem question={makeQuestion()} index={1} />);
+    const radioC = within(screen.getByTestId('bank-similar-option-C')).getByRole('radio');
+    fireEvent.keyDown(radioC, { key: ' ' });
+    expect(screen.getByTestId('bank-similar-reveal')).toBeInTheDocument();
+  });
+
+  it('選項共同冗餘前綴 → 前綴以 option-text__redundant 標記、剩餘文字保留', () => {
+    const q = makeQuestion({
+      stem: '關於 GRI 準則，下列敘述何者正確？',
+      options: [
+        { key: 'A', text: 'GRI 揭露項目' },
+        { key: 'B', text: 'GRI 報告原則' },
+        { key: 'C', text: 'GRI 通用準則' },
+        { key: 'D', text: 'GRI 行業準則' },
+      ],
+      answer: 'A',
+    });
+    render(<BankSimilarQuestionItem question={q} index={1} />);
+
+    const optA = screen.getByTestId('bank-similar-option-A');
+    const redundant = optA.querySelector('.option-text__redundant');
+    expect(redundant).not.toBeNull();
+    expect(redundant?.textContent).toBe('GRI');
+    // 冗餘前綴標 aria-hidden，剩餘文字仍渲染
+    expect(redundant).toHaveAttribute('aria-hidden', 'true');
+    expect(optA).toHaveTextContent('揭露項目');
   });
 
   it('考科2 題目顯示「考科二」標籤', () => {

--- a/quiz-app/src/components/BankSimilarQuestionItem/BankSimilarQuestionItem.test.tsx
+++ b/quiz-app/src/components/BankSimilarQuestionItem/BankSimilarQuestionItem.test.tsx
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import type { QuizQuestion } from '../../types/quiz';
+import { BankSimilarQuestionItem } from './BankSimilarQuestionItem';
+
+/** 模擬執行時 JSON／資料缺口導致 options 為 nullish（型別外） */
+function questionWithoutOptions(): QuizQuestion {
+  return {
+    id: 'bad-opt-1',
+    stem: '無選項資料題幹',
+    options: undefined as unknown as QuizQuestion['options'],
+    answer: 'A',
+    subject: '考科1',
+    sourceType: 'gist',
+    hasAnswer: true,
+  };
+}
+
+describe('BankSimilarQuestionItem', () => {
+  it('options 為 undefined 時不崩潰並顯示 fallback UI', () => {
+    render(<BankSimilarQuestionItem question={questionWithoutOptions()} index={1} />);
+    expect(screen.getByText(/此題無選項資料/)).toBeInTheDocument();
+    expect(screen.getByText(/無選項資料題幹/)).toBeInTheDocument();
+  });
+
+  it('options 為 null 時不崩潰並顯示 fallback', () => {
+    const q = questionWithoutOptions();
+    q.options = null as unknown as QuizQuestion['options'];
+    render(<BankSimilarQuestionItem question={q} index={2} />);
+    expect(screen.getByText(/此題無選項資料/)).toBeInTheDocument();
+  });
+});

--- a/quiz-app/src/components/BankSimilarQuestionItem/BankSimilarQuestionItem.tsx
+++ b/quiz-app/src/components/BankSimilarQuestionItem/BankSimilarQuestionItem.tsx
@@ -93,7 +93,9 @@ export function BankSimilarQuestionItem({
   index,
 }: BankSimilarQuestionItemProps) {
   const labelId = useId();
-  const radioGroupName = `bank-similar-${question.id}`;
+  // radio group name 綁 useId 而非 question.id：同一相似題若同時出現在多個
+  // 展開的錯題面板，各實例 radio 不會併入同一原生 group 而互相取消勾選
+  const radioGroupName = `bank-similar-${labelId}`;
   const [picked, setPicked] = useState<string | null>(null);
   const revealed = picked !== null;
 

--- a/quiz-app/src/components/BankSimilarQuestionItem/BankSimilarQuestionItem.tsx
+++ b/quiz-app/src/components/BankSimilarQuestionItem/BankSimilarQuestionItem.tsx
@@ -1,0 +1,216 @@
+// 結果頁「題庫相似題」單題：顯示題幹與選項，選取後揭曉答案
+import {
+  useCallback,
+  useId,
+  useMemo,
+  useState,
+  type KeyboardEvent,
+} from 'react';
+import type { QuizQuestion, QuizOption } from '../../types/quiz';
+import { findRedundantPrefix } from '../../utils/option-prefix';
+import '../QuestionCard/QuestionCard.css';
+import './BankSimilarQuestionItem.css';
+
+export interface BankSimilarQuestionItemProps {
+  question: QuizQuestion;
+  /** 列表序號（1-based） */
+  index: number;
+}
+
+function SimilarOptionRow({
+  option,
+  status,
+  isSelected,
+  isDisabled,
+  redundantPrefix,
+  radioName,
+  onPick,
+}: {
+  option: QuizOption;
+  status: 'default' | 'selected' | 'correct' | 'incorrect';
+  isSelected: boolean;
+  isDisabled: boolean;
+  redundantPrefix: string | null;
+  radioName: string;
+  onPick: (key: QuizOption['key']) => void;
+}) {
+  const statusClass = status !== 'default' ? status : '';
+
+  const onKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        if (!isDisabled) onPick(option.key);
+      }
+    },
+    [isDisabled, onPick, option.key]
+  );
+
+  return (
+    <label
+      className={`option-item bank-similar-option ${statusClass}`}
+      data-testid={`bank-similar-option-${option.key}`}
+    >
+      <input
+        type="radio"
+        name={radioName}
+        value={option.key}
+        checked={isSelected}
+        disabled={isDisabled}
+        onChange={() => !isDisabled && onPick(option.key)}
+        onKeyDown={onKeyDown}
+        aria-label={`${option.key}: ${option.text}`}
+      />
+      <span className="option-key">{option.key}</span>
+      <span className="option-text">
+        {redundantPrefix && option.text.startsWith(redundantPrefix) ? (
+          <>
+            <span className="option-text__redundant" aria-hidden="true">
+              {redundantPrefix}
+            </span>
+            {option.text.slice(redundantPrefix.length)}
+          </>
+        ) : (
+          option.text
+        )}
+      </span>
+      {status === 'correct' && (
+        <span className="option-icon material-icons" aria-label="正確答案">
+          check_circle
+        </span>
+      )}
+      {status === 'incorrect' && (
+        <span className="option-icon material-icons" aria-label="錯誤">
+          cancel
+        </span>
+      )}
+    </label>
+  );
+}
+
+export function BankSimilarQuestionItem({
+  question,
+  index,
+}: BankSimilarQuestionItemProps) {
+  const labelId = useId();
+  const radioGroupName = `bank-similar-${question.id}`;
+  const [picked, setPicked] = useState<string | null>(null);
+  const revealed = picked !== null;
+
+  const redundantPrefix = useMemo(() => {
+    const optionTexts = question.options?.map((o) => o.text) ?? [];
+    return findRedundantPrefix(question.stem, optionTexts);
+  }, [question.stem, question.options]);
+
+  const getOptionStatus = useCallback(
+    (optionKey: string): 'default' | 'selected' | 'correct' | 'incorrect' => {
+      if (!revealed) return 'default';
+
+      const correct = question.answer;
+      if (!question.hasAnswer || correct === null) {
+        return picked === optionKey ? 'selected' : 'default';
+      }
+
+      if (optionKey === correct) return 'correct';
+      if (picked === optionKey && picked !== correct) return 'incorrect';
+      return 'default';
+    },
+    [revealed, picked, question.answer, question.hasAnswer]
+  );
+
+  const handlePick = useCallback((key: QuizOption['key']) => {
+    setPicked(key);
+  }, []);
+
+  const correctAnswer = question.answer;
+  const isCorrectPick =
+    revealed &&
+    question.hasAnswer &&
+    correctAnswer !== null &&
+    picked === correctAnswer;
+
+  if (!question.options?.length) {
+    return (
+      <li className="bank-similar-item">
+        <span className="similar-index">{index}.</span>
+        <div className="similar-content">
+          <p className="similar-stem">{question.stem}</p>
+          <p className="bank-similar-no-options">此題無選項資料</p>
+          <div className="similar-meta">
+            <span className="similar-subject">
+              {question.subject === '考科1' ? '考科一' : '考科二'}
+            </span>
+          </div>
+        </div>
+      </li>
+    );
+  }
+
+  return (
+    <li className="bank-similar-item">
+      <span className="similar-index">{index}.</span>
+      <div className="similar-content">
+        <p className="similar-stem" id={labelId}>
+          {question.stem}
+        </p>
+        <div className="similar-meta similar-meta--top">
+          <span className="similar-subject">
+            {question.subject === '考科1' ? '考科一' : '考科二'}
+          </span>
+        </div>
+
+        <div
+          className="question-options bank-similar-options"
+          role="radiogroup"
+          aria-labelledby={labelId}
+        >
+          {question.options.map((option) => (
+            <SimilarOptionRow
+              key={option.key}
+              option={option}
+              status={getOptionStatus(option.key)}
+              isSelected={picked === option.key}
+              isDisabled={revealed}
+              redundantPrefix={redundantPrefix}
+              radioName={radioGroupName}
+              onPick={handlePick}
+            />
+          ))}
+        </div>
+
+        {revealed && (
+          <div
+            className="bank-similar-reveal"
+            role="status"
+            aria-live="polite"
+            data-testid="bank-similar-reveal"
+          >
+            {!question.hasAnswer || correctAnswer === null ? (
+              <p className="bank-similar-reveal-text muted">
+                <span className="material-icons sm">info</span>
+                此題題庫未標示標準答案；您選擇了 <strong>{picked}</strong>
+              </p>
+            ) : (
+              <>
+                <p className="bank-similar-reveal-text">
+                  <span className="material-icons sm">verified</span>
+                  正確答案：<strong>{correctAnswer}</strong>
+                  {isCorrectPick ? (
+                    <span className="bank-similar-result ok"> — 答對了</span>
+                  ) : (
+                    <span className="bank-similar-result bad">
+                      {' '}
+                      — 您選擇了 {picked}
+                    </span>
+                  )}
+                </p>
+              </>
+            )}
+          </div>
+        )}
+      </div>
+    </li>
+  );
+}
+
+export default BankSimilarQuestionItem;

--- a/quiz-app/src/pages/ResultPage.test.tsx
+++ b/quiz-app/src/pages/ResultPage.test.tsx
@@ -37,7 +37,7 @@ vi.mock('../data/questions', () => {
     subject: '考科1',
     sourceType: 'gist',
     hasAnswer: true,
-  } as unknown as QuizQuestion;
+  };
 
   // Refs #64：weak-section 測試需要多個可解析的 id
   const weakFixtures: Record<string, QuizQuestion> = {

--- a/quiz-app/src/pages/ResultPage.test.tsx
+++ b/quiz-app/src/pages/ResultPage.test.tsx
@@ -2,7 +2,7 @@
 // 重點：score 評語分支、stats 渲染、wrongAnswers 分支、handleExport、操作按鈕。
 // AI streaming 路徑需要 puter.js 全 mock，屬整合測試範疇，不在此檔涵蓋。
 import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
-import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { render, screen, fireEvent, cleanup, within } from '@testing-library/react';
 import type { QuizResult, QuizQuestion, AnswerRecord } from '../types/quiz';
 
 // 在 import ResultPage 前先 mock 資料層，否則 ResultPage import 時會吃真實題庫
@@ -22,10 +22,29 @@ vi.mock('../data/questions', () => {
     section: 'fixture',
     explanation: '二氧化碳為主要溫室氣體',
   } as unknown as QuizQuestion;
+
+  const similarFixture: QuizQuestion = {
+    id: 'fx-sim-001',
+    stem: '題庫相似題測試：下列何者是再生能源？',
+    options: [
+      { key: 'A', text: '燃煤' },
+      { key: 'B', text: '太陽能' },
+      { key: 'C', text: '燃油' },
+      { key: 'D', text: '天然氣' },
+    ],
+    answer: 'B',
+    subject: '考科1',
+    sourceType: 'gist',
+    hasAnswer: true,
+  };
+
   return {
     allQuestions: [fixture],
     getQuestionById: (id: string) => (id === 'fx-001' ? fixture : undefined),
-    getSimilarQuestions: () => [],
+    getSimilarQuestions: (questionId: string, maxResults = 5) => {
+      if (questionId !== 'fx-001') return [];
+      return [similarFixture].slice(0, maxResults);
+    },
     stats: { total: 1, subject1: 1, subject2: 0 },
   };
 });
@@ -156,10 +175,16 @@ describe('ResultPage', () => {
     expect(screen.getByRole('button', { name: /AI 解析/ })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /AI 生成相似題/ })).toBeInTheDocument();
 
-    // toggle 題庫相似題（getSimilarQuestions 已 mock 為空陣列，分支仍走過）
     const bankBtn = screen.getByRole('button', { name: /題庫相似題/ });
     fireEvent.click(bankBtn);
     expect(screen.getByRole('button', { name: /收起題庫相似題/ })).toBeInTheDocument();
+    expect(screen.getByText(/題庫相似題測試/)).toBeInTheDocument();
+    expect(screen.getByTestId('bank-similar-option-A')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('bank-similar-option-A'));
+    const reveal = screen.getByTestId('bank-similar-reveal');
+    expect(within(reveal).getByText(/正確答案/)).toBeInTheDocument();
+    expect(within(reveal).getByText(/您選擇了 A/)).toBeInTheDocument();
   });
 
   it('onGoHome / onRetry 按鈕觸發 callback', () => {

--- a/quiz-app/src/pages/ResultPage.tsx
+++ b/quiz-app/src/pages/ResultPage.tsx
@@ -8,6 +8,7 @@ import {
 } from '../utils/ai-helper';
 import { SourceBreakdown } from '../components/SourceBreakdown/SourceBreakdown';
 import type { QuizResult, QuizQuestion } from '../types/quiz';
+import { BankSimilarQuestionItem } from '../components/BankSimilarQuestionItem/BankSimilarQuestionItem';
 import './ResultPage.css';
 
 interface ResultPageProps {
@@ -398,22 +399,11 @@ export function ResultPage({ result, onGoHome, onRetry }: ResultPageProps) {
                             return (
                               <ul className="bank-similar-list">
                                 {similarQs.map((sq, idx) => (
-                                  <li key={sq.id} className="bank-similar-item">
-                                    <span className="similar-index">{idx + 1}.</span>
-                                    <div className="similar-content">
-                                      <p className="similar-stem">{sq.stem}</p>
-                                      <div className="similar-meta">
-                                        <span className="similar-subject">
-                                          {sq.subject === '考科1' ? '考科一' : '考科二'}
-                                        </span>
-                                        {sq.answer && (
-                                          <span className="similar-answer">
-                                            答案：{sq.answer}
-                                          </span>
-                                        )}
-                                      </div>
-                                    </div>
-                                  </li>
+                                  <BankSimilarQuestionItem
+                                    key={sq.id}
+                                    question={sq}
+                                    index={idx + 1}
+                                  />
                                 ))}
                               </ul>
                             );


### PR DESCRIPTION
## 摘要
修正結果頁「題庫相似題」僅顯示題幹與答案、未列出選項的問題（[Issue #74](https://github.com/thc1006/ipas-net-zero-quiz/issues/74)）。

## 變更
- 新增 `BankSimilarQuestionItem`：渲染 `options`、沿用 `QuestionCard` 選項樣式與 redundant prefix；選取後揭曉正解並標示對錯；無選項時 fallback。
- `ResultPage` 改為使用該元件。
- 單元測試：`BankSimilarQuestionItem`、`ResultPage` 展開相似題流程。

Closes #74