### PR TITLE
chore(data): replace CBAM Omnibus 2025/XXX placeholder with Reg 2025/2083 + bump v1.2.0 (#70)

### DIFF
--- a/quiz-app/package.json
+++ b/quiz-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ipas-net-zero-quiz",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "iPAS 淨零碳規劃管理師 備考神器 - 考古題線上測驗",
   "type": "module",
   "packageManager": "pnpm@9.15.4",

--- a/quiz-app/src/data/integrated_dataset.json
+++ b/quiz-app/src/data/integrated_dataset.json
@@ -1313,9 +1313,16 @@
       "metadata": {
         "answer_verified": true,
         "verification_date": "2026-04-25",
-        "verification_source": "CBAM Omnibus 修正案（Regulation (EU) 2025/XXX, 2025-10-20 生效）將憑證繳交期限由 5/31 延至 9/30；首次繳交為 2027-09-30（涵蓋 2026 進口）。",
-        "original_id": "c1-038"
-      }
+        "verification_source": "CBAM Omnibus — Regulation (EU) 2025/2083 of 8 October 2025（OJ L 2025/10/17 刊登、2025/10/20 生效）；Article 22(1) 將年度憑證繳交期限由 5/31 延至 9/30，首次繳交為 2027-09-30（涵蓋 2026 進口）。",
+        "original_id": "c1-038",
+        "sources": [
+          "https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32025R2083"
+        ],
+        "sources_verified_date": "2026-05-05"
+      },
+      "quality_flags": [
+        "time_sensitive"
+      ]
     },
     {
       "index": 39,
@@ -1381,9 +1388,16 @@
       "metadata": {
         "answer_verified": true,
         "verification_date": "2026-04-25",
-        "verification_source": "CBAM Omnibus 修正案（Regulation (EU) 2025/XXX, 2025-10-20 生效）將憑證繳交期限由 5/31 延至 9/30；首次繳交為 2027-09-30（涵蓋 2026 進口）。",
-        "original_id": "c1-040"
-      }
+        "verification_source": "CBAM Omnibus — Regulation (EU) 2025/2083 of 8 October 2025（OJ L 2025/10/17 刊登、2025/10/20 生效）；Article 22(1) 將年度憑證繳交期限由 5/31 延至 9/30，首次繳交為 2027-09-30（涵蓋 2026 進口）。",
+        "original_id": "c1-040",
+        "sources": [
+          "https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32025R2083"
+        ],
+        "sources_verified_date": "2026-05-05"
+      },
+      "quality_flags": [
+        "time_sensitive"
+      ]
     },
     {
       "index": 41,
@@ -2777,7 +2791,7 @@
         "verification_batch": "D",
         "confidence": "medium",
         "sources_count": 2,
-        "verification_source": "CBAM Omnibus 修正案（Regulation (EU) 2025/XXX, 2025-10-20 生效）將憑證繳交期限由 5/31 延至 9/30；首次繳交為 2027-09-30（涵蓋 2026 進口）。",
+        "verification_source": "CBAM Omnibus — Regulation (EU) 2025/2083 of 8 October 2025（OJ L 2025/10/17 刊登、2025/10/20 生效）；Article 22(1) 將年度憑證繳交期限由 5/31 延至 9/30，首次繳交為 2027-09-30（涵蓋 2026 進口）。",
         "prior_answer": "D",
         "sources": [
           "https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32025R2083"
@@ -2786,6 +2800,9 @@
         "option_text_changed_on": "2026-04-25",
         "option_text_change_note": "選項 D 文字由錯誤的『8/31』改為正確的『10/31』(CBAM Omnibus 回購截止)；答案字母 D 不變"
       },
+      "quality_flags": [
+        "time_sensitive"
+      ],
       "explanation": "依 CBAM Omnibus 修正案（2025/10 生效），進口商請求回購（buy-back）多餘 CBAM 憑證之截止日為每年 10 月 31 日，11 月 1 日系統自動註銷未用憑證（原規定為 6/30）。（正式編號 Regulation (EU) 2025/2083，歐盟執委會 2025/10/8 採納，OJ 2025/10/17 刊登，10/20 生效）\n\n資料來源：https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32025R2083"
     },
     {
@@ -3142,12 +3159,15 @@
         "verification_batch": "D",
         "confidence": "medium",
         "sources_count": 2,
-        "verification_source": "CBAM Omnibus 修正案（Regulation (EU) 2025/XXX, 2025-10-20 生效）將憑證繳交期限由 5/31 延至 9/30；首次繳交為 2027-09-30（涵蓋 2026 進口）。",
+        "verification_source": "CBAM Omnibus — Regulation (EU) 2025/2083 of 8 October 2025（OJ L 2025/10/17 刊登、2025/10/20 生效）；Article 22(1) 將年度憑證繳交期限由 5/31 延至 9/30，首次繳交為 2027-09-30（涵蓋 2026 進口）。",
         "sources": [
           "https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32025R2083"
         ],
         "sources_verified_date": "2026-04-25"
       },
+      "quality_flags": [
+        "time_sensitive"
+      ],
       "explanation": "依 CBAM Omnibus 修正案（2025/10 生效），進口商須於每年 9 月底前（9/30）支付前一年度 CBAM 憑證（原為 5/31）。（正式編號 Regulation (EU) 2025/2083，歐盟執委會 2025/10/8 採納，OJ 2025/10/17 刊登，10/20 生效）\n\n資料來源：https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32025R2083"
     },
     {
@@ -5135,12 +5155,15 @@
         "verification_batch": "E",
         "confidence": "medium",
         "sources_count": 3,
-        "verification_source": "CBAM Omnibus 修正案（Regulation (EU) 2025/XXX, 2025-10-20 生效）將憑證繳交期限由 5/31 延至 9/30；首次繳交為 2027-09-30（涵蓋 2026 進口）。",
+        "verification_source": "CBAM Omnibus — Regulation (EU) 2025/2083 of 8 October 2025（OJ L 2025/10/17 刊登、2025/10/20 生效）；Article 22(1) 將年度憑證繳交期限由 5/31 延至 9/30，首次繳交為 2027-09-30（涵蓋 2026 進口）。",
         "sources": [
           "https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32025R2083"
         ],
         "sources_verified_date": "2026-04-25"
       },
+      "quality_flags": [
+        "time_sensitive"
+      ],
       "explanation": "依 CBAM Omnibus 修正案（2025/10 生效），過渡期後進口商須於每年 9 月 30 日前繳交足夠之 CBAM 憑證（原規定為 5/31）。（正式編號 Regulation (EU) 2025/2083，歐盟執委會 2025/10/8 採納，OJ 2025/10/17 刊登，10/20 生效）\n\n資料來源：https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32025R2083"
     },
     {
@@ -10566,9 +10589,16 @@
       "metadata": {
         "answer_verified": true,
         "verification_date": "2026-04-25",
-        "verification_source": "CBAM Omnibus 修正案（Regulation (EU) 2025/XXX, 2025-10-20 生效）將憑證繳交期限由 5/31 延至 9/30；首次繳交為 2027-09-30（涵蓋 2026 進口）。",
-        "original_id": "c2-115"
-      }
+        "verification_source": "CBAM Omnibus — Regulation (EU) 2025/2083 of 8 October 2025（OJ L 2025/10/17 刊登、2025/10/20 生效）；Article 22(1) 將年度憑證繳交期限由 5/31 延至 9/30，首次繳交為 2027-09-30（涵蓋 2026 進口）。",
+        "original_id": "c2-115",
+        "sources": [
+          "https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32025R2083"
+        ],
+        "sources_verified_date": "2026-05-05"
+      },
+      "quality_flags": [
+        "time_sensitive"
+      ]
     },
     {
       "index": 309,
@@ -15217,9 +15247,16 @@
       "metadata": {
         "answer_verified": true,
         "verification_date": "2026-04-25",
-        "verification_source": "CBAM Omnibus 修正案（Regulation (EU) 2025/XXX, 2025-10-20 生效）將憑證繳交期限由 5/31 延至 9/30；首次繳交為 2027-09-30（涵蓋 2026 進口）。",
-        "original_id": "c2-249"
-      }
+        "verification_source": "CBAM Omnibus — Regulation (EU) 2025/2083 of 8 October 2025（OJ L 2025/10/17 刊登、2025/10/20 生效）；Article 22(1) 將年度憑證繳交期限由 5/31 延至 9/30，首次繳交為 2027-09-30（涵蓋 2026 進口）。",
+        "original_id": "c2-249",
+        "sources": [
+          "https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32025R2083"
+        ],
+        "sources_verified_date": "2026-05-05"
+      },
+      "quality_flags": [
+        "time_sensitive"
+      ]
     },
     {
       "index": 443,


### PR DESCRIPTION
Closes #70.

## Summary
7 個 CBAM 主庫題的 \`metadata.verification_source\` 寫的是 \"Regulation (EU) 2025/XXX, 2025-10-20 生效\"，\"XXX\" 是字面 placeholder（寫題當時尚未取得正式 EU regulation 編號）。本 PR 基於 **2026-05 大規模上網調研**確認該 placeholder 對應的真實法規 = **Regulation (EU) 2025/2083 of 8 October 2025**，補完 7 題的 \`verification_source\` 文字、\`sources\` URL、\`quality_flags\`。同時順手 SemVer minor bump v1.1.0 → v1.2.0 對齊今日累積的 user-facing features 釋出。

## 調研摘要（2026-05-05）
- **WebFetch verbatim 抓 EUR-Lex CELEX:32025R2083** 確認官方標題：\"Regulation (EU) 2025/2083 of the European Parliament and of the Council of 8 October 2025 amending Regulation (EU) 2023/956 as regards simplifying and strengthening the carbon border adjustment mechanism\"
- OJ 刊登 2025-10-17，依 Recital 38「third day following publication」→ **生效 2025-10-20**（與題目宣稱一致）
- **Article 22(1)** 修法：年度繳交期限 5/31 → 9/30、首次 2027 for 2026（與題目一致）
- 2026 Q1-Q2 implementing/delegated acts（IR 2025/2546–2548, 2621 等）與 2025-12-17 downstream extension proposal（COM(2025) 989，2028 生效）皆**不影響**本 7 題事實
- Cross-verified：EY、KPMG、Mayer Brown、Reed Smith、ICAP、EC DG TAXUD、CBAM Guide

## 7 題位置與動作
| Index | Original ID | 原本有 sources? | 動作 |
|---|---|---|---|
| 38 | c1-038 | ❌ | text fix + add sources/sources_verified_date + quality_flags |
| 40 | c1-040 | ❌ | 同上 |
| 81 | (none) | ✅ CELEX | text fix + quality_flags only |
| 91 | (none) | ✅ CELEX | 同上 |
| 149 | (none) | ✅ CELEX | 同上 |
| 308 | c2-115 | ❌ | text fix + add sources/sources_verified_date + quality_flags |
| 442 | c2-249 | ❌ | 同上 |

\`verification_source\` 文字統一改為：
> \"CBAM Omnibus — Regulation (EU) 2025/2083 of 8 October 2025（OJ L 2025/10/17 刊登、2025/10/20 生效）；Article 22(1) 將年度憑證繳交期限由 5/31 延至 9/30，首次繳交為 2027-09-30（涵蓋 2026 進口）。\"

## Version bump v1.1.0 → v1.2.0
今日累積 user-facing features：
- #64 per-question 答對率 chip + 弱題清單（PR #80）
- #71 in-progress quiz 持久化 + abort flow（PR #75）
- #63 回報此題 GitHub Issue 預填（PR #78）
- #72 Settings 返回首頁明確按鈕（PR #77）
- #61, #62 IFRS S1/S2 接軌時程題目擴增（PR #68, #73）

SemVer minor bump（純 additive，無 breaking change）。

## 不動的事
- 既有 3 個 entries 的 sources URL（已是 CELEX:32025R2083，正確）
- 既有 \`sources_verified_date\` 不更新（保留 audit trail）

## 驗證
- ✅ 0 個 \"2025/XXX\" 殘留（grep）
- ✅ 7 個 entries 全部有 quality_flags + sources（Node runtime check）
- ✅ \`tsc --noEmit\` clean
- ✅ \`vitest run\` — 425/425 pass
- ✅ \`pnpm build\` — production OK
- ✅ WebFetch 兩次（CELEX + ELI URL）確認內容一致、curl HTTP 200