### PR TITLE
feat(stats): per-question local correctness rate + show on QuestionCard (#64)

### DIFF
--- a/quiz-app/src/components/QuestionCard/QuestionCard.css
+++ b/quiz-app/src/components/QuestionCard/QuestionCard.css
@@ -21,6 +21,21 @@
   color: var(--color-text-secondary);
 }
 
+/* 個人作答歷史 chip（Refs #64） */
+.question-stat-chip {
+  font-size: var(--font-size-xs);
+  color: var(--color-text-secondary);
+  background: var(--color-surface-variant);
+  padding: 2px 8px;
+  border-radius: var(--radius-sm);
+  white-space: nowrap;
+  margin-left: auto;
+}
+.question-stat-chip__count {
+  margin-left: 2px;
+  opacity: 0.75;
+}
+
 /* 回報此題 icon button（#63）— 低調 icon-only、開新分頁不打斷答題 flow */
 .question-feedback-link {
   display: inline-flex;
@@ -28,6 +43,9 @@
   justify-content: center;
   width: 28px;
   height: 28px;
+  /* 兩個 margin-left:auto 並存 — 渲染時前者「先佔」剩餘空間，
+     兩者同時存在時 chip 把自己 + feedback link 推到右側群組；
+     無 chip 時 feedback link 自己貼右 */
   margin-left: auto;
   border-radius: var(--radius-sm);
   color: var(--color-text-secondary);

--- a/quiz-app/src/components/QuestionCard/QuestionCard.test.tsx
+++ b/quiz-app/src/components/QuestionCard/QuestionCard.test.tsx
@@ -217,6 +217,71 @@ describe('QuestionCard 元件', () => {
       expect(options).toHaveLength(4);
     });
   });
