### PR TITLE
fix(data): q46 MRV 答案 D→A，對齊 UNFCCC Bali Action Plan 體系

### DIFF
--- a/quiz-app/src/data/integrated_dataset.json
+++ b/quiz-app/src/data/integrated_dataset.json
@@ -1591,17 +1591,26 @@
           "text": "監控（Monitoring）、報告（Reporting）、驗證（Verification）"
         }
       ],
-      "answer": "D",
+      "answer": "A",
       "source": "gist",
       "original_section": "考科1",
       "exam_subject": "考科1",
       "metadata": {
         "answer_verified": true,
-        "verification_date": "2026-01-23",
+        "verification_date": "2026-05-13",
         "verification_batch": "D",
         "confidence": "high",
-        "sources_count": 2
-      }
+        "sources_count": 2,
+        "prior_answer": "D",
+        "answer_correction_reason": "前版答案 D (Monitoring/Reporting/Verification) 採 EU 法規體系，跟同題庫 q17 (Bali Action Plan, ans B) 及 q44 (ans D = Measurable/Reportable/Verifiable) 矛盾。經 2026-05 深度調研確認 iPAS 教材依 UNFCCC 體系，正解為 A。",
+        "sources": [
+          "https://unfccc.int/resource/docs/2007/cop13/eng/06a01.pdf",
+          "https://www.ipas.org.tw/NZ/",
+          "https://oaout.moenv.gov.tw/law/LawContent.aspx?id=GL005954"
+        ],
+        "sources_verified_date": "2026-05-13"
+      },
+      "explanation": "MRV 一詞最早出自 UNFCCC 2007 年峇里路線圖（Bali Action Plan, Decision 1/CP.13）§1(b)(i)(ii) 條約原文，使用形容詞型「measurable, reportable and verifiable」描述開發中國家減緩行動應達成的特性。iPAS 淨零碳教材依此 UNFCCC 體系，正解為 A「可測量、可報告、可查證」。注意：EU MRV Regulation 2015/757（海運）、EU ETS、CBAM 等操作層級法規改用名詞型「Monitoring / Reporting / Verification」(D)，是另一個治理體系的用詞，不適用 iPAS。"
     },
     {
       "index": 47,

--- a/quiz-app/src/data/integrated_dataset.json
+++ b/quiz-app/src/data/integrated_dataset.json
@@ -1600,7 +1600,7 @@
         "verification_date": "2026-05-13",
         "verification_batch": "D",
         "confidence": "high",
-        "sources_count": 2,
+        "sources_count": 3,
         "prior_answer": "D",
         "answer_correction_reason": "前版答案 D (Monitoring/Reporting/Verification) 採 EU 法規體系，跟同題庫 q17 (Bali Action Plan, ans B) 及 q44 (ans D = Measurable/Reportable/Verifiable) 矛盾。經 2026-05 深度調研確認 iPAS 教材依 UNFCCC 體系，正解為 A。",
         "sources": [
@@ -1610,7 +1610,7 @@
         ],
         "sources_verified_date": "2026-05-13"
       },
-      "explanation": "MRV 一詞最早出自 UNFCCC 2007 年峇里路線圖（Bali Action Plan, Decision 1/CP.13）§1(b)(i)(ii) 條約原文，使用形容詞型「measurable, reportable and verifiable」描述開發中國家減緩行動應達成的特性。iPAS 淨零碳教材依此 UNFCCC 體系，正解為 A「可測量、可報告、可查證」。注意：EU MRV Regulation 2015/757（海運）、EU ETS、CBAM 等操作層級法規改用名詞型「Monitoring / Reporting / Verification」(D)，是另一個治理體系的用詞，不適用 iPAS。"
+      "explanation": "MRV 一詞最早出自 UNFCCC 2007 年峇里路線圖（Bali Action Plan, Decision 1/CP.13）§1(b)(ii) 條約原文，使用形容詞型「measurable, reportable and verifiable」描述開發中國家減緩行動應達成的特性。iPAS 淨零碳教材依此 UNFCCC 體系，正解為 A「可測量、可報告、可查證」。注意：EU MRV Regulation 2015/757（海運）、EU ETS、CBAM 等操作層級法規改用名詞型「Monitoring / Reporting / Verification」(D)，是另一個治理體系的用詞，不適用 iPAS。"
     },
     {
       "index": 47,


### PR DESCRIPTION
## Problem
gist_items[46]「MRV 機制中，MRV 的各字母代表什麼意思？」答案 D (Monitoring/Reporting/Verification) **跟同題庫其他兩道 MRV 題矛盾**：

| 題 | 答案 |
|---|---|
| q17 Bali Action Plan COP13 (明指 source) | B = Measurable/Reportable/Verifiable |
| q44 (c2-110) | D = Measurable/Reportable/Verifiable |
| **q46 (本 PR 修)** | ~~D = Monitoring/Reporting/Verification~~ → **A = 可測量、可報告、可查證** |

## 為什麼會發生

MRV 有 **兩種正式 expansion**，依治理體系分：
- **UNFCCC 條約原文** (Bali Action Plan 2007 §1(b)(i)(ii)): 形容詞型 `Measurable / Reportable / Verifiable`
- **EU 法規操作層級** (Reg 2015/757 海運、ETS、CBAM Reg 2023/1773): 名詞型 `Monitoring / Reporting / Verification`

iPAS 淨零碳教材依 UNFCCC 體系（iPAS 官方樣題第 17 題即用此 expansion）。q46 原作者誤用 EU 法規體系答案。

## Why batch verify 沒抓到
3 題在 2026-01-23 batch verify，逐題對單一 source 判定為「對」，但**沒做 cross-題 consistency check**。本次 user 透過「回報此題」button 反映 q44 答案有疑慮（其實 q44 是對的、q46 才有問題），檢查時發現內部矛盾。

## Sources (curl 200 OK 2026-05-13)
1. https://unfccc.int/resource/docs/2007/cop13/eng/06a01.pdf
2. https://www.ipas.org.tw/NZ/
3. https://oaout.moenv.gov.tw/law/LawContent.aspx?id=GL005954

## 同時擴充記錄
- `metadata.prior_answer = 'D'` 審計軌跡
- `metadata.answer_correction_reason` 完整原因
- `metadata.sources` + `sources_verified_date`
- explanation 加詳細兩體系差異說明

## 不影響
- `questions.json` 沒 q46 mirror（dual-file 規則此題不適用）
- q17 / q44 不變（兩題答案已對齊 UNFCCC 體系）