### PR TITLE
fix(settings): replace icon-only X with explicit "返回首頁" button (closes #72)

### DIFF
--- a/quiz-app/src/pages/SettingsPage.css
+++ b/quiz-app/src/pages/SettingsPage.css
@@ -20,6 +20,15 @@
   margin: 0;
 }
 
+/* 返回首頁按鈕（Refs #72）— icon + 文字明確標示，避免 X icon-only 不直覺 */
+.settings-back-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+  font-size: var(--font-size-sm);
+  white-space: nowrap;
+}
+
 /* 設定區塊 */
 .settings-section {
   margin-bottom: var(--spacing-lg);
@@ -177,6 +186,15 @@
   .setting-item select,
   .setting-item input[type="number"] {
     width: 100%;
+  }
+  /* 返回首頁按鈕在小螢幕換行時全寬，更易點擊（Refs #72） */
+  .settings-header {
+    flex-wrap: wrap;
+    gap: var(--spacing-sm);
+  }
+  .settings-back-btn {
+    width: 100%;
+    justify-content: center;
   }
 }
 

--- a/quiz-app/src/pages/SettingsPage.test.tsx
+++ b/quiz-app/src/pages/SettingsPage.test.tsx
@@ -43,10 +43,12 @@ describe('SettingsPage', () => {
     expect(screen.getByText(/加強練習池/)).toBeInTheDocument();
   });
 
-  it('clicking close button calls onClose', () => {
+  it('clicking 「返回首頁」 button calls onClose', () => {
     const onClose = vi.fn();
     renderSettings(onClose);
-    fireEvent.click(screen.getByLabelText('關閉設定'));
+    // Refs #72：原 X icon-only 按鈕改為「返回首頁」明確文字按鈕，
+    // 走 visible text 為 accessible name（無 aria-label，避免 WCAG SC 2.5.3 違反）
+    fireEvent.click(screen.getByRole('button', { name: /返回首頁/ }));
     expect(onClose).toHaveBeenCalledOnce();
   });
 

--- a/quiz-app/src/pages/SettingsPage.tsx
+++ b/quiz-app/src/pages/SettingsPage.tsx
@@ -42,11 +42,21 @@ export function SettingsPage({ accessibility, onClose }: SettingsPageProps) {
     <div className="settings-page animate-fade-in">
       <header className="settings-header">
         <h1>
-          <span className="material-icons">settings</span>
+          <span className="material-icons" aria-hidden="true">settings</span>
           設定
         </h1>
-        <button className="btn btn-text" onClick={onClose} aria-label="關閉設定">
-          <span className="material-icons">close</span>
+        {/*
+          使用 visible text「返回首頁」當 accessible name（不加 aria-label，
+          避免 WCAG SC 2.5.3「Label in Name」違反 — 見
+          memory/feedback_wcag_label_in_name.md）。
+          原本是 icon-only X button，使用者反映 #72 找不到返回入口。
+        */}
+        <button
+          className="btn btn-secondary settings-back-btn"
+          onClick={onClose}
+        >
+          <span className="material-icons" aria-hidden="true">arrow_back</span>
+          返回首頁
         </button>
       </header>
 

--- a/quiz-app/src/pages/SettingsPage.tsx
+++ b/quiz-app/src/pages/SettingsPage.tsx
@@ -46,9 +46,10 @@ export function SettingsPage({ accessibility, onClose }: SettingsPageProps) {
           設定
         </h1>
         {/*
-          使用 visible text「返回首頁」當 accessible name（不加 aria-label，
-          避免 WCAG SC 2.5.3「Label in Name」違反 — 見
-          memory/feedback_wcag_label_in_name.md）。
+          使用 visible text「返回首頁」當 accessible name（不加 aria-label）。
+          若 aria-label 與 visible text 不一致，voice-control 使用者說 visible
+          name 將無法觸發此元素 — WCAG 2.1 SC 2.5.3「Label in Name」(Level A)：
+          https://www.w3.org/WAI/WCAG21/Understanding/label-in-name.html
           原本是 icon-only X button，使用者反映 #72 找不到返回入口。
         */}
         <button


### PR DESCRIPTION
Closes #72

## 拆解 user 報告

「設置頁點按鈕之後無法以返回方式回到主頁面，同時重新刷新設置會消失」拆兩件事：

### 1. 無法返回（真 bug）
原本右上角只有 X icon-only 按鈕（`aria-label="關閉設定"`）。Icon-only 對某些使用者語意不明 → 誤以為沒返回入口。

**修法**：改為「← 返回首頁」**明確 icon + 文字按鈕**（`btn-secondary` 取代 `btn-text`，視覺優先級提升）。**不加 aria-label**，讓 visible text 當 accessible name — 遵循 WCAG SC 2.5.3「Label in Name」（PR #67、#75 同樣議題已記 memory，此次預先避免）。

### 2. 重整設置消失（**false alarm，已稽核**）

稽核 SettingsPage 上 5 個設定項目持久化狀況：
| 設定項 | hook | localStorage key | 持久化 |
|---|---|---|---|
| 深色模式 | `useAccessibility` | `ipas-quiz-a11y` | ✅ |
| 字體大小 | 同上 | 同上 | ✅ |
| 高對比度 | 同上 | 同上 | ✅ |
| 色覺辨認模式 | 同上 | 同上 | ✅ |
| 加強練習池 | `usePracticeMode` | `practice-pool-enabled` + `practice-pool-ai-opt-in` | ✅ |

**全部已持久化**。報告可能是 incognito mode / 清過 localStorage / 不同 browser profile 等場景下的 false alarm。本 PR 不重做持久化、保留現狀；未來若觀察到具體 reproduce path 再開新 issue。

## 響應式

Mobile (< 640px) 返回按鈕換行後全寬，提升 thumb 可達性。@media 規則合進既有 mobile block，避免被 responsive test 抓第一個 @media 誤判（同 PR #75 學到的細節）。

## Test plan

- [x] 375/375 unit tests pass（SettingsPage close 測試 selector 從 `getByLabelText('關閉設定')` 改為 `getByRole('button', { name: /返回首頁/ })`）
- [x] tsc --noEmit clean
- [x] lint 無新警告
- [ ] 部署後 manual smoke：
  - [ ] 從首頁開設定 → 看到「← 返回首頁」明確按鈕
  - [ ] 點擊 → 回首頁
  - [ ] mobile (< 640px) 看到按鈕換行全寬
  - [ ] 改深色模式 → reload → 仍是深色（驗證持久化）