### PR TITLE
feat(feedback): 「回報此題」button on QuestionCard + ResultPage wrong-list (closes #63)

### DIFF
--- a/.github/ISSUE_TEMPLATE/question-feedback.yml
+++ b/.github/ISSUE_TEMPLATE/question-feedback.yml
@@ -1,0 +1,66 @@
+name: 題目回報
+description: 回報題庫中某題的問題（答案錯、條號過時、source 失效、選項歧義等）
+title: "[題目回報] "
+labels: ["question-feedback", "quiz-app:data"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        感謝協助維護題庫！從測驗 / 結果頁的「回報此題」按鈕跳來時，下方欄位多數會自動帶入。
+        若 q_id / q_stem 為空，請貼到該欄位裡的「題目開頭」幫助我們定位題目。
+
+  - type: input
+    id: q_id
+    attributes:
+      label: 題目 ID
+      description: 通常自動帶入。範例 `gist-334` / `pool-aig-ifrs2026-001` / `S_YAMOL_023-q078`
+      placeholder: gist-XXX 或 pool-XXX
+    validations:
+      required: false
+
+  - type: textarea
+    id: q_stem
+    attributes:
+      label: 題目開頭（題幹前 60–100 字）
+      description: 通常自動帶入；若 ID 不確定，貼題幹開頭幫助定位
+      placeholder: 例如「ISSB S1/S2 我國採用時程，下列何者錯誤？」
+    validations:
+      required: false
+
+  - type: dropdown
+    id: feedback_type
+    attributes:
+      label: 回報類型
+      description: 選最貼近的一項；若選「其他」請於補充說明描述
+      options:
+        - 答案錯誤（標準答案不對）
+        - 條號 / 法規過時（IFRS、金管會、ISO 等已修訂）
+        - Source URL 失效（連結 404 / redirect 錯)
+        - 選項歧義（多個選項都可能對 / 全錯）
+        - 題幹不清楚 / 排版錯誤
+        - 重複題目
+        - 其他
+    validations:
+      required: true
+
+  - type: textarea
+    id: details
+    attributes:
+      label: 補充說明
+      description: 您觀察到的具體問題、預期答案、可信來源連結等
+      placeholder: |
+        例如：
+        - 我認為正解應為 B（依 IFRS S2 §29(d) 內部碳定價揭露）
+        - source URL 已 redirect 到首頁、原條文不存在
+        - https://www.ifrs.org/.../ifrs-s2 ...
+    validations:
+      required: true
+
+  - type: input
+    id: from_page
+    attributes:
+      label: 從哪個頁面回報？
+      description: 可選；自動帶入「測驗中」或「結果頁錯題列表」
+      placeholder: quiz / result
+    validations:
+      required: false

--- a/quiz-app/src/components/QuestionCard/QuestionCard.css
+++ b/quiz-app/src/components/QuestionCard/QuestionCard.css
@@ -21,6 +21,28 @@
   color: var(--color-text-secondary);
 }
 
+/* 回報此題 icon button（#63）— 低調 icon-only、開新分頁不打斷答題 flow */
+.question-feedback-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  margin-left: auto;
+  border-radius: var(--radius-sm);
+  color: var(--color-text-secondary);
+  text-decoration: none;
+  transition: background-color var(--transition-fast), color var(--transition-fast);
+}
+.question-feedback-link:hover {
+  background: var(--color-divider);
+  color: var(--color-text-primary);
+}
+.question-feedback-link:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
 .subject-tag {
   font-size: var(--font-size-xs);
 }

--- a/quiz-app/src/components/QuestionCard/QuestionCard.tsx
+++ b/quiz-app/src/components/QuestionCard/QuestionCard.tsx
@@ -6,6 +6,7 @@ import { SourceBadge } from '../SourceBadge/SourceBadge';
 import { SourceBanner } from '../SourceBanner/SourceBanner';
 import { LAW_PCODE_LABELS } from '../../data/law-pcode-labels';
 import { findRedundantPrefix } from '../../utils/option-prefix';
+import { buildFeedbackUrl } from '../../utils/question-feedback-url';
 import './QuestionCard.css';
 
 /**
@@ -140,6 +141,23 @@ export function QuestionCard({
             qualityFlags={question.qualityFlags ?? []}
           />
         )}
+        {/* 回報此題（Refs #63）— 開新分頁不打斷答題 flow；icon-only 但有 aria-label */}
+        <a
+          className="question-feedback-link"
+          href={buildFeedbackUrl({
+            questionId: question.id,
+            stem: question.stem,
+            fromPage: 'quiz',
+          })}
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="回報此題的問題"
+          title="此題有問題？回報維護者"
+        >
+          <span className="material-icons sm" aria-hidden="true">
+            flag
+          </span>
+        </a>
       </header>
 
       {/* 練習池來源 banner — 主題庫題不顯示 */}

--- a/quiz-app/src/pages/ResultPage.css
+++ b/quiz-app/src/pages/ResultPage.css
@@ -224,10 +224,40 @@
   flex: 1;
 }
 
+.wrong-stem-row {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--spacing-sm);
+}
+
 .wrong-stem {
+  flex: 1;
   font-size: var(--font-size-sm);
   margin-bottom: var(--spacing-sm);
   line-height: 1.6;
+}
+
+/* 回報此題 icon button（#63）— 與 QuestionCard.css 同 rule，
+   ResultPage 不 import QuestionCard.css 故此處重定義（小規則、不易漂移） */
+.wrong-feedback-link.question-feedback-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  flex-shrink: 0;
+  border-radius: var(--radius-sm);
+  color: var(--color-text-secondary);
+  text-decoration: none;
+  transition: background-color var(--transition-fast), color var(--transition-fast);
+}
+.wrong-feedback-link.question-feedback-link:hover {
+  background: var(--color-divider);
+  color: var(--color-text-primary);
+}
+.wrong-feedback-link.question-feedback-link:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
 }
 
 .wrong-answers {

--- a/quiz-app/src/pages/ResultPage.tsx
+++ b/quiz-app/src/pages/ResultPage.tsx
@@ -8,6 +8,7 @@ import {
 } from '../utils/ai-helper';
 import { SourceBreakdown } from '../components/SourceBreakdown/SourceBreakdown';
 import type { QuizResult, QuizQuestion } from '../types/quiz';
+import { buildFeedbackUrl } from '../utils/question-feedback-url';
 import './ResultPage.css';
 
 interface ResultPageProps {
@@ -255,7 +256,26 @@ export function ResultPage({ result, onGoHome, onRetry }: ResultPageProps) {
                 <article key={answer.questionId} className="wrong-item">
                   <div className="wrong-number">#{index + 1}</div>
                   <div className="wrong-content">
-                    <p className="wrong-stem">{question.stem}</p>
+                    <div className="wrong-stem-row">
+                      <p className="wrong-stem">{question.stem}</p>
+                      {/* 回報此題（Refs #63）— 開新分頁、不打斷使用者瀏覽結果頁 */}
+                      <a
+                        className="question-feedback-link wrong-feedback-link"
+                        href={buildFeedbackUrl({
+                          questionId: question.id,
+                          stem: question.stem,
+                          fromPage: 'result',
+                        })}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        aria-label="回報此題的問題"
+                        title="此題有問題？回報維護者"
+                      >
+                        <span className="material-icons sm" aria-hidden="true">
+                          flag
+                        </span>
+                      </a>
+                    </div>
                     <div className="wrong-answers">
                       <span className="your-answer">
                         你的答案：

--- a/quiz-app/src/utils/question-feedback-url.test.ts
+++ b/quiz-app/src/utils/question-feedback-url.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import { buildFeedbackUrl } from './question-feedback-url';
+
+describe('buildFeedbackUrl (#63)', () => {
+  it('產生指向 issues/new 的 URL 並帶 template + q_id + q_stem + from_page', () => {
+    const url = buildFeedbackUrl({
+      questionId: 'gist-334',
+      stem: 'ISSB S1 描述何者錯誤？',
+      fromPage: 'quiz',
+    });
+    const u = new URL(url);
+    expect(u.origin + u.pathname).toBe(
+      'https://github.com/thc1006/ipas-net-zero-quiz/issues/new'
+    );
+    expect(u.searchParams.get('template')).toBe('question-feedback.yml');
+    expect(u.searchParams.get('q_id')).toBe('gist-334');
+    expect(u.searchParams.get('q_stem')).toBe('ISSB S1 描述何者錯誤？');
+    expect(u.searchParams.get('from_page')).toBe('quiz');
+  });
+
+  it('題幹超過 100 字會截斷並加省略號', () => {
+    const longStem = 'A'.repeat(150);
+    const url = buildFeedbackUrl({
+      questionId: 'q-1',
+      stem: longStem,
+      fromPage: 'result',
+    });
+    const stem = new URL(url).searchParams.get('q_stem')!;
+    expect(stem.length).toBe(101); // 100 + '…'
+    expect(stem.endsWith('…')).toBe(true);
+    expect(stem.startsWith('A'.repeat(100))).toBe(true);
+  });
+
+  it('題幹剛好 100 字不截斷不加省略號', () => {
+    const exactStem = 'A'.repeat(100);
+    const url = buildFeedbackUrl({
+      questionId: 'q-1',
+      stem: exactStem,
+      fromPage: 'quiz',
+    });
+    const stem = new URL(url).searchParams.get('q_stem')!;
+    expect(stem).toBe(exactStem);
+    expect(stem.endsWith('…')).toBe(false);
+  });
+
+  it('題幹前後空白會 trim', () => {
+    const url = buildFeedbackUrl({
+      questionId: 'q-1',
+      stem: '  題目開頭  ',
+      fromPage: 'quiz',
+    });
+    expect(new URL(url).searchParams.get('q_stem')).toBe('題目開頭');
+  });
+
+  it('特殊字元（中文、&、=）正確 percent-encode', () => {
+    const url = buildFeedbackUrl({
+      questionId: 'p&q=1',
+      stem: '依 IFRS S2 §15(a)',
+      fromPage: 'result',
+    });
+    const u = new URL(url);
+    // URLSearchParams 會自動正確 encode；URL 還原時 get() 回原值
+    expect(u.searchParams.get('q_id')).toBe('p&q=1');
+    expect(u.searchParams.get('q_stem')).toBe('依 IFRS S2 §15(a)');
+    // 確認 raw URL 有 percent-encoding 而非裸字元
+    expect(url).toMatch(/q_id=p%26q%3D1/);
+  });
+});

--- a/quiz-app/src/utils/question-feedback-url.ts
+++ b/quiz-app/src/utils/question-feedback-url.ts
@@ -1,0 +1,42 @@
+// 題目回報：生成 GitHub Issue 預填 URL（Refs #63）
+//
+// GitHub Issue Forms 支援以 query string 預填欄位值：
+//   /issues/new?template=<file>.yml&<field_id>=<encoded value>
+// 詳見：https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository
+
+const ISSUE_NEW_BASE =
+  'https://github.com/thc1006/ipas-net-zero-quiz/issues/new';
+const TEMPLATE = 'question-feedback.yml';
+const STEM_MAX_CHARS = 100;
+
+export interface QuestionFeedbackContext {
+  /** 題目 ID（gist-XXX / pool-XXX / item_id） */
+  questionId: string;
+  /** 題幹原文；會截斷至 STEM_MAX_CHARS 字 + 省略號 */
+  stem: string;
+  /** 回報來源頁；'quiz'（測驗中）或 'result'（結果頁錯題列表） */
+  fromPage: 'quiz' | 'result';
+}
+
+/**
+ * 把題幹截斷到 max 字。中文 1 char = 1 字元，已足夠定位題目。
+ */
+function truncateStem(stem: string, max = STEM_MAX_CHARS): string {
+  const trimmed = stem.trim();
+  if (trimmed.length <= max) return trimmed;
+  return trimmed.slice(0, max) + '…';
+}
+
+/**
+ * 生成 GitHub Issue 預填表單的 URL。
+ * Caller 用 `<a href={url} target="_blank" rel="noopener noreferrer">` 開新分頁，
+ * 不打斷使用者作答 / 看結果頁。
+ */
+export function buildFeedbackUrl(ctx: QuestionFeedbackContext): string {
+  const params = new URLSearchParams();
+  params.set('template', TEMPLATE);
+  params.set('q_id', ctx.questionId);
+  params.set('q_stem', truncateStem(ctx.stem));
+  params.set('from_page', ctx.fromPage);
+  return `${ISSUE_NEW_BASE}?${params.toString()}`;
+}


### PR DESCRIPTION
Closes #63

## 動機

依 issue #63 建立最小可行的使用者回報通道（per AnkiHub suggestion-workflow 啟示）：作答 / 看結果頁時點 flag icon → 開新分頁帶題目 ID + 題幹 prefix 跳到 GitHub issue 預填表單，使用者填補充說明送出。**零 server、零後端、所有資料 audit 留在 GitHub issues**。

## User-facing flow

1. 使用者在 QuizPage 答題中 / ResultPage 錯題列表中發現問題（答案不對、source 過時、選項有歧義...）
2. 點題目右上角 🚩 flag icon（hover tooltip：「此題有問題？回報維護者」）
3. **新分頁**開啟 GitHub issue 表單，q_id 與 q_stem 已自動帶入
4. 使用者選 dropdown 類型（答案錯 / 條號過時 / source 失效 / 選項歧義 / 題幹不清 / 重複 / 其他）+ 補充說明
5. 送出 → 自動 labelled `question-feedback` + `quiz-app:data`、title prefix `[題目回報]`

## 不打斷使用者 flow（per #63 UX 注意）

- icon-only 低調設計（hover 才顯灰底）
- `target="_blank"` + `rel="noopener noreferrer"` — **不離開**作答 / 結果頁
- 沒 confirm dialog（aria-label + tooltip 已足以避免誤觸）

## 改動

| 檔案 | 內容 |
|---|---|
| `.github/ISSUE_TEMPLATE/question-feedback.yml` (NEW) | GitHub Issue Forms YAML：q_id / q_stem / feedback_type dropdown / details / from_page |
| `quiz-app/src/utils/question-feedback-url.ts` (NEW) | `buildFeedbackUrl({ questionId, stem, fromPage })` — URLSearchParams encode、題幹截 100 字 |
| `quiz-app/src/utils/question-feedback-url.test.ts` (NEW) | 5 unit tests：happy path / 截斷 / 邊界 / 空白 trim / 特殊字元 percent-encode |
| `quiz-app/src/components/QuestionCard/QuestionCard.tsx` | header 加 `<a>` flag icon button (`fromPage: 'quiz'`) |
| `quiz-app/src/pages/ResultPage.tsx` | wrong-list 每項加同樣按鈕 (`fromPage: 'result'`)；wrong-stem 改 row layout 讓 icon 對齊 |
| QuestionCard.css + ResultPage.css | `.question-feedback-link` 樣式（兩處定義避免跨檔 import） |

## 配套：repo label

已透過 `gh label create question-feedback --color d876e3` 建好 repo-level label（顏色配 question 系 #d876e3）。新 issue 透過 template 自動帶上。

## a11y

- icon `aria-hidden="true"`
- button (`<a>`) `aria-label="回報此題的問題"` —「icon-only 元素」這條路徑必須有 aria-label（與「visible text + icon」不同；前者沒文字、後者有），不違反 WCAG SC 2.5.3
- `:focus-visible` outline 鍵盤可達

## Test plan

- [x] 380/380 unit tests pass（375 既有 + 5 URL helper）
- [x] tsc --noEmit clean
- [x] lint 無新警告
- [x] ISSUE_TEMPLATE YAML 為 GitHub Issue Forms 標準格式
- [ ] 部署後 manual smoke：
  - [ ] QuizPage 點 flag → 新分頁 GitHub issue 表單，q_id + q_stem 已預填
  - [ ] ResultPage 錯題 flag → 同上、from_page=result
  - [ ] mobile 點按鈕仍可達（不被 hover 樣式擋）
  - [ ] keyboard Tab 可 focus → Enter 開新分頁
  - [ ] SR 唸出「回報此題的問題」

## 不做（per #63 unfaq）

- 不直接寫題庫 API（仍是 PR-based maintainer review）
- 不收集匿名統計（屬 #64 範疇）
- 不做即時推送通知