+
+  describe('作答歷史 chip（Refs #64）', () => {
+    // 這些測試在 question-stats-storage 真實 mock 下跑
+    // (test-setup 的 vi.fn() 預設會回 undefined → loadStats 視為空)
+    it('未作答過的題目顯示「新題目」', () => {
+      render(
+        <QuestionCard
+          question={mockQuestion}
+          questionNumber={1}
+          onSelectAnswer={vi.fn()}
+        />
+      );
+      expect(screen.getByTestId('question-stat-chip')).toHaveTextContent('新題目');
+    });
+
+    it('無標準答案題目（hasAnswer=false）不渲染 chip', () => {
+      render(
+        <QuestionCard
+          question={{ ...mockQuestion, answer: null, hasAnswer: false }}
+          questionNumber={1}
+          onSelectAnswer={vi.fn()}
+        />
+      );
+      expect(screen.queryByTestId('question-stat-chip')).not.toBeInTheDocument();
+    });
+
+    it('已有 stats 時顯示答對率 + 次數', () => {
+      // 安裝 real localStorage 並寫入該題 stats
+      const store = new Map<string, string>();
+      store.set(
+        'ipas-question-stats',
+        JSON.stringify({
+          version: 1,
+          items: { [mockQuestion.id]: { attempts: 5, correct: 3, lastTriedAt: 0 } },
+        })
+      );
+      Object.defineProperty(globalThis, 'localStorage', {
+        value: {
+          getItem: (k: string) => store.get(k) ?? null,
+          setItem: (k: string, v: string) => store.set(k, v),
+          removeItem: (k: string) => {
+            store.delete(k);
+          },
+          clear: () => store.clear(),
+          key: (i: number) => Array.from(store.keys())[i] ?? null,
+          get length() {
+            return store.size;
+          },
+        },
+        writable: true,
+        configurable: true,
+      });
+
+      render(
+        <QuestionCard
+          question={mockQuestion}
+          questionNumber={1}
+          onSelectAnswer={vi.fn()}
+        />
+      );
+      const chip = screen.getByTestId('question-stat-chip');
+      expect(chip).toHaveTextContent(/答對率\s*60%/);
+      expect(chip).toHaveTextContent(/5 次/);
+    });
+  });
 });
 
 describe('QuestionCard 冗餘前綴 dim 化', () => {

--- a/quiz-app/src/components/QuestionCard/QuestionCard.tsx
+++ b/quiz-app/src/components/QuestionCard/QuestionCard.tsx
@@ -7,7 +7,7 @@ import { SourceBanner } from '../SourceBanner/SourceBanner';
 import { LAW_PCODE_LABELS } from '../../data/law-pcode-labels';
 import { findRedundantPrefix } from '../../utils/option-prefix';
 import { buildFeedbackUrl } from '../../utils/question-feedback-url';
-import { loadStats } from '../../utils/question-stats-storage';
+import { useAllQuestionStats } from '../../hooks/useQuestionStats';
 import './QuestionCard.css';
 
 /**
@@ -67,13 +67,13 @@ export function QuestionCard({
     () => findRedundantPrefix(question.stem, question.options.map((o) => o.text)),
     [question.stem, question.options],
   );
-  // 每題作答統計 chip（Refs #64）— 只在 mount 時 / question.id 變動時讀
-  // 一次 localStorage，不隨 selectedAnswer 等狀態 re-render 重讀
-  const stat = useMemo(() => {
-    if (!question.hasAnswer) return null;
-    const s = loadStats()[question.id];
-    return s ?? null;
-  }, [question.id, question.hasAnswer]);
+  // 每題作答統計 chip（Refs #64）— 透過 useAllQuestionStats 訂閱跨 tab 變更
+  // （另一分頁 clearStats / 完成 quiz 時自動 refresh），無答案題不顯示
+  const allStats = useAllQuestionStats();
+  const stat = useMemo(
+    () => (question.hasAnswer ? allStats[question.id] ?? null : null),
+    [question.id, question.hasAnswer, allStats]
+  );
   const [isLoadingAI, setIsLoadingAI] = useState(false);
 
   const getOptionStatus = useCallback(

--- a/quiz-app/src/components/QuestionCard/QuestionCard.tsx
+++ b/quiz-app/src/components/QuestionCard/QuestionCard.tsx
@@ -149,10 +149,12 @@ export function QuestionCard({
             qualityFlags={question.qualityFlags ?? []}
           />
         )}
-        {/* 個人作答歷史 chip（Refs #64）— 只在有標準答案的題目顯示 */}
+        {/* 個人作答歷史 chip（Refs #64）— 只在有標準答案的題目顯示
+            stat.attempts > 0 雙重保險：storage validator 已拒絕 attempts<1，
+            這裡再 guard 避免任何漏網路徑導致 NaN%（Copilot PR #80） */}
         {question.hasAnswer && (
           <span className="question-stat-chip" data-testid="question-stat-chip">
-            {stat ? (
+            {stat && stat.attempts > 0 ? (
               <>
                 答對率 {Math.round((stat.correct / stat.attempts) * 100)}%
                 <span className="question-stat-chip__count">（{stat.attempts} 次）</span>

--- a/quiz-app/src/components/QuestionCard/QuestionCard.tsx
+++ b/quiz-app/src/components/QuestionCard/QuestionCard.tsx
@@ -7,6 +7,7 @@ import { SourceBanner } from '../SourceBanner/SourceBanner';
 import { LAW_PCODE_LABELS } from '../../data/law-pcode-labels';
 import { findRedundantPrefix } from '../../utils/option-prefix';
 import { buildFeedbackUrl } from '../../utils/question-feedback-url';
+import { loadStats } from '../../utils/question-stats-storage';
 import './QuestionCard.css';
 
 /**
@@ -66,6 +67,13 @@ export function QuestionCard({
     () => findRedundantPrefix(question.stem, question.options.map((o) => o.text)),
     [question.stem, question.options],
   );
+  // 每題作答統計 chip（Refs #64）— 只在 mount 時 / question.id 變動時讀
+  // 一次 localStorage，不隨 selectedAnswer 等狀態 re-render 重讀
+  const stat = useMemo(() => {
+    if (!question.hasAnswer) return null;
+    const s = loadStats()[question.id];
+    return s ?? null;
+  }, [question.id, question.hasAnswer]);
   const [isLoadingAI, setIsLoadingAI] = useState(false);
 
   const getOptionStatus = useCallback(
@@ -140,6 +148,19 @@ export function QuestionCard({
             sourceType={question.provenance.source_type}
             qualityFlags={question.qualityFlags ?? []}
           />
+        )}
+        {/* 個人作答歷史 chip（Refs #64）— 只在有標準答案的題目顯示 */}
+        {question.hasAnswer && (
+          <span className="question-stat-chip" data-testid="question-stat-chip">
+            {stat ? (
+              <>
+                答對率 {Math.round((stat.correct / stat.attempts) * 100)}%
+                <span className="question-stat-chip__count">（{stat.attempts} 次）</span>
+              </>
+            ) : (
+              '新題目'
+            )}
+          </span>
         )}
         {/* 回報此題（Refs #63）— 開新分頁不打斷答題 flow；icon-only 但有 aria-label */}
         <a

--- a/quiz-app/src/hooks/useQuestionStats.test.ts
+++ b/quiz-app/src/hooks/useQuestionStats.test.ts
@@ -1,0 +1,112 @@
+// useQuestionStats 跨 tab 同步測試（Refs #64）
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+import { useAllQuestionStats } from './useQuestionStats';
+
+const STATS_KEY = 'ipas-question-stats';
+
+function installRealLocalStorage() {
+  const store = new Map<string, string>();
+  Object.defineProperty(globalThis, 'localStorage', {
+    value: {
+      getItem: (k: string) => store.get(k) ?? null,
+      setItem: (k: string, v: string) => store.set(k, v),
+      removeItem: (k: string) => {
+        store.delete(k);
+      },
+      clear: () => store.clear(),
+      key: (i: number) => Array.from(store.keys())[i] ?? null,
+      get length() {
+        return store.size;
+      },
+    },
+    writable: true,
+    configurable: true,
+  });
+}
+
+describe('useAllQuestionStats（Refs #64）', () => {
+  beforeEach(() => {
+    installRealLocalStorage();
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it('初始 mount 時讀取 localStorage 既有 stats', () => {
+    localStorage.setItem(
+      STATS_KEY,
+      JSON.stringify({
+        version: 1,
+        items: { q1: { attempts: 3, correct: 2, lastTriedAt: 1 } },
+      })
+    );
+    const { result } = renderHook(() => useAllQuestionStats());
+    expect(result.current).toEqual({ q1: { attempts: 3, correct: 2, lastTriedAt: 1 } });
+  });
+
+  it('localStorage 為空時回 {}', () => {
+    const { result } = renderHook(() => useAllQuestionStats());
+    expect(result.current).toEqual({});
+  });
+
+  it('storage 事件（其他 tab 改 stats key）觸發 refresh', () => {
+    const { result } = renderHook(() => useAllQuestionStats());
+    expect(result.current).toEqual({});
+
+    // 模擬另一 tab 寫入並 dispatch storage event
+    localStorage.setItem(
+      STATS_KEY,
+      JSON.stringify({
+        version: 1,
+        items: { q2: { attempts: 5, correct: 3, lastTriedAt: 100 } },
+      })
+    );
+    act(() => {
+      window.dispatchEvent(new StorageEvent('storage', { key: STATS_KEY }));
+    });
+    expect(result.current).toEqual({ q2: { attempts: 5, correct: 3, lastTriedAt: 100 } });
+  });
+
+  it('storage 事件（key=null，另一 tab 呼 localStorage.clear）觸發 refresh', () => {
+    localStorage.setItem(
+      STATS_KEY,
+      JSON.stringify({
+        version: 1,
+        items: { q1: { attempts: 3, correct: 2, lastTriedAt: 1 } },
+      })
+    );
+    const { result } = renderHook(() => useAllQuestionStats());
+    expect(result.current).toEqual({ q1: { attempts: 3, correct: 2, lastTriedAt: 1 } });
+
+    // 另一 tab clear()，再 dispatch event with key=null
+    localStorage.removeItem(STATS_KEY);
+    act(() => {
+      window.dispatchEvent(new StorageEvent('storage', { key: null }));
+    });
+    expect(result.current).toEqual({});
+  });
+
+  it('storage 事件 key 為其他 key 時不 refresh', () => {
+    const { result } = renderHook(() => useAllQuestionStats());
+    const before = result.current;
+
+    act(() => {
+      window.dispatchEvent(
+        new StorageEvent('storage', { key: 'unrelated-key' })
+      );
+    });
+    // 還是同一個 reference（沒重抓）— 用 reference equality 確認
+    expect(result.current).toBe(before);
+  });
+
+  it('unmount 時移除 listener（不 leak）', () => {
+    const { unmount } = renderHook(() => useAllQuestionStats());
+    unmount();
+    // unmount 後 dispatch event 不應 throw（沒 listener）
+    expect(() => {
+      window.dispatchEvent(new StorageEvent('storage', { key: STATS_KEY }));
+    }).not.toThrow();
+  });
+});

--- a/quiz-app/src/hooks/useQuestionStats.ts
+++ b/quiz-app/src/hooks/useQuestionStats.ts
@@ -1,0 +1,26 @@
+// 每題作答統計（Refs #64）— React 端讀取 + 跨 tab 同步
+//
+// 動機：QuestionCard / ResultPage 原本 mount 時讀一次 localStorage，
+// 若使用者另開分頁清除 stats 或完成另一份 quiz，當前分頁不會更新。
+// 透過 `storage` 事件（瀏覽器只在「其他 tab」改 storage 時觸發）即時同步。
+import { useEffect, useState } from 'react';
+import { loadStats, type QuestionStat } from '../utils/question-stats-storage';
+
+const STORAGE_KEY = 'ipas-question-stats';
+
+/** Returns the full stats dict; refreshes when another tab updates storage. */
+export function useAllQuestionStats(): Record<string, QuestionStat> {
+  const [stats, setStats] = useState<Record<string, QuestionStat>>(() => loadStats());
+  useEffect(() => {
+    const onStorage = (e: StorageEvent) => {
+      // e.key === null：另一 tab 呼叫 localStorage.clear()
+      // e.key === STORAGE_KEY：另一 tab 改了我們這支 key
+      if (e.key === STORAGE_KEY || e.key === null) {
+        setStats(loadStats());
+      }
+    };
+    window.addEventListener('storage', onStorage);
+    return () => window.removeEventListener('storage', onStorage);
+  }, []);
+  return stats;
+}

--- a/quiz-app/src/hooks/useQuiz.test.ts
+++ b/quiz-app/src/hooks/useQuiz.test.ts
@@ -538,4 +538,151 @@ describe('useQuiz Hook', () => {
       expect(result.current.isActive).toBe(true);
     });
   });
+
+  // === per-question stats（Refs #64） ===
+  // finishQuiz 寫入 question-stats；softReset / resetQuiz 不寫
+  describe('per-question stats', () => {
+    const STATS_KEY = 'ipas-question-stats';
+
+    beforeEach(() => {
+      const store = new Map<string, string>();
+      Object.defineProperty(window, 'localStorage', {
+        value: {
+          getItem: (k: string): string | null => store.get(k) ?? null,
+          setItem: (k: string, v: string): void => {
+            store.set(k, v);
+          },
+          removeItem: (k: string): void => {
+            store.delete(k);
+          },
+          clear: (): void => {
+            store.clear();
+          },
+          key: (i: number): string | null => Array.from(store.keys())[i] ?? null,
+          get length(): number {
+            return store.size;
+          },
+        },
+        writable: true,
+        configurable: true,
+      });
+    });
+
+    function readStats(): Record<string, { attempts: number; correct: number; lastTriedAt: number }> {
+      const raw = window.localStorage.getItem(STATS_KEY);
+      if (!raw) return {};
+      const parsed = JSON.parse(raw) as { items: Record<string, { attempts: number; correct: number; lastTriedAt: number }> };
+      return parsed.items;
+    }
+
+    it('finishQuiz 後寫入 attempts + correct', () => {
+      const { result } = renderHook(() => useQuiz());
+      act(() => {
+        result.current.startQuiz({ ...defaultConfig, questionCount: 3, shuffleQuestions: false });
+      });
+
+      const q1 = result.current.currentQuestion;
+      act(() => { result.current.submitAnswer(q1?.answer ?? 'Z'); });
+      act(() => { result.current.nextQuestion(); });
+      const q2 = result.current.currentQuestion;
+      act(() => { result.current.submitAnswer('Z'); }); // 故意錯
+      act(() => { result.current.finishQuiz(); });
+
+      const stats = readStats();
+      // q1 答對：attempts=1, correct=1（僅當該題有標準答案）
+      if (q1?.answer != null) {
+        expect(stats[q1.id]?.attempts).toBe(1);
+        expect(stats[q1.id]?.correct).toBe(1);
+      }
+      // q2 答錯：attempts=1, correct=0（僅當該題有標準答案）
+      if (q2?.answer != null) {
+        expect(stats[q2.id]?.attempts).toBe(1);
+        expect(stats[q2.id]?.correct).toBe(0);
+      }
+    });
+
+    it('跳過的題目（沒呼叫 submitAnswer）不寫 stats', () => {
+      const { result } = renderHook(() => useQuiz());
+      act(() => {
+        result.current.startQuiz({ ...defaultConfig, questionCount: 3, shuffleQuestions: false });
+      });
+
+      const q1 = result.current.currentQuestion;
+      // 只答 q1，q2 q3 跳過
+      act(() => { result.current.submitAnswer(q1?.answer ?? 'Z'); });
+      act(() => { result.current.finishQuiz(); });
+
+      const stats = readStats();
+      // q1 之外不應有其他項目（cap 1 個）
+      const keys = Object.keys(stats);
+      expect(keys.length).toBeLessThanOrEqual(1);
+    });
+
+    it('同一題在同一 quiz 內被覆寫（GH #59）只算 1 次 attempt', () => {
+      const { result } = renderHook(() => useQuiz());
+      act(() => {
+        result.current.startQuiz({ ...defaultConfig, questionCount: 3, shuffleQuestions: false });
+      });
+      const q1 = result.current.currentQuestion;
+      if (q1?.answer == null) return; // 該題無標準答案則略過
+
+      // 同題答 3 次（最後留 q1.answer）
+      act(() => { result.current.submitAnswer('Z'); });
+      act(() => { result.current.submitAnswer('Y'); });
+      act(() => { result.current.submitAnswer(q1.answer!); });
+      act(() => { result.current.finishQuiz(); });
+
+      const stats = readStats();
+      expect(stats[q1.id]?.attempts).toBe(1);
+      expect(stats[q1.id]?.correct).toBe(1);
+    });
+
+    it('跨 quiz session attempts 累計', () => {
+      const { result } = renderHook(() => useQuiz());
+
+      // 第一輪
+      act(() => {
+        result.current.startQuiz({ ...defaultConfig, questionCount: 1, shuffleQuestions: false });
+      });
+      const q1 = result.current.currentQuestion;
+      if (q1?.answer == null) return;
+      act(() => { result.current.submitAnswer(q1.answer!); });
+      act(() => { result.current.finishQuiz(); });
+
+      // 第二輪同題（shuffleQuestions=false 順序穩定）
+      act(() => {
+        result.current.startQuiz({ ...defaultConfig, questionCount: 1, shuffleQuestions: false });
+      });
+      act(() => { result.current.submitAnswer('Z'); }); // 故意錯
+      act(() => { result.current.finishQuiz(); });
+
+      const stats = readStats();
+      expect(stats[q1.id]?.attempts).toBe(2);
+      expect(stats[q1.id]?.correct).toBe(1);
+    });
+
+    it('resetQuiz 不寫 stats', () => {
+      const { result } = renderHook(() => useQuiz());
+      act(() => {
+        result.current.startQuiz({ ...defaultConfig, questionCount: 3, shuffleQuestions: false });
+      });
+      const q1 = result.current.currentQuestion;
+      act(() => { result.current.submitAnswer(q1?.answer ?? 'Z'); });
+      act(() => { result.current.resetQuiz(); });
+
+      expect(window.localStorage.getItem(STATS_KEY)).toBeNull();
+    });
+
+    it('softReset（abort）不寫 stats', () => {
+      const { result } = renderHook(() => useQuiz());
+      act(() => {
+        result.current.startQuiz({ ...defaultConfig, questionCount: 3, shuffleQuestions: false });
+      });
+      const q1 = result.current.currentQuestion;
+      act(() => { result.current.submitAnswer(q1?.answer ?? 'Z'); });
+      act(() => { result.current.softReset(); });
+
+      expect(window.localStorage.getItem(STATS_KEY)).toBeNull();
+    });
+  });
 });

--- a/quiz-app/src/hooks/useQuiz.ts
+++ b/quiz-app/src/hooks/useQuiz.ts
@@ -18,6 +18,10 @@ import {
   loadProgress,
   clearProgress,
 } from '../utils/quiz-progress-storage';
+import {
+  recordAttempts,
+  type AttemptUpdate,
+} from '../utils/question-stats-storage';
 
 /** 測驗狀態 */
 export interface QuizState {
@@ -291,6 +295,17 @@ export function useQuiz() {
       wrongCount,
       skippedCount: questions.length - answers.length,
     };
+
+    // 累積每題作答統計（Refs #64）— 跳題（selectedAnswer=null）與
+    // 無標準答案題（correctAnswer=null）都不算 attempt
+    const statUpdates: AttemptUpdate[] = answers
+      .filter((a) => a.correctAnswer !== null && a.selectedAnswer !== null)
+      .map((a) => ({
+        id: a.questionId,
+        isCorrect: a.isCorrect === true,
+        at: a.timestamp,
+      }));
+    recordAttempts(statUpdates);
 
     clearProgress();
     setState(initialState);

--- a/quiz-app/src/pages/ResultPage.css
+++ b/quiz-app/src/pages/ResultPage.css
@@ -184,6 +184,79 @@
   color: var(--color-text-muted);
 }
 
+/* 最常答錯區（Refs #64）— 顯示累積歷史弱題，排在 wrong-section 前 */
+.weak-section {
+  margin-bottom: var(--spacing-lg);
+}
+
+.weak-section h2 {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  font-size: var(--font-size-lg);
+  color: var(--color-warning);
+  margin-bottom: var(--spacing-xs);
+}
+
+.weak-section__hint {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
+  margin-bottom: var(--spacing-md);
+}
+
+.weak-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+}
+
+.weak-item {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  padding: var(--spacing-sm);
+  background: var(--color-surface-variant);
+  border-radius: var(--radius-sm);
+  border-left: 3px solid var(--color-warning);
+}
+
+.weak-rank {
+  font-size: var(--font-size-sm);
+  font-weight: 600;
+  color: var(--color-text-secondary);
+  min-width: 28px;
+}
+
+.weak-stem {
+  flex: 1;
+  font-size: var(--font-size-sm);
+  margin: 0;
+  line-height: 1.5;
+  /* 多行截斷避免過長題幹擠壓 */
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.weak-rate {
+  font-size: var(--font-size-sm);
+  font-weight: 600;
+  color: var(--color-error);
+  white-space: nowrap;
+}
+
+.weak-rate__count {
+  margin-left: 4px;
+  font-weight: 400;
+  font-size: var(--font-size-xs);
+  color: var(--color-text-secondary);
+}
+
 /* 錯題區 */
 .wrong-section {
   margin-bottom: var(--spacing-lg);

--- a/quiz-app/src/pages/ResultPage.test.tsx
+++ b/quiz-app/src/pages/ResultPage.test.tsx
@@ -7,26 +7,35 @@ import type { QuizResult, QuizQuestion, AnswerRecord } from '../types/quiz';
 
 // 在 import ResultPage 前先 mock 資料層，否則 ResultPage import 時會吃真實題庫
 vi.mock('../data/questions', () => {
+  const baseOptions = [
+    { key: 'A', text: 'CO2' },
+    { key: 'B', text: 'O2' },
+    { key: 'C', text: 'N2' },
+    { key: 'D', text: 'Ar' },
+  ];
   const fixture: QuizQuestion = {
     id: 'fx-001',
     number: 1,
     stem: '測試題目：下列何者為溫室氣體？',
-    options: [
-      { key: 'A', text: 'CO2' },
-      { key: 'B', text: 'O2' },
-      { key: 'C', text: 'N2' },
-      { key: 'D', text: 'Ar' },
-    ],
+    options: baseOptions,
     answer: 'A',
     subject: '考科1',
     section: 'fixture',
     explanation: '二氧化碳為主要溫室氣體',
   } as unknown as QuizQuestion;
+  // Refs #64：weak-section 測試需要多個可解析的 id
+  const weakFixtures: Record<string, QuizQuestion> = {
+    'fx-weak-1': { ...fixture, id: 'fx-weak-1', stem: '弱題一：題幹一' },
+    'fx-weak-2': { ...fixture, id: 'fx-weak-2', stem: '弱題二：題幹二' },
+    'fx-strong': { ...fixture, id: 'fx-strong', stem: '強題（不該出現）' },
+  };
+  const all = [fixture, ...Object.values(weakFixtures)];
   return {
-    allQuestions: [fixture],
-    getQuestionById: (id: string) => (id === 'fx-001' ? fixture : undefined),
+    allQuestions: all,
+    getQuestionById: (id: string) =>
+      id === 'fx-001' ? fixture : weakFixtures[id] ?? undefined,
     getSimilarQuestions: () => [],
-    stats: { total: 1, subject1: 1, subject2: 0 },
+    stats: { total: all.length, subject1: all.length, subject2: 0 },
   };
 });
 
@@ -211,5 +220,79 @@ describe('ResultPage', () => {
     );
     // section 仍渲染，但內部沒有 wrong-item
     expect(screen.getByText(/錯誤題目 \(1 題\)/)).toBeInTheDocument();
+  });
+
+  // === 最常答錯 weak-section（Refs #64）===
+  describe('最常答錯 section', () => {
+    function installStatsLocalStorage(
+      items: Record<string, { attempts: number; correct: number; lastTriedAt: number }>
+    ) {
+      const store = new Map<string, string>();
+      if (Object.keys(items).length > 0) {
+        store.set('ipas-question-stats', JSON.stringify({ version: 1, items }));
+      }
+      Object.defineProperty(globalThis, 'localStorage', {
+        value: {
+          getItem: (k: string) => store.get(k) ?? null,
+          setItem: (k: string, v: string) => store.set(k, v),
+          removeItem: (k: string) => {
+            store.delete(k);
+          },
+          clear: () => store.clear(),
+          key: (i: number) => Array.from(store.keys())[i] ?? null,
+          get length() {
+            return store.size;
+          },
+        },
+        writable: true,
+        configurable: true,
+      });
+    }
+
+    it('完全沒 stats 時不渲染 weak-section', () => {
+      installStatsLocalStorage({});
+      render(<ResultPage result={makeResult()} onGoHome={() => {}} onRetry={() => {}} />);
+      expect(screen.queryByTestId('weak-section')).not.toBeInTheDocument();
+    });
+
+    it('attempts < 3 或 rate >= 0.5 時不渲染 weak-section', () => {
+      installStatsLocalStorage({
+        'fx-strong': { attempts: 5, correct: 5, lastTriedAt: 1 }, // 100% 過濾
+        'fx-weak-1': { attempts: 2, correct: 0, lastTriedAt: 2 }, // attempts 不足
+      });
+      render(<ResultPage result={makeResult()} onGoHome={() => {}} onRetry={() => {}} />);
+      expect(screen.queryByTestId('weak-section')).not.toBeInTheDocument();
+    });
+
+    it('有 weak 題目時渲染 + 題幹 + 答對率 + 順序（rate 升冪）', () => {
+      installStatsLocalStorage({
+        'fx-weak-1': { attempts: 5, correct: 1, lastTriedAt: 100 }, // 20%
+        'fx-weak-2': { attempts: 4, correct: 1, lastTriedAt: 200 }, // 25%
+        'fx-strong': { attempts: 5, correct: 5, lastTriedAt: 300 }, // 100% 過濾
+      });
+      render(<ResultPage result={makeResult()} onGoHome={() => {}} onRetry={() => {}} />);
+
+      const section = screen.getByTestId('weak-section');
+      expect(section).toBeInTheDocument();
+      expect(section).toHaveTextContent('弱題一');
+      expect(section).toHaveTextContent('弱題二');
+      expect(section).not.toHaveTextContent('強題');
+      expect(section).toHaveTextContent('20%');
+      expect(section).toHaveTextContent('25%');
+      // rate 升冪：20% 在 25% 之前
+      const html = section.innerHTML;
+      expect(html.indexOf('弱題一')).toBeLessThan(html.indexOf('弱題二'));
+    });
+
+    it('找不到題幹（getQuestionById 回 undefined）的 stats 被過濾', () => {
+      installStatsLocalStorage({
+        'unknown-orphan': { attempts: 10, correct: 0, lastTriedAt: 1 },
+        'fx-weak-1': { attempts: 5, correct: 2, lastTriedAt: 2 }, // 40%
+      });
+      render(<ResultPage result={makeResult()} onGoHome={() => {}} onRetry={() => {}} />);
+      const section = screen.getByTestId('weak-section');
+      expect(section).toHaveTextContent('弱題一');
+      expect(section).not.toHaveTextContent('unknown-orphan');
+    });
   });
 });

--- a/quiz-app/src/pages/ResultPage.tsx
+++ b/quiz-app/src/pages/ResultPage.tsx
@@ -9,7 +9,12 @@ import {
 import { SourceBreakdown } from '../components/SourceBreakdown/SourceBreakdown';
 import type { QuizResult, QuizQuestion } from '../types/quiz';
 import { buildFeedbackUrl } from '../utils/question-feedback-url';
+import { loadStats, selectWeakQuestions } from '../utils/question-stats-storage';
 import './ResultPage.css';
+
+const WEAK_MIN_ATTEMPTS = 3;
+const WEAK_MAX_RATE = 0.5;
+const WEAK_LIST_LIMIT = 10;
 
 interface ResultPageProps {
   result: QuizResult;
@@ -56,6 +61,24 @@ export function ResultPage({ result, onGoHome, onRetry }: ResultPageProps) {
     () => answers.filter((a) => a.isCorrect === false),
     [answers]
   );
+
+  // 累積最常答錯（Refs #64）— pure 篩選/排序在 selectWeakQuestions，
+  // 此處只負責 id → 題幹查找（沒查到的就過濾掉，多為已被刪除題或 pool 題未載入）
+  // 注意：finishQuiz 已寫入本次 quiz 的 stats，所以這裡讀到的含本場結果累積值
+  const weakQuestions = useMemo(() => {
+    const stats = loadStats();
+    const weak = selectWeakQuestions(stats, {
+      minAttempts: WEAK_MIN_ATTEMPTS,
+      maxRate: WEAK_MAX_RATE,
+      limit: WEAK_LIST_LIMIT,
+    });
+    return weak
+      .map((w) => {
+        const q = getQuestionById(w.id);
+        return q ? { ...w, stem: q.stem } : null;
+      })
+      .filter((x): x is NonNullable<typeof x> => x !== null);
+  }, []);
 
   // 請求 AI 解釋特定題目（Streaming）
   const handleAskAI = useCallback(async (question: QuizQuestion) => {
@@ -208,6 +231,31 @@ export function ResultPage({ result, onGoHome, onRetry }: ResultPageProps) {
 
       {/* 按題目來源分組的正確率（僅啟用練習池且抽到池題時顯示） */}
       <SourceBreakdown answers={answers} />
+
+      {/* 最常答錯（Refs #64）— 累積 ≥3 次且答對率 <50% 的歷史弱題 */}
+      {weakQuestions.length > 0 && (
+        <section className="weak-section card" data-testid="weak-section">
+          <h2>
+            <span className="material-icons" aria-hidden="true">trending_down</span>
+            最常答錯
+          </h2>
+          <p className="weak-section__hint">
+            根據你過去作答紀錄（≥ {WEAK_MIN_ATTEMPTS} 次且答對率低於 50%）
+          </p>
+          <ul className="weak-list">
+            {weakQuestions.map((w, i) => (
+              <li key={w.id} className="weak-item">
+                <span className="weak-rank">#{i + 1}</span>
+                <p className="weak-stem">{w.stem}</p>
+                <span className="weak-rate" aria-label={`答對 ${w.correct} 次、共 ${w.attempts} 次`}>
+                  {Math.round(w.rate * 100)}%
+                  <span className="weak-rate__count">（{w.correct}/{w.attempts}）</span>
+                </span>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
 
       {/* 錯題列表 */}
       {wrongAnswers.length > 0 && (

--- a/quiz-app/src/pages/ResultPage.tsx
+++ b/quiz-app/src/pages/ResultPage.tsx
@@ -240,7 +240,7 @@ export function ResultPage({ result, onGoHome, onRetry }: ResultPageProps) {
             最常答錯
           </h2>
           <p className="weak-section__hint">
-            根據你過去作答紀錄（≥ {WEAK_MIN_ATTEMPTS} 次且答對率低於 50%）
+            根據你過去作答紀錄（≥ {WEAK_MIN_ATTEMPTS} 次且答對率低於 {Math.round(WEAK_MAX_RATE * 100)}%）
           </p>
           <ul className="weak-list">
             {weakQuestions.map((w, i) => (

--- a/quiz-app/src/pages/ResultPage.tsx
+++ b/quiz-app/src/pages/ResultPage.tsx
@@ -9,7 +9,8 @@ import {
 import { SourceBreakdown } from '../components/SourceBreakdown/SourceBreakdown';
 import type { QuizResult, QuizQuestion } from '../types/quiz';
 import { buildFeedbackUrl } from '../utils/question-feedback-url';
-import { loadStats, selectWeakQuestions } from '../utils/question-stats-storage';
+import { selectWeakQuestions } from '../utils/question-stats-storage';
+import { useAllQuestionStats } from '../hooks/useQuestionStats';
 import './ResultPage.css';
 
 const WEAK_MIN_ATTEMPTS = 3;
@@ -64,10 +65,10 @@ export function ResultPage({ result, onGoHome, onRetry }: ResultPageProps) {
 
   // 累積最常答錯（Refs #64）— pure 篩選/排序在 selectWeakQuestions，
   // 此處只負責 id → 題幹查找（沒查到的就過濾掉，多為已被刪除題或 pool 題未載入）
-  // 注意：finishQuiz 已寫入本次 quiz 的 stats，所以這裡讀到的含本場結果累積值
+  // 透過 useAllQuestionStats 訂閱跨 tab 變更：別的分頁清除統計時，本頁也即時更新
+  const allStats = useAllQuestionStats();
   const weakQuestions = useMemo(() => {
-    const stats = loadStats();
-    const weak = selectWeakQuestions(stats, {
+    const weak = selectWeakQuestions(allStats, {
       minAttempts: WEAK_MIN_ATTEMPTS,
       maxRate: WEAK_MAX_RATE,
       limit: WEAK_LIST_LIMIT,
@@ -78,7 +79,7 @@ export function ResultPage({ result, onGoHome, onRetry }: ResultPageProps) {
         return q ? { ...w, stem: q.stem } : null;
       })
       .filter((x): x is NonNullable<typeof x> => x !== null);
-  }, []);
+  }, [allStats]);
 
   // 請求 AI 解釋特定題目（Streaming）
   const handleAskAI = useCallback(async (question: QuizQuestion) => {

--- a/quiz-app/src/pages/SettingsPage.css
+++ b/quiz-app/src/pages/SettingsPage.css
@@ -210,3 +210,52 @@
     align-self: flex-end;
   }
 }
+
+/* 清除作答統計確認 dialog（Refs #64）— 與 quiz-abort-dialog 同 pattern */
+.settings-confirm-dialog-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  padding: var(--spacing-md);
+}
+
+.settings-confirm-dialog {
+  background: var(--color-surface);
+  border-radius: var(--radius-md);
+  padding: var(--spacing-lg);
+  max-width: 480px;
+  width: 100%;
+  box-shadow: var(--shadow-2);
+}
+
+.settings-confirm-dialog h2 {
+  font-size: var(--font-size-lg);
+  font-weight: 600;
+  margin: 0 0 var(--spacing-sm);
+  color: var(--color-text-primary);
+}
+
+.settings-confirm-dialog p {
+  margin: 0 0 var(--spacing-lg);
+  color: var(--color-text-secondary);
+  line-height: 1.6;
+}
+
+.settings-confirm-dialog__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--spacing-sm);
+}
+
+@media (max-width: 640px) {
+  .settings-confirm-dialog__actions {
+    flex-direction: column-reverse;
+  }
+  .settings-confirm-dialog__actions .btn {
+    width: 100%;
+  }
+}

--- a/quiz-app/src/pages/SettingsPage.test.tsx
+++ b/quiz-app/src/pages/SettingsPage.test.tsx
@@ -77,4 +77,32 @@ describe('SettingsPage', () => {
     fireEvent.click(toggle);
     expect(localStorage.getItem('practice-pool-enabled')).toBe('0');
   });
+
+  // 清除作答統計按鈕（Refs #64）
+  describe('清除作答統計', () => {
+    const STATS_KEY = 'ipas-question-stats';
+    const sampleStats = JSON.stringify({
+      version: 1,
+      items: { q1: { attempts: 3, correct: 1, lastTriedAt: 1 } },
+    });
+
+    it('confirm 確認時呼叫 clearStats，移除 localStorage 紀錄', () => {
+      localStorage.setItem(STATS_KEY, sampleStats);
+      const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+      renderSettings();
+      fireEvent.click(screen.getByRole('button', { name: /清除作答統計/ }));
+      expect(confirmSpy).toHaveBeenCalled();
+      expect(localStorage.getItem(STATS_KEY)).toBeNull();
+      confirmSpy.mockRestore();
+    });
+
+    it('confirm 取消時不清除', () => {
+      localStorage.setItem(STATS_KEY, sampleStats);
+      const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false);
+      renderSettings();
+      fireEvent.click(screen.getByRole('button', { name: /清除作答統計/ }));
+      expect(localStorage.getItem(STATS_KEY)).toBe(sampleStats);
+      confirmSpy.mockRestore();
+    });
+  });
 });

--- a/quiz-app/src/pages/SettingsPage.test.tsx
+++ b/quiz-app/src/pages/SettingsPage.test.tsx
@@ -1,6 +1,14 @@
 // SettingsPage component test — practice toggle + opt-in dialog flow
 import { beforeAll, afterEach, describe, expect, it, vi } from 'vitest';
 import { render, screen, fireEvent, cleanup, waitFor } from '@testing-library/react';
+
+// Mock usePracticePool 避免背景 fetch 造成 act warning（pre-existing pattern issue）
+vi.mock('../hooks/usePracticePool', () => ({
+  usePracticePool: () => ({
+    pool: { _meta: { totals: { total: 0, external_mock: 0, ai_generated: 0 } } },
+  }),
+}));
+
 import { SettingsPage } from './SettingsPage';
 import { useAccessibility } from '../hooks/useAccessibility';
 import { renderHook } from '@testing-library/react';
@@ -78,7 +86,7 @@ describe('SettingsPage', () => {
     expect(localStorage.getItem('practice-pool-enabled')).toBe('0');
   });
 
-  // 清除作答統計按鈕（Refs #64）
+  // 清除作答統計（Refs #64）— state-driven dialog，取代 window.confirm
   describe('清除作答統計', () => {
     const STATS_KEY = 'ipas-question-stats';
     const sampleStats = JSON.stringify({
@@ -86,23 +94,49 @@ describe('SettingsPage', () => {
       items: { q1: { attempts: 3, correct: 1, lastTriedAt: 1 } },
     });
 
-    it('confirm 確認時呼叫 clearStats，移除 localStorage 紀錄', () => {
+    it('點清除按鈕開啟確認 dialog，「確定清除」呼叫 clearStats 並關閉', () => {
       localStorage.setItem(STATS_KEY, sampleStats);
-      const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
       renderSettings();
-      fireEvent.click(screen.getByRole('button', { name: /清除作答統計/ }));
-      expect(confirmSpy).toHaveBeenCalled();
+
+      // dialog 預設關閉
+      expect(screen.queryByRole('dialog', { name: /清除作答統計/ })).not.toBeInTheDocument();
+
+      // 點外面的 trigger 按鈕（注意：dialog 內也有「確定清除」會被 getAll 抓到）
+      fireEvent.click(screen.getByRole('button', { name: '清除作答統計' }));
+      const dialog = screen.getByRole('dialog', { name: /清除作答統計/ });
+      expect(dialog).toBeInTheDocument();
+
+      // dialog 內的「確定清除」
+      fireEvent.click(screen.getByRole('button', { name: /確定清除/ }));
       expect(localStorage.getItem(STATS_KEY)).toBeNull();
-      confirmSpy.mockRestore();
+      expect(screen.queryByRole('dialog', { name: /清除作答統計/ })).not.toBeInTheDocument();
     });
 
-    it('confirm 取消時不清除', () => {
+    it('點「取消」不清除、關閉 dialog', () => {
       localStorage.setItem(STATS_KEY, sampleStats);
-      const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false);
       renderSettings();
-      fireEvent.click(screen.getByRole('button', { name: /清除作答統計/ }));
+      fireEvent.click(screen.getByRole('button', { name: '清除作答統計' }));
+      fireEvent.click(screen.getByRole('button', { name: /^取消$/ }));
       expect(localStorage.getItem(STATS_KEY)).toBe(sampleStats);
-      confirmSpy.mockRestore();
+      expect(screen.queryByRole('dialog', { name: /清除作答統計/ })).not.toBeInTheDocument();
+    });
+
+    it('ESC 鍵關閉 dialog（a11y）', () => {
+      renderSettings();
+      fireEvent.click(screen.getByRole('button', { name: '清除作答統計' }));
+      expect(screen.getByRole('dialog', { name: /清除作答統計/ })).toBeInTheDocument();
+      fireEvent.keyDown(window, { key: 'Escape' });
+      expect(screen.queryByRole('dialog', { name: /清除作答統計/ })).not.toBeInTheDocument();
+    });
+
+    it('點 overlay 背景關閉 dialog', () => {
+      renderSettings();
+      fireEvent.click(screen.getByRole('button', { name: '清除作答統計' }));
+      // role=dialog 元素本身就是 overlay；其 onClick 觸發 close
+      // 內層 .settings-confirm-dialog 用 stopPropagation 阻擋自身 click 冒泡
+      const overlay = screen.getByRole('dialog', { name: /清除作答統計/ });
+      fireEvent.click(overlay);
+      expect(screen.queryByRole('dialog', { name: /清除作答統計/ })).not.toBeInTheDocument();
     });
   });
 });

--- a/quiz-app/src/pages/SettingsPage.tsx
+++ b/quiz-app/src/pages/SettingsPage.tsx
@@ -213,7 +213,7 @@ export function SettingsPage({ accessibility, onClose }: SettingsPageProps) {
             }}
           >
             <span className="material-icons" aria-hidden="true">delete_sweep</span>
-            清除
+            清除作答統計
           </button>
         </div>
       </section>

--- a/quiz-app/src/pages/SettingsPage.tsx
+++ b/quiz-app/src/pages/SettingsPage.tsx
@@ -1,5 +1,5 @@
 // 設定頁面元件
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import type { useAccessibility } from '../hooks/useAccessibility';
 import { usePracticeMode } from '../hooks/usePracticeMode';
 import { usePracticePool } from '../hooks/usePracticePool';
@@ -28,6 +28,18 @@ export function SettingsPage({ accessibility, onClose }: SettingsPageProps) {
   const practiceMode = usePracticeMode();
   const { pool } = usePracticePool();
   const [optInOpen, setOptInOpen] = useState(false);
+  // Refs #64：清除作答統計確認 dialog（取代 window.confirm，與 quiz-abort-dialog 同 pattern）
+  const [clearStatsConfirmOpen, setClearStatsConfirmOpen] = useState(false);
+
+  // ESC 關閉 clear-stats dialog（a11y 期待行為，對齊 QuizPage abort dialog）
+  useEffect(() => {
+    if (!clearStatsConfirmOpen) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setClearStatsConfirmOpen(false);
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [clearStatsConfirmOpen]);
 
   const onTogglePractice = () => {
     if (practiceMode.enabled) {
@@ -205,18 +217,52 @@ export function SettingsPage({ accessibility, onClose }: SettingsPageProps) {
           </div>
           <button
             className="btn btn-secondary"
-            onClick={() => {
-              // 不可逆動作 — 用 native confirm 與 abort flow 一致地點對齊
-              if (window.confirm('確定要清除所有作答統計嗎？此動作無法復原。')) {
-                clearStats();
-              }
-            }}
+            onClick={() => setClearStatsConfirmOpen(true)}
           >
             <span className="material-icons" aria-hidden="true">delete_sweep</span>
             清除作答統計
           </button>
         </div>
       </section>
+
+      {/* 清除作答統計確認 dialog（Refs #64）— 取代 window.confirm 對齊既有 dialog pattern */}
+      {clearStatsConfirmOpen && (
+        <div
+          className="settings-confirm-dialog-overlay"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="clear-stats-confirm-title"
+          onClick={() => setClearStatsConfirmOpen(false)}
+        >
+          <div className="settings-confirm-dialog" onClick={(e) => e.stopPropagation()}>
+            <h2 id="clear-stats-confirm-title">清除作答統計？</h2>
+            <p>
+              所有題目的累積答對率紀錄將被刪除，此動作無法復原。
+              （資料僅儲存在本機，不會上傳）
+            </p>
+            <div className="settings-confirm-dialog__actions">
+              <button
+                type="button"
+                className="btn btn-secondary"
+                onClick={() => setClearStatsConfirmOpen(false)}
+              >
+                取消
+              </button>
+              <button
+                type="button"
+                className="btn btn-primary"
+                onClick={() => {
+                  clearStats();
+                  setClearStatsConfirmOpen(false);
+                }}
+                autoFocus
+              >
+                確定清除
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
 
       {/* 重置 */}
       <section className="settings-section">

--- a/quiz-app/src/pages/SettingsPage.tsx
+++ b/quiz-app/src/pages/SettingsPage.tsx
@@ -4,6 +4,7 @@ import type { useAccessibility } from '../hooks/useAccessibility';
 import { usePracticeMode } from '../hooks/usePracticeMode';
 import { usePracticePool } from '../hooks/usePracticePool';
 import { PracticeOptInDialog } from '../components/PracticeOptInDialog/PracticeOptInDialog';
+import { clearStats } from '../utils/question-stats-storage';
 import packageJson from '../../package.json';
 import './SettingsPage.css';
 
@@ -188,6 +189,34 @@ export function SettingsPage({ accessibility, onClose }: SettingsPageProps) {
         }}
         onDecline={() => setOptInOpen(false)}
       />
+
+      {/* 作答統計（Refs #64）*/}
+      <section className="settings-section card">
+        <h2>作答統計</h2>
+        <div className="setting-item">
+          <div className="setting-info">
+            <span className="material-icons">insights</span>
+            <div>
+              <p className="setting-title">清除作答統計</p>
+              <p className="setting-desc">
+                清除所有題目的累積答對率紀錄。資料僅儲存在本機（localStorage），不會上傳。
+              </p>
+            </div>
+          </div>
+          <button
+            className="btn btn-secondary"
+            onClick={() => {
+              // 不可逆動作 — 用 native confirm 與 abort flow 一致地點對齊
+              if (window.confirm('確定要清除所有作答統計嗎？此動作無法復原。')) {
+                clearStats();
+              }
+            }}
+          >
+            <span className="material-icons" aria-hidden="true">delete_sweep</span>
+            清除
+          </button>
+        </div>
+      </section>
 
       {/* 重置 */}
       <section className="settings-section">

--- a/quiz-app/src/utils/question-stats-storage.test.ts
+++ b/quiz-app/src/utils/question-stats-storage.test.ts
@@ -1,0 +1,214 @@
+// question-stats-storage 測試（Refs #64）
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  loadStats,
+  recordAttempts,
+  clearStats,
+  selectWeakQuestions,
+} from './question-stats-storage';
+
+// 真實 Map-based localStorage mock — test-setup 裡的 vi.fn() 不會保存值
+function installLocalStorageMock() {
+  const store = new Map<string, string>();
+  const mock = {
+    getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
+    setItem: (k: string, v: string) => {
+      store.set(k, v);
+    },
+    removeItem: (k: string) => {
+      store.delete(k);
+    },
+    clear: () => store.clear(),
+    key: (i: number) => Array.from(store.keys())[i] ?? null,
+    get length() {
+      return store.size;
+    },
+  } as Storage;
+  Object.defineProperty(globalThis, 'localStorage', {
+    value: mock,
+    writable: true,
+    configurable: true,
+  });
+  return store;
+}
+
+describe('question-stats-storage', () => {
+  beforeEach(() => {
+    installLocalStorageMock();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('loadStats', () => {
+    it('回 {} 當 localStorage 沒有 key', () => {
+      expect(loadStats()).toEqual({});
+    });
+
+    it('回 {} 當 raw JSON 損壞，且會清掉壞資料', () => {
+      localStorage.setItem('ipas-question-stats', '{not json');
+      expect(loadStats()).toEqual({});
+      expect(localStorage.getItem('ipas-question-stats')).toBeNull();
+    });
+
+    it('回 {} 當 schema version 不符', () => {
+      localStorage.setItem(
+        'ipas-question-stats',
+        JSON.stringify({ version: 999, items: {} })
+      );
+      expect(loadStats()).toEqual({});
+      expect(localStorage.getItem('ipas-question-stats')).toBeNull();
+    });
+
+    it('回 {} 當 items 不是 object', () => {
+      localStorage.setItem(
+        'ipas-question-stats',
+        JSON.stringify({ version: 1, items: 'oops' })
+      );
+      expect(loadStats()).toEqual({});
+    });
+
+    it('拒絕 attempts < 0 / 非數字 / NaN', () => {
+      const bad = [
+        { version: 1, items: { q1: { attempts: -1, correct: 0, lastTriedAt: 1 } } },
+        { version: 1, items: { q1: { attempts: 'x', correct: 0, lastTriedAt: 1 } } },
+        { version: 1, items: { q1: { attempts: NaN, correct: 0, lastTriedAt: 1 } } },
+      ];
+      for (const b of bad) {
+        localStorage.setItem('ipas-question-stats', JSON.stringify(b));
+        expect(loadStats()).toEqual({});
+      }
+    });
+
+    it('拒絕 correct > attempts（資料不一致）', () => {
+      localStorage.setItem(
+        'ipas-question-stats',
+        JSON.stringify({
+          version: 1,
+          items: { q1: { attempts: 1, correct: 5, lastTriedAt: 1 } },
+        })
+      );
+      expect(loadStats()).toEqual({});
+    });
+
+    it('正常 payload 回 items dict', () => {
+      const items = { q1: { attempts: 3, correct: 2, lastTriedAt: 1000 } };
+      localStorage.setItem(
+        'ipas-question-stats',
+        JSON.stringify({ version: 1, items })
+      );
+      expect(loadStats()).toEqual(items);
+    });
+  });
+
+  describe('recordAttempts', () => {
+    it('空陣列為 no-op，不觸碰 storage', () => {
+      const setSpy = vi.spyOn(localStorage, 'setItem');
+      recordAttempts([]);
+      expect(setSpy).not.toHaveBeenCalled();
+    });
+
+    it('新題目從 0 累積', () => {
+      recordAttempts([
+        { id: 'q1', isCorrect: true, at: 100 },
+        { id: 'q2', isCorrect: false, at: 200 },
+      ]);
+      const s = loadStats();
+      expect(s.q1).toEqual({ attempts: 1, correct: 1, lastTriedAt: 100 });
+      expect(s.q2).toEqual({ attempts: 1, correct: 0, lastTriedAt: 200 });
+    });
+
+    it('既有題目 increment attempts/correct、lastTriedAt 取較新者', () => {
+      recordAttempts([{ id: 'q1', isCorrect: true, at: 100 }]);
+      recordAttempts([{ id: 'q1', isCorrect: false, at: 50 }]); // older 'at'
+      recordAttempts([{ id: 'q1', isCorrect: true, at: 300 }]);
+      const s = loadStats();
+      expect(s.q1).toEqual({ attempts: 3, correct: 2, lastTriedAt: 300 });
+    });
+
+    it('correct=false 只 increment attempts、不 increment correct', () => {
+      recordAttempts([{ id: 'q1', isCorrect: false, at: 100 }]);
+      recordAttempts([{ id: 'q1', isCorrect: false, at: 200 }]);
+      const s = loadStats();
+      expect(s.q1).toEqual({ attempts: 2, correct: 0, lastTriedAt: 200 });
+    });
+
+    it('quota 例外靜默忽略，不 throw', () => {
+      vi.spyOn(localStorage, 'setItem').mockImplementation(() => {
+        throw new Error('QuotaExceededError');
+      });
+      expect(() => recordAttempts([{ id: 'q1', isCorrect: true, at: 1 }])).not.toThrow();
+    });
+  });
+
+  describe('selectWeakQuestions', () => {
+    const opts = { minAttempts: 3, maxRate: 0.5, limit: 10 };
+
+    it('attempts < minAttempts 的題目被排除', () => {
+      const stats = {
+        q1: { attempts: 2, correct: 0, lastTriedAt: 1 }, // 答錯 2 次但不夠 3 次
+        q2: { attempts: 3, correct: 0, lastTriedAt: 2 },
+      };
+      const weak = selectWeakQuestions(stats, opts);
+      expect(weak.map((w) => w.id)).toEqual(['q2']);
+    });
+
+    it('rate >= maxRate 的題目被排除', () => {
+      const stats = {
+        q1: { attempts: 4, correct: 2, lastTriedAt: 1 }, // rate 0.5 = maxRate（排除：< 0.5 才算）
+        q2: { attempts: 4, correct: 1, lastTriedAt: 2 }, // rate 0.25
+      };
+      const weak = selectWeakQuestions(stats, opts);
+      expect(weak.map((w) => w.id)).toEqual(['q2']);
+    });
+
+    it('排序：rate 升冪 → attempts 降冪 → lastTriedAt 降冪', () => {
+      const stats = {
+        a: { attempts: 5, correct: 1, lastTriedAt: 100 }, // rate 0.20
+        b: { attempts: 3, correct: 1, lastTriedAt: 200 }, // rate 0.33
+        c: { attempts: 4, correct: 0, lastTriedAt: 300 }, // rate 0.00
+        d: { attempts: 5, correct: 1, lastTriedAt: 50 },  // rate 0.20（同 a，attempts 同 → lastTriedAt 較舊）
+      };
+      const weak = selectWeakQuestions(stats, opts);
+      // c (0%) → a (20%, attempts 5, newer) → d (20%, attempts 5, older) → b (33%)
+      expect(weak.map((w) => w.id)).toEqual(['c', 'a', 'd', 'b']);
+    });
+
+    it('上限 limit 截斷', () => {
+      const stats: Record<string, { attempts: number; correct: number; lastTriedAt: number }> = {};
+      for (let i = 0; i < 15; i++) {
+        stats[`q${i}`] = { attempts: 3, correct: 0, lastTriedAt: i };
+      }
+      const weak = selectWeakQuestions(stats, { ...opts, limit: 10 });
+      expect(weak).toHaveLength(10);
+    });
+
+    it('空 stats 回空陣列', () => {
+      expect(selectWeakQuestions({}, opts)).toEqual([]);
+    });
+
+    it('完全沒符合條件的 stats 回空陣列', () => {
+      const stats = {
+        q1: { attempts: 5, correct: 5, lastTriedAt: 1 }, // 100% 答對
+      };
+      expect(selectWeakQuestions(stats, opts)).toEqual([]);
+    });
+  });
+
+  describe('clearStats', () => {
+    it('清掉 storage', () => {
+      recordAttempts([{ id: 'q1', isCorrect: true, at: 1 }]);
+      expect(loadStats()).not.toEqual({});
+      clearStats();
+      expect(loadStats()).toEqual({});
+    });
+
+    it('removeItem throw 時靜默', () => {
+      vi.spyOn(localStorage, 'removeItem').mockImplementation(() => {
+        throw new Error('boom');
+      });
+      expect(() => clearStats()).not.toThrow();
+    });
+  });
+});

--- a/quiz-app/src/utils/question-stats-storage.test.ts
+++ b/quiz-app/src/utils/question-stats-storage.test.ts
@@ -101,6 +101,29 @@ describe('question-stats-storage', () => {
       );
       expect(loadStats()).toEqual(items);
     });
+
+    it('shape 不符且 removeItem throw 也靜默回 {}', () => {
+      // 走 isValidPayload=false → removeItem catch 路徑
+      localStorage.setItem(
+        'ipas-question-stats',
+        JSON.stringify({ version: 999, items: {} })
+      );
+      vi.spyOn(localStorage, 'removeItem').mockImplementation(() => {
+        throw new Error('boom');
+      });
+      expect(() => loadStats()).not.toThrow();
+      expect(loadStats()).toEqual({});
+    });
+
+    it('JSON.parse throw 且 removeItem 也 throw → 靜默回 {}', () => {
+      // 走 outer catch → 內層 removeItem catch 路徑
+      localStorage.setItem('ipas-question-stats', 'definitely{not}json');
+      vi.spyOn(localStorage, 'removeItem').mockImplementation(() => {
+        throw new Error('boom');
+      });
+      expect(() => loadStats()).not.toThrow();
+      expect(loadStats()).toEqual({});
+    });
   });
 
   describe('recordAttempts', () => {

--- a/quiz-app/src/utils/question-stats-storage.test.ts
+++ b/quiz-app/src/utils/question-stats-storage.test.ts
@@ -69,8 +69,9 @@ describe('question-stats-storage', () => {
       expect(loadStats()).toEqual({});
     });
 
-    it('拒絕 attempts < 0 / 非數字 / NaN', () => {
+    it('拒絕 attempts < 1 / 非數字 / NaN（含 attempts=0 防 NaN%；Copilot PR #80）', () => {
       const bad = [
+        { version: 1, items: { q1: { attempts: 0, correct: 0, lastTriedAt: 1 } } },
         { version: 1, items: { q1: { attempts: -1, correct: 0, lastTriedAt: 1 } } },
         { version: 1, items: { q1: { attempts: 'x', correct: 0, lastTriedAt: 1 } } },
         { version: 1, items: { q1: { attempts: NaN, correct: 0, lastTriedAt: 1 } } },

--- a/quiz-app/src/utils/question-stats-storage.ts
+++ b/quiz-app/src/utils/question-stats-storage.ts
@@ -1,0 +1,143 @@
+// 每題作答統計（local-only correctness rate；Refs #64）
+//
+// 設計：
+// - 寫入時機：finishQuiz 一次 bulk 寫入（不在 submitAnswer 即時寫）
+//   理由：useQuiz 在同一 quiz session 內允許使用者點「上一題」改答，
+//   submitAnswer 會被多次呼叫。state.answers 已用 questionId 去重
+//   （useQuiz.ts findIndex 覆寫邏輯），所以從 finishQuiz 拿到的就是
+//   一題一筆「該 quiz 最終答」，剛好是我們要記為 1 次 attempt 的結果。
+// - aborted（softReset）/ resetQuiz 不觸發 finishQuiz，故不寫 stats —
+//   未完成的 quiz 不算數，語義一致。
+// - localStorage 容量試算：~870 題 × ~80 bytes ≈ 70 KB（遠 < 5 MB quota）
+
+const STORAGE_KEY = 'ipas-question-stats';
+const SCHEMA_VERSION = 1;
+
+export interface QuestionStat {
+  attempts: number;
+  correct: number;
+  /** epoch ms — 用於 ResultPage 弱題排序 tie-break */
+  lastTriedAt: number;
+}
+
+interface PersistedStats {
+  version: typeof SCHEMA_VERSION;
+  items: Record<string, QuestionStat>;
+}
+
+export interface AttemptUpdate {
+  id: string;
+  isCorrect: boolean;
+  /** epoch ms */
+  at: number;
+}
+
+/** Load all stats. Returns {} on absent / wrong shape / quota error. */
+export function loadStats(): Record<string, QuestionStat> {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw) as unknown;
+    if (!isValidPayload(parsed)) {
+      try {
+        localStorage.removeItem(STORAGE_KEY);
+      } catch {
+        /* ignore */
+      }
+      return {};
+    }
+    return parsed.items;
+  } catch {
+    try {
+      localStorage.removeItem(STORAGE_KEY);
+    } catch {
+      /* ignore */
+    }
+    return {};
+  }
+}
+
+/**
+ * Bulk-record attempts. Increments attempts (and correct if isCorrect=true)
+ * for each entry; updates lastTriedAt to the latest `at` per question.
+ * Empty input is a no-op (avoids touching storage).
+ */
+export function recordAttempts(updates: AttemptUpdate[]): void {
+  if (updates.length === 0) return;
+  const current = loadStats();
+  for (const u of updates) {
+    const prev = current[u.id];
+    const attempts = (prev?.attempts ?? 0) + 1;
+    const correct = (prev?.correct ?? 0) + (u.isCorrect ? 1 : 0);
+    const lastTriedAt = Math.max(prev?.lastTriedAt ?? 0, u.at);
+    current[u.id] = { attempts, correct, lastTriedAt };
+  }
+  const payload: PersistedStats = {
+    version: SCHEMA_VERSION,
+    items: current,
+  };
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
+  } catch {
+    /* quota / private mode — 靜默 */
+  }
+}
+
+/** 清除所有作答統計（SettingsPage「清除作答統計」按鈕用）. */
+export function clearStats(): void {
+  try {
+    localStorage.removeItem(STORAGE_KEY);
+  } catch {
+    /* ignore */
+  }
+}
+
+/**
+ * 從 stats dict 篩選 + 排序「最常答錯」清單（Refs #64）。
+ * 條件：attempts >= minAttempts 且 correct/attempts < maxRate
+ * 排序：rate 升冪 → attempts 降冪 → lastTriedAt 降冪
+ *
+ * Pure 函式，方便單元測試；ResultPage 用 stemLookup 把 id 轉題幹後渲染。
+ */
+export interface WeakItem {
+  id: string;
+  attempts: number;
+  correct: number;
+  rate: number;
+  lastTriedAt: number;
+}
+
+export function selectWeakQuestions(
+  stats: Record<string, QuestionStat>,
+  opts: { minAttempts: number; maxRate: number; limit: number }
+): WeakItem[] {
+  const out: WeakItem[] = [];
+  for (const [id, s] of Object.entries(stats)) {
+    if (s.attempts < opts.minAttempts) continue;
+    const rate = s.correct / s.attempts;
+    if (rate >= opts.maxRate) continue;
+    out.push({ id, attempts: s.attempts, correct: s.correct, rate, lastTriedAt: s.lastTriedAt });
+  }
+  out.sort((a, b) => {
+    if (a.rate !== b.rate) return a.rate - b.rate;
+    if (a.attempts !== b.attempts) return b.attempts - a.attempts;
+    return b.lastTriedAt - a.lastTriedAt;
+  });
+  return out.slice(0, opts.limit);
+}
+
+function isValidPayload(v: unknown): v is PersistedStats {
+  if (!v || typeof v !== 'object') return false;
+  const p = v as Partial<PersistedStats>;
+  if (p.version !== SCHEMA_VERSION) return false;
+  if (!p.items || typeof p.items !== 'object') return false;
+  for (const [, stat] of Object.entries(p.items)) {
+    if (!stat || typeof stat !== 'object') return false;
+    const s = stat as Partial<QuestionStat>;
+    if (typeof s.attempts !== 'number' || !Number.isFinite(s.attempts) || s.attempts < 0) return false;
+    if (typeof s.correct !== 'number' || !Number.isFinite(s.correct) || s.correct < 0) return false;
+    if (s.correct > s.attempts) return false;
+    if (typeof s.lastTriedAt !== 'number' || !Number.isFinite(s.lastTriedAt)) return false;
+  }
+  return true;
+}

--- a/quiz-app/src/utils/question-stats-storage.ts
+++ b/quiz-app/src/utils/question-stats-storage.ts
@@ -134,7 +134,9 @@ function isValidPayload(v: unknown): v is PersistedStats {
   for (const [, stat] of Object.entries(p.items)) {
     if (!stat || typeof stat !== 'object') return false;
     const s = stat as Partial<QuestionStat>;
-    if (typeof s.attempts !== 'number' || !Number.isFinite(s.attempts) || s.attempts < 0) return false;
+    // attempts >= 1：recordAttempts 一律 +1，正常路徑寫不出 0；
+    // 拒絕 0 防手動竄改 / 殘留資料導致 correct/attempts = NaN（Copilot PR #80）
+    if (typeof s.attempts !== 'number' || !Number.isFinite(s.attempts) || s.attempts < 1) return false;
     if (typeof s.correct !== 'number' || !Number.isFinite(s.correct) || s.correct < 0) return false;
     if (s.correct > s.attempts) return false;
     if (typeof s.lastTriedAt !== 'number' || !Number.isFinite(s.lastTriedAt)) return false;


### PR DESCRIPTION
Closes #64.

## Summary
業界 MIT Canvas 模式的 single-maintainer/前端版本：每題本機累積作答統計，QuestionCard chip 顯示「答對率 X%（N 次）」，ResultPage 補「最常答錯」累積清單，SettingsPage 加清除按鈕。

## Storage 層 — `utils/question-stats-storage.ts`
- localStorage key `ipas-question-stats`、schema v1
- shape `Record<id, { attempts, correct, lastTriedAt }>`
- API: `loadStats` / `recordAttempts` / `clearStats` / `selectWeakQuestions`（pure 函式，方便單元測試）
- 嚴格 `isValidPayload`：attempts/correct/lastTriedAt 數字、`correct ≤ attempts`、版號 1
- 損壞 JSON / wrong shape → 清掉回 `{}`；quota 例外靜默忽略

## 寫入時機 — finishQuiz bulk 寫（刻意偏離 issue 寫的 \"submitAnswer\"）
Issue 原寫「submitAnswer 後追加」，但 `useQuiz` 允許使用者點「上一題」改答，且 `state.answers` 已 dedupe by questionId（GH #59 修法）。若每次 `submitAnswer` 都寫，同一 quiz 內同一題會被算多次 attempt。在 `finishQuiz` 拿到的就是「一題一筆最終答」，剛好 1 attempt — 語義正確 + I/O 也少。

`softReset` / `resetQuiz`（abort、reset）不觸發 finishQuiz → 未完成 quiz 不算數。
跳過題（`selectedAnswer=null`）與無答案題（`correctAnswer=null`）都不算 attempt。

## UI
- **QuestionCard** header 多 chip：新題目「新題目」/ 已答過「答對率 X%（N 次）」；`hasAnswer=false` 不渲染
- **ResultPage** 在 `SourceBreakdown` 後加「最常答錯」section：attempts ≥ 3 且 rate < 0.5、取前 10，排序 rate 升冪 → attempts 降冪 → lastTriedAt 降冪
- **SettingsPage** 加「作答統計 → 清除」按鈕（native `confirm()`，不可逆動作）

## 隱私
純 local-only、無上傳；儲存內容僅 questionId + counts + ts，無 PII。SettingsPage 描述同步揭露。

## 測試（+29 tests，總 380 → 409）
- `question-stats-storage.test.ts` — 20 tests：load 損壞處理、recordAttempts 累計/quota、clearStats、selectWeakQuestions（排序、limit、empty、邊界 rate=maxRate 排除）
- `useQuiz.test.ts` +6 tests：finishQuiz 寫入 / 跳題不寫 / 同題覆寫算 1 次（GH #59 整合）/ 跨 session 累計 / `resetQuiz` 不寫 / `softReset` 不寫
- `QuestionCard.test.tsx` +3 tests：新題目顯示、`hasAnswer=false` 不渲染、stats 60% 顯示

## 驗證
- `pnpm exec tsc --noEmit` clean
- `pnpm exec vitest run` — 409/409 pass
- `pnpm lint` — 0 errors（6 pre-existing warnings、皆與本 PR 無關）
- `pnpm build` — production build OK，bundle 增加 < 1KB