### PR TITLE
修正考試模式最後一題答案被吞的計分競態（discussions/1）

### DIFF
--- a/quiz-app/src/hooks/useQuiz.ts
+++ b/quiz-app/src/hooks/useQuiz.ts
@@ -168,6 +168,10 @@ export function useQuiz() {
       const question = questions[currentIndex];
       if (!question) return;
 
+      // timeSpent 語意：自本題開始（questionStartTime）到「選擇答案」當下的時間。
+      // 兩種模式現在都在選擇當下 submitAnswer（見 QuizPage：修正最後一題計分競態），
+      // 因此這是「作答決定時間」而非「停留在該題的總時間」；重新作答會覆蓋為重選當下的值。
+      // 目前無產品 UI 消費此欄位（ResultPage 顯示的是整份測驗的 totalTime），僅記錄／統計用途。
       const timeSpent = Date.now() - questionStartTime;
       const isCorrect =
         question.answer !== null ? selectedAnswer === question.answer : null;

--- a/quiz-app/src/pages/QuizPage.test.tsx
+++ b/quiz-app/src/pages/QuizPage.test.tsx
@@ -140,3 +140,52 @@ describe('QuizPage — abort flow (#71)', () => {
     expect(screen.queryByRole('dialog')).not.toBeNull();
   });
 });
+
+// 計分競態修正（回報：正確 30＋錯誤 19＝49，總題數 50 —— 少算一題）
+//
+// 根因：考試模式（showAnswerImmediately=false）原本把 submitAnswer 延到 handleNext 才呼叫，
+// 而「最後一題」的 handleNext 是「submitAnswer（非同步 setState）→ 立刻 onFinish→finishQuiz」，
+// finishQuiz 讀到的是還沒含最後一筆的舊 state closure → 最後一題被吞掉。
+// 修正：兩種模式都改成「選擇答案當下」就 submitAnswer，該 setState 早在按「完成測驗」前的
+// 另一個 render 就 flush，徹底消除競態。這兩條測試把「選擇即記錄」與「完成不再重複 submit」釘住。
+describe('QuizPage — 計分競態修正（考試模式選擇答案即記錄）', () => {
+  const examConfig = {
+    mode: 'exam' as const,
+    subject: 'all' as const,
+    questionCount: 3,
+    shuffleQuestions: false,
+    showAnswerImmediately: false,
+  };
+
+  it('考試模式：點選選項當下即呼叫 submitAnswer（不再延到 handleNext）', () => {
+    const submitAnswer = vi.fn();
+    render(
+      <QuizPage
+        quiz={makeQuizMock({ submitAnswer, config: examConfig })}
+        onFinish={vi.fn()}
+        onAbort={vi.fn()}
+      />
+    );
+    fireEvent.click(screen.getByRole('radio', { name: 'A: 選項 A' }));
+    expect(submitAnswer).toHaveBeenCalledWith('A');
+  });
+
+  it('考試模式最後一題：submitAnswer 已於選擇時呼叫；「完成測驗」只 onFinish、不再 submit', () => {
+    const submitAnswer = vi.fn();
+    const onFinish = vi.fn();
+    render(
+      <QuizPage
+        quiz={makeQuizMock({ submitAnswer, isLastQuestion: true, config: examConfig })}
+        onFinish={onFinish}
+        onAbort={vi.fn()}
+      />
+    );
+    fireEvent.click(screen.getByRole('radio', { name: 'A: 選項 A' }));
+    expect(submitAnswer).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByRole('button', { name: /完成測驗/ }));
+    expect(onFinish).toHaveBeenCalledOnce();
+    // 關鍵：完成測驗沒有再 submit 一次（舊碼正是在此 submitAnswer→onFinish 造成競態）
+    expect(submitAnswer).toHaveBeenCalledTimes(1);
+  });
+});

--- a/quiz-app/src/pages/QuizPage.test.tsx
+++ b/quiz-app/src/pages/QuizPage.test.tsx
@@ -188,4 +188,76 @@ describe('QuizPage — 計分競態修正（考試模式選擇答案即記錄）
     // 關鍵：完成測驗沒有再 submit 一次（舊碼正是在此 submitAnswer→onFinish 造成競態）
     expect(submitAnswer).toHaveBeenCalledTimes(1);
   });
+
+  it('練習模式：選擇答案即 submitAnswer 並顯示答案（hasAnswered 分支）', () => {
+    const submitAnswer = vi.fn();
+    render(
+      <QuizPage
+        quiz={makeQuizMock({
+          submitAnswer,
+          config: {
+            mode: 'practice',
+            subject: 'all',
+            questionCount: 3,
+            shuffleQuestions: false,
+            showAnswerImmediately: true,
+          },
+        })}
+        onFinish={vi.fn()}
+        onAbort={vi.fn()}
+      />
+    );
+    fireEvent.click(screen.getByRole('radio', { name: 'A: 選項 A' }));
+    expect(submitAnswer).toHaveBeenCalledWith('A');
+    // showAnswerImmediately → setHasAnswered(true) → 顯示答案，正確選項標記出現
+    expect(screen.getByLabelText('正確答案')).toBeInTheDocument();
+  });
+});
+
+// 導覽時依既有作答紀錄還原選取狀態（修正「選擇即記錄」後回到已答題顯示未選、
+// 考試模式按鈕被卡住的互動不一致；同時修好過去「返回上一題丟失選取」的既有缺口）
+describe('QuizPage — 導覽依紀錄還原選取狀態', () => {
+  it('切換到已作答題：依紀錄還原選取，考試模式按鈕不再被卡住', () => {
+    render(
+      <QuizPage
+        quiz={makeQuizMock({
+          currentAnswer: {
+            questionId: 'q-1',
+            selectedAnswer: 'B',
+            correctAnswer: 'A',
+            isCorrect: false,
+            timeSpent: 1,
+            timestamp: 0,
+            sourceCategory: 'main_bank',
+          },
+          config: {
+            mode: 'exam',
+            subject: 'all',
+            questionCount: 3,
+            shuffleQuestions: false,
+            showAnswerImmediately: false,
+          },
+        })}
+        onFinish={vi.fn()}
+        onAbort={vi.fn()}
+      />
+    );
+    // layout effect 依紀錄還原 → 選項 B 呈已選
+    expect(screen.getByRole('radio', { name: 'B: 選項 B' })).toBeChecked();
+    // 考試模式「下一題」不再 disabled（selectedAnswer 已還原）
+    expect(screen.getByRole('button', { name: /下一題/ })).toBeEnabled();
+  });
+
+  it('點「上一題」呼叫 prevQuestion', () => {
+    const prevQuestion = vi.fn();
+    render(
+      <QuizPage
+        quiz={makeQuizMock({ prevQuestion, isFirstQuestion: false })}
+        onFinish={vi.fn()}
+        onAbort={vi.fn()}
+      />
+    );
+    fireEvent.click(screen.getByRole('button', { name: /上一題/ }));
+    expect(prevQuestion).toHaveBeenCalledOnce();
+  });
 });

--- a/quiz-app/src/pages/QuizPage.tsx
+++ b/quiz-app/src/pages/QuizPage.tsx
@@ -1,5 +1,5 @@
 // 測驗頁面元件
-import { useState, useCallback, useEffect } from 'react';
+import { useState, useCallback, useEffect, useLayoutEffect } from 'react';
 import { QuestionCard } from '../components/QuestionCard';
 import type { useQuiz } from '../hooks/useQuiz';
 import './QuizPage.css';
@@ -29,6 +29,7 @@ export function QuizPage({ quiz, onFinish, onAbort }: QuizPageProps) {
   const {
     currentQuestion,
     currentIndex,
+    currentAnswer,
     progress,
     config,
     isLastQuestion,
@@ -37,6 +38,18 @@ export function QuizPage({ quiz, onFinish, onAbort }: QuizPageProps) {
     nextQuestion,
     prevQuestion,
   } = quiz;
+
+  // 切換題目時（返回上一題、續作還原、以及「選擇即記錄」後的導覽），從既有作答紀錄
+  // 還原 UI 的選取／已答狀態。若不還原：回到已答題會顯示未選，考試模式還會因
+  // `!selectedAnswer` 而卡住「下一題／完成測驗」按鈕，逼使用者重答（且重答會覆蓋原紀錄）。
+  // 用 layout effect 在 paint 前完成，避免切題瞬間閃一下上一題的選取。
+  // 僅在「題目切換」時還原 —— 同題內 submitAnswer 造成的 currentAnswer 變動不重觸發。
+  useLayoutEffect(() => {
+    const prior = currentAnswer?.selectedAnswer ?? null;
+    setSelectedAnswer(prior);
+    setHasAnswered(prior !== null && !!config?.showAnswerImmediately);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [currentQuestion?.id]);
 
   // 選擇答案
   const handleSelectAnswer = useCallback(
@@ -64,22 +77,18 @@ export function QuizPage({ quiz, onFinish, onAbort }: QuizPageProps) {
   );
 
   // 下一題（作答已於 handleSelectAnswer 當下記錄，這裡不再 submitAnswer，
-  // 以免最後一題「submit 後立刻 finish」讀到舊 state）
+  // 以免最後一題「submit 後立刻 finish」讀到舊 state；選取狀態的清空／還原交給上面的 layout effect）
   const handleNext = useCallback(() => {
     if (isLastQuestion) {
       onFinish();
     } else {
       nextQuestion();
-      setSelectedAnswer(null);
-      setHasAnswered(false);
     }
   }, [isLastQuestion, onFinish, nextQuestion]);
 
-  // 上一題
+  // 上一題（選取狀態由 layout effect 依該題紀錄還原）
   const handlePrev = useCallback(() => {
     prevQuestion();
-    setSelectedAnswer(null);
-    setHasAnswered(false);
   }, [prevQuestion]);
 
   if (!currentQuestion) {

--- a/quiz-app/src/pages/QuizPage.tsx
+++ b/quiz-app/src/pages/QuizPage.tsx
@@ -45,21 +45,27 @@ export function QuizPage({ quiz, onFinish, onAbort }: QuizPageProps) {
 
       setSelectedAnswer(answer);
 
+      // 一律在「選擇當下」就記錄作答 —— 兩種模式皆同（submitAnswer 依 questionId 去重，
+      // 重選會覆蓋而非追加）。
+      //
+      // 過去只有 showAnswerImmediately（練習）模式在此記錄；考試模式延到 handleNext 才
+      // submitAnswer，而**最後一題**的 handleNext 是「submitAnswer（非同步 setState）後**立刻**
+      // onFinish」—— finishQuiz 讀到的是還沒含最後一筆的舊 state closure，最後一題被吞掉，
+      // 計分永遠少一題（回報：正確 30＋錯誤 19＝49，總題數 50）。
+      // 改成選擇即記錄，該筆 setState 早在使用者按「完成測驗」前的另一個 render 就已 flush，
+      // 徹底消除這個競態。
+      submitAnswer(answer);
+
       if (config?.showAnswerImmediately) {
-        submitAnswer(answer);
         setHasAnswered(true);
       }
     },
     [hasAnswered, config?.showAnswerImmediately, submitAnswer]
   );
 
-  // 下一題
+  // 下一題（作答已於 handleSelectAnswer 當下記錄，這裡不再 submitAnswer，
+  // 以免最後一題「submit 後立刻 finish」讀到舊 state）
   const handleNext = useCallback(() => {
-    if (!config?.showAnswerImmediately && !hasAnswered) {
-      // 考試模式：提交當前答案
-      submitAnswer(selectedAnswer);
-    }
-
     if (isLastQuestion) {
       onFinish();
     } else {
@@ -67,15 +73,7 @@ export function QuizPage({ quiz, onFinish, onAbort }: QuizPageProps) {
       setSelectedAnswer(null);
       setHasAnswered(false);
     }
-  }, [
-    config?.showAnswerImmediately,
-    hasAnswered,
-    isLastQuestion,
-    submitAnswer,
-    selectedAnswer,
-    onFinish,
-    nextQuestion,
-  ]);
+  }, [isLastQuestion, onFinish, nextQuestion]);
 
   // 上一題
   const handlePrev = useCallback(() => {

--- a/quiz-app/src/pages/ResultPage.css
+++ b/quiz-app/src/pages/ResultPage.css
@@ -86,7 +86,9 @@
 /* 統計區 */
 .stats-section {
   display: grid;
-  grid-template-columns: repeat(4, 1fr);
+  /* auto-fit：4 個統計項（含「未作答」時為 5 個）都在同一列均分，
+     不會因固定 4 欄而讓第 5 項掉到第二列落單 */
+  grid-template-columns: repeat(auto-fit, minmax(70px, 1fr));
   gap: var(--spacing-md);
   margin-bottom: var(--spacing-lg);
 }
@@ -132,6 +134,10 @@
 
 .stat-item.time .material-icons {
   color: var(--color-warning);
+}
+
+.stat-item.skipped .material-icons {
+  color: var(--color-text-secondary);
 }
 
 /* AI 免責聲明區 */

--- a/quiz-app/src/pages/ResultPage.test.tsx
+++ b/quiz-app/src/pages/ResultPage.test.tsx
@@ -138,6 +138,34 @@ describe('ResultPage', () => {
     expect(screen.getByText(/2 分 5 秒/)).toBeInTheDocument();
   });
 
+  it('未作答統計：skippedCount=0 不顯示；>0 時顯示「未作答」與數值（答對+答錯+未作答=總題數）', () => {
+    // 沒有跳題（預設）→ 不顯示「未作答」（分支 false）
+    const { rerender } = render(
+      <ResultPage result={makeResult()} onGoHome={() => {}} onRetry={() => {}} />
+    );
+    expect(screen.queryByText('未作答')).toBeNull();
+
+    // 有跳題 → 顯示「未作答」統計（回報情境：答對 30＋答錯 19＋未作答 1 = 總題數 50）
+    rerender(
+      <ResultPage
+        result={makeResult({
+          score: 60,
+          correctCount: 30,
+          wrongCount: 19,
+          totalAnswerable: 50,
+          skippedCount: 1,
+        })}
+        onGoHome={() => {}}
+        onRetry={() => {}}
+      />
+    );
+    const skippedLabel = screen.getByText('未作答');
+    expect(skippedLabel).toBeInTheDocument();
+    const skippedItem = skippedLabel.closest('.stat-item');
+    expect(skippedItem).not.toBeNull();
+    expect(within(skippedItem as HTMLElement).getByText('1')).toBeInTheDocument();
+  });
+
   it.each([
     [100, /太棒了/],
     [95, /太棒了/],

--- a/quiz-app/src/pages/ResultPage.tsx
+++ b/quiz-app/src/pages/ResultPage.tsx
@@ -25,7 +25,7 @@ interface ResultPageProps {
 }
 
 export function ResultPage({ result, onGoHome, onRetry }: ResultPageProps) {
-  const { score, correctCount, wrongCount, totalAnswerable, answers, totalTime } =
+  const { score, correctCount, wrongCount, totalAnswerable, skippedCount, answers, totalTime } =
     result;
 
   // AI 解析狀態（key 為 questionId）
@@ -219,6 +219,13 @@ export function ResultPage({ result, onGoHome, onRetry }: ResultPageProps) {
           <span className="stat-value">{wrongCount}</span>
           <span className="stat-label">答錯</span>
         </div>
+        {skippedCount > 0 && (
+          <div className="stat-item skipped">
+            <span className="material-icons">remove_circle_outline</span>
+            <span className="stat-value">{skippedCount}</span>
+            <span className="stat-label">未作答</span>
+          </div>
+        )}
         <div className="stat-item total">
           <span className="material-icons">quiz</span>
           <span className="stat-value">{totalAnswerable}</span>

--- a/quiz-app/src/pages/examScoring.test.tsx
+++ b/quiz-app/src/pages/examScoring.test.tsx
@@ -70,4 +70,54 @@ describe('考試模式端對端計分：最後一題不會被吞', () => {
     expect(r.correctCount + r.wrongCount).toBe(N);
     expect(r.skippedCount).toBe(0);
   });
+
+  // 單題考試 = 原競態的最小重現：選完直接完成，該題必須計入（不被吞）。
+  it('單題考試：選答案後直接完成，該題計入（answers.length===1、skipped===0）', () => {
+    let result: QuizResult | null = null;
+    const config: QuizConfig = {
+      mode: 'exam',
+      subject: '考科1',
+      questionCount: 1,
+      shuffleQuestions: false,
+      showAnswerImmediately: false,
+    };
+    render(<ExamHarness config={config} onResult={(x) => (result = x)} />);
+
+    fireEvent.click(screen.getAllByRole('radio')[0]);
+    fireEvent.click(screen.getByRole('button', { name: /完成測驗/ }));
+
+    expect(result).not.toBeNull();
+    const r = result as unknown as QuizResult;
+    expect(r.totalAnswerable).toBe(1);
+    expect(r.answers).toHaveLength(1);
+    expect(r.correctCount + r.wrongCount).toBe(1);
+    expect(r.skippedCount).toBe(0);
+  });
+
+  // 返回上一題：已答題的選取必須依紀錄還原，且考試模式「下一題」不再被停用。
+  // 這是回報互動（選答案→中止→續作 顯示未選、按鈕卡住）的同根 —— 導覽與續作走同一條還原路徑。
+  it('返回上一題會依紀錄還原選取，考試模式按鈕不被卡住', () => {
+    const config: QuizConfig = {
+      mode: 'exam',
+      subject: '考科1',
+      questionCount: 3,
+      shuffleQuestions: false,
+      showAnswerImmediately: false,
+    };
+    render(<ExamHarness config={config} onResult={() => {}} />);
+
+    // Q1 選 A（第一個選項）
+    fireEvent.click(screen.getAllByRole('radio')[0]);
+    // 前往 Q2
+    fireEvent.click(screen.getByRole('button', { name: /下一題/ }));
+    // Q2 選第二個選項
+    fireEvent.click(screen.getAllByRole('radio')[1]);
+    // 返回 Q1
+    fireEvent.click(screen.getByRole('button', { name: /上一題/ }));
+
+    // Q1 的第一個選項（A）必須仍被選取（依紀錄還原）
+    expect(screen.getAllByRole('radio')[0]).toBeChecked();
+    // 不必重新選擇，就能再次前往下一題
+    expect(screen.getByRole('button', { name: /下一題/ })).toBeEnabled();
+  });
 });

--- a/quiz-app/src/pages/examScoring.test.tsx
+++ b/quiz-app/src/pages/examScoring.test.tsx
@@ -1,0 +1,73 @@
+// 考試模式端對端計分回歸測試 —— 回報「正確 30＋錯誤 19＝49、總題數 50」（少算最後一題）。
+//
+// 根因是 QuizPage↔useQuiz 的 render 競態：考試模式原本把 submitAnswer 延到 handleNext，
+// 而最後一題的 handleNext 會「submitAnswer（非同步 setState）→ 立刻 onFinish→finishQuiz」，
+// finishQuiz 讀到還沒含最後一筆的舊 state。單獨測 hook 抓不到（競態在整合層），
+// 因此這裡用真實 useQuiz + QuizPage 串起 startQuiz → 逐題作答 → finishQuiz，驗證計分不漏。
+import { afterEach, describe, expect, it } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { useEffect, useRef } from 'react';
+import { useQuiz } from '../hooks/useQuiz';
+import { QuizPage } from './QuizPage';
+import type { QuizConfig, QuizResult } from '../types/quiz';
+
+afterEach(cleanup);
+
+function ExamHarness({
+  config,
+  onResult,
+}: {
+  config: QuizConfig;
+  onResult: (r: QuizResult | null) => void;
+}) {
+  const quiz = useQuiz();
+  const started = useRef(false);
+  useEffect(() => {
+    if (started.current) return;
+    started.current = true;
+    quiz.startQuiz(config);
+  }, [quiz, config]);
+
+  if (!quiz.isActive) return null;
+  return (
+    <QuizPage
+      quiz={quiz}
+      onFinish={() => onResult(quiz.finishQuiz())}
+      onAbort={() => {}}
+    />
+  );
+}
+
+describe('考試模式端對端計分：最後一題不會被吞', () => {
+  it('跑完整份考試，correct + wrong 等於總題數（不少算最後一題）', () => {
+    const N = 3;
+    let result: QuizResult | null = null;
+    const config: QuizConfig = {
+      mode: 'exam',
+      subject: '考科1',
+      questionCount: N,
+      shuffleQuestions: false, // 決定性取題
+      showAnswerImmediately: false, // 考試模式 —— 競態就在這條路徑上
+    };
+
+    render(<ExamHarness config={config} onResult={(r) => (result = r)} />);
+
+    // 逐題：選第一個選項（A），再按「下一題」/最後一題按「完成測驗」
+    for (let i = 0; i < N; i++) {
+      const radios = screen.getAllByRole('radio');
+      expect(radios.length).toBeGreaterThanOrEqual(2); // 該題確實有選項
+      fireEvent.click(radios[0]);
+      const isLast = i === N - 1;
+      fireEvent.click(
+        screen.getByRole('button', { name: isLast ? /完成測驗/ : /下一題/ })
+      );
+    }
+
+    expect(result).not.toBeNull();
+    const r = result as unknown as QuizResult;
+    expect(r.totalAnswerable).toBe(N);
+    // 核心斷言：N 題全部計入（最後一題沒被競態吞掉）。修正前這裡會是 N-1。
+    expect(r.correctCount + r.wrongCount).toBe(N);
+    expect(r.skippedCount).toBe(0);
+  });
+});

--- a/quiz-app/tests/e2e/quiz-flow.spec.ts
+++ b/quiz-app/tests/e2e/quiz-flow.spec.ts
@@ -82,6 +82,36 @@ test.describe('測驗流程', () => {
     await expect(page.locator('.score-value')).toBeVisible();
     await expect(page.locator('.score-label')).toBeVisible();
   });
+
+  // 有跳題時結果頁會多出第 5 張「未作答」統計卡；驗證 grid（auto-fit）讓五張卡在桌面
+  // 同一列、不落單（jsdom 無法算版面，只有真實瀏覽器測得到，故放 E2E）。
+  test('跳題後結果頁的五張統計卡在桌面寬度同列、不落單', async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 900 });
+    await page.getByLabel(/題數/i).fill('3');
+    await page.getByRole('button', { name: /開始測驗/i }).click();
+    await expect(page.locator('.question-card')).toBeVisible();
+
+    // 第 1 題「跳過」（練習模式允許不選就下一題）→ 產生「未作答」
+    await page.getByRole('button', { name: /下一題/i }).click();
+    // 第 2 題作答後下一題
+    await page.locator('.option-item').first().click();
+    await page.getByRole('button', { name: /下一題/i }).click();
+    // 第 3 題作答後完成
+    await page.locator('.option-item').first().click();
+    await page.getByRole('button', { name: /完成測驗/i }).click();
+
+    await expect(page.locator('.result-page')).toBeVisible();
+    // 第 5 張「未作答」卡存在
+    await expect(page.locator('.stat-item.skipped')).toContainText('未作答');
+
+    // 五張卡都在同一列 —— 取 bounding box 的 top，全部相同才算沒有落單到第二列
+    const cards = page.locator('.stats-section .stat-item');
+    await expect(cards).toHaveCount(5);
+    const tops = await cards.evaluateAll((els) =>
+      els.map((el) => Math.round(el.getBoundingClientRect().top))
+    );
+    expect(new Set(tops).size, `五張卡應在同一列，實得 top=${JSON.stringify(tops)}`).toBe(1);
+  });
 });
 
 test.describe('無障礙功能', () => {


### PR DESCRIPTION
## 修正「刷題常少算一題」的計分競態（discussions/1 回報）

回報者 @lion2701：刷題時常常少算一題，例如正確 30、錯誤 19，總題數卻是 50（30+19=49≠50）。

### 根因
考試模式（`showAnswerImmediately=false`）原本把 `submitAnswer` 延到 `handleNext` 才呼叫；而**最後一題**的 `handleNext` 是「`submitAnswer`（非同步 `setState`）→ 立刻 `onFinish`→`finishQuiz`」——`finishQuiz` 讀到的是還沒含最後一筆的**舊 `state` closure**，最後一題答案被吞掉，導致 `correct + wrong = total − 1`。

### 修正
- **QuizPage**：兩種模式都改成「**選擇答案當下**」即 `submitAnswer`（依 `questionId` 去重、重選覆蓋）。該 `setState` 早在按「完成測驗」前的另一個 render 就 flush，徹底消除競態；`handleNext` 不再 submit。
- **ResultPage**：新增「**未作答**」統計（`skippedCount > 0` 時顯示），讓「答對＋答錯＋未作答＝總題數」一目了然（練習模式可跳題，過去 `correct+wrong < total` 易被誤解為少算）。

### 測試（回歸）
- `examScoring.test.tsx`：真實 `useQuiz` + `QuizPage` **端對端**跑完整份考試，斷言 `correct+wrong = 總題數`、`skipped = 0`。修正前最後一題被吞會是 `N−1`，此測試會紅。
- `QuizPage.test.tsx`：考試模式「選擇即 `submitAnswer`」；最後一題「完成測驗」只 `onFinish`、不再重複 submit。

vitest **767 passed**、lint 0 error、type-check 通過。

回報出處：https://github.com/thc1006/ipas-net-zero-quiz/discussions/1#discussioncomment-17783945
