### PR TITLE
最小化測驗進度持久化：主題庫題只存 id、載入時重建（closes #106）

### DIFF
--- a/quiz-app/src/data/cross-bank-integrity.test.ts
+++ b/quiz-app/src/data/cross-bank-integrity.test.ts
@@ -91,6 +91,24 @@ describe('跨題庫：同一道題不得同時存在於主題庫與練習池', (
     };
     expect(calcSignature(rewritten)).toBe(calcSignature(target!));
   });
+
+  // #106（最小化持久化）依賴此不變量：saveProgress 把「getQuestionById 找得到」的題目
+  // 最小化為 id 字串、載入時由主題庫重建；練習池題目必須永遠找不到（保留完整物件），
+  // 否則會被重建成「同 id 的主題庫題」而換錯內容（stem-guard 只在 stem 相同時擋得住）。
+  // 主題庫 runtime id 依 questions.ts：gist → `gist-<index>`、unique → item_id。
+  it('id 命名空間不得與主題庫交疊（#106 靠此保證練習池題不被重建成主題庫題）', () => {
+    const mainIds = new Set<string>([
+      ...ds.gist_items.map((q) => `gist-${q.index}`),
+      ...ds.our_unique_items.map((q) => q.item_id as string),
+    ]);
+    const collisions = POOL.map((q) => q.id as string).filter((id) =>
+      mainIds.has(id)
+    );
+    expect(
+      collisions,
+      `練習池 id 與主題庫 id 交疊 → #106 重建會換錯題：${collisions.join(', ')}`
+    ).toEqual([]);
+  });
 });
 
 describe('數值題不得有兩個選項是同一個答案', () => {

--- a/quiz-app/src/data/questions.ts
+++ b/quiz-app/src/data/questions.ts
@@ -184,10 +184,17 @@ export function getRandomQuestionsFromPool(
 
 
 /**
+ * id → 題目索引。allQuestions 的 id 保證唯一（cross-bank-integrity 有 gate 守），
+ * 故 Map 與線性 find 等價，但把 getQuestionById 由 O(n) 降為 O(1)。
+ * 這對 #106 的持久化最小化很關鍵：saveProgress 每次 state 變動就對每題呼叫一次。
+ */
+const questionsById = new Map(allQuestions.map((q) => [q.id, q]));
+
+/**
  * 依據 ID 取得題目
  */
 export function getQuestionById(id: string): QuizQuestion | undefined {
-  return allQuestions.find((q) => q.id === id);
+  return questionsById.get(id);
 }
 
 /**

--- a/quiz-app/src/hooks/nullAnswerScoring.test.tsx
+++ b/quiz-app/src/hooks/nullAnswerScoring.test.tsx
@@ -28,7 +28,7 @@ import {
   FIXTURE_NULL_ANSWER_ID,
 } from '../utils/__fixtures__/practice-pool-fixture';
 import { loadProgress } from '../utils/quiz-progress-storage';
-import type { QuizConfig } from '../types/quiz';
+import type { QuizConfig, QuizResult } from '../types/quiz';
 
 // test-setup 的 localStorage 是純 vi.fn() stub（不真的存），所以 saveProgress→
 // resumeQuiz 無法 round-trip。要測「續作舊進度還原一份含無答案題的 quiz」這條
@@ -240,6 +240,17 @@ describe('無標準答案的題目（answer=null + ambiguous）絕不送到使�
       // 兩題都在（非無答案題），但 sa-A 的過期紀錄被丟棄 → 該題未作答
       expect(result.current.questions.map((q) => q.id)).toEqual(['sa-A', 'sa-B']);
       expect(result.current.progress.answered).toBe(0);
+
+      // 端到端 refute review 的「畫面顯示錯、卻得 100 分」：完成測驗時，過期題計為未作答
+      // （skipped），不是答對 —— 分數為 0、correctCount 0，而非 100。
+      let fin: QuizResult | null = null;
+      act(() => {
+        fin = result.current.finishQuiz();
+      });
+      const f = fin as unknown as QuizResult;
+      expect(f.correctCount).toBe(0);
+      expect(f.score).toBe(0);
+      expect(f.skippedCount).toBe(2);
     });
 
     it('保存後標準答案未變 → 紀錄照常保留（對帳不誤丟）', () => {

--- a/quiz-app/src/hooks/nullAnswerScoring.test.tsx
+++ b/quiz-app/src/hooks/nullAnswerScoring.test.tsx
@@ -212,5 +212,57 @@ describe('無標準答案的題目（answer=null + ambiguous）絕不送到使�
       expect(ok).toBe(false);
       expect(result.current.isActive).toBe(false); // 沒 resume，維持 idle
     });
+
+    // #106 split-brain 對帳：最小化持久化用現行題庫重建題目；若標準答案在保存後被更正，
+    // 舊紀錄的 correctAnswer 會與現行 question.answer 不符 → 丟棄該筆，讓該題以未作答呈現，
+    // 避免「畫面回饋（現行答案）與計分（舊紀錄）分裂」。
+    it('保存後標準答案被更正 → 與現行不符的舊紀錄被對帳丟棄，該題回未作答', () => {
+      const staleAnswer = ansBase.answer === 'A' ? 'B' : 'A'; // 保證 !== 現行 answer
+      const { result, ok } = resume({
+        isActive: true,
+        questions: [mkAns('sa-A'), mkAns('sa-B')],
+        currentIndex: 0,
+        answers: [
+          {
+            questionId: 'sa-A',
+            selectedAnswer: 'A',
+            correctAnswer: staleAnswer, // 模擬答案已更正：與 sa-A 現行 answer 不一致
+            isCorrect: true,
+            timeSpent: 1,
+            timestamp: Date.now(),
+            sourceCategory: 'main_bank',
+          },
+        ],
+        startTime: Date.now(),
+        config: baseConfig,
+      });
+      expect(ok).toBe(true);
+      // 兩題都在（非無答案題），但 sa-A 的過期紀錄被丟棄 → 該題未作答
+      expect(result.current.questions.map((q) => q.id)).toEqual(['sa-A', 'sa-B']);
+      expect(result.current.progress.answered).toBe(0);
+    });
+
+    it('保存後標準答案未變 → 紀錄照常保留（對帳不誤丟）', () => {
+      const { result, ok } = resume({
+        isActive: true,
+        questions: [mkAns('sa-A'), mkAns('sa-B')],
+        currentIndex: 0,
+        answers: [
+          {
+            questionId: 'sa-A',
+            selectedAnswer: ansBase.answer,
+            correctAnswer: ansBase.answer, // 與現行一致
+            isCorrect: true,
+            timeSpent: 1,
+            timestamp: Date.now(),
+            sourceCategory: 'main_bank',
+          },
+        ],
+        startTime: Date.now(),
+        config: baseConfig,
+      });
+      expect(ok).toBe(true);
+      expect(result.current.progress.answered).toBe(1); // 紀錄保留
+    });
   });
 });

--- a/quiz-app/src/hooks/useQuiz.test.ts
+++ b/quiz-app/src/hooks/useQuiz.test.ts
@@ -391,7 +391,7 @@ describe('useQuiz Hook', () => {
   // === resumeQuiz（Refs #71）===
   // 此區需要真實 localStorage 行為（test-setup mock 會讓 getItem 回 undefined）
   describe('resumeQuiz', () => {
-    const STORAGE_KEY = 'ipas-quiz-in-progress';
+    const STORAGE_KEY = 'ipas-quiz-in-progress-v2';
 
     beforeEach(() => {
       // 同 quiz-progress-storage.test.ts 的 real localStorage 安裝

--- a/quiz-app/src/hooks/useQuiz.ts
+++ b/quiz-app/src/hooks/useQuiz.ts
@@ -336,14 +336,30 @@ export function useQuiz() {
       clearProgress();
       return false;
     }
-    if (answerable.length === s.questions.length) {
-      setState(s); // 沒有無答案題 → 原樣還原（常態、快路徑）
+    // #106 對帳：最小化持久化在 resume 時用**現行題庫**重建題目。若某題的標準答案在保存後
+    // 被更正（如 gist[340] B→C），舊 answers 紀錄的 correctAnswer 會與重建後的現行
+    // question.answer 不一致 —— 沿用會造成分裂：畫面回饋與 finishQuiz 依現行答案，該筆紀錄卻
+    // 凍在舊答案。策略：丟棄該筆紀錄，讓該題以未作答呈現，使用者依現行內容重答（重答走
+    // submitAnswer 會依現行答案重新計分）。只比得到「標準答案字母」—— 選項文字若在答案字母
+    // 不變下被改寫，紀錄仍相容（顯示自動更新為現行），無法也無需從紀錄偵測（未存舊選項）。
+    const answerById = new Map(answerable.map((q) => [q.id, q]));
+    const reconciledAnswers = s.answers.filter((a) => {
+      const q = answerById.get(a.questionId);
+      return !!q && a.correctAnswer === q.answer;
+    });
+
+    const nothingDropped =
+      answerable.length === s.questions.length &&
+      reconciledAnswers.length === s.answers.length;
+
+    if (nothingDropped) {
+      setState(s); // 常態快路徑：題目與答案紀錄都無變動
     } else {
-      // 有題被濾掉 → 重新錨定：currentIndex 指回原本正在作答的那一題（若它還在），
-      // 否則往前收斂；answers 只保留仍存在的題，避免 finishQuiz 的 skippedCount 算錯。
+      // 有題被濾掉（無答案題）或有紀錄被對帳丟棄（答案已更正）→ 重新錨定：currentIndex
+      // 指回原本正在作答的那一題（若它還在），否則往前收斂；answers 用對帳後的結果，
+      // 避免 finishQuiz 的 skippedCount 與畫面回饋算錯。
       const curId = s.questions[s.currentIndex]?.id;
       const survivedIdx = answerable.findIndex((q) => q.id === curId);
-      const survivingIds = new Set(answerable.map((q) => q.id));
       setState({
         ...s,
         questions: answerable,
@@ -351,7 +367,7 @@ export function useQuiz() {
           survivedIdx >= 0
             ? survivedIdx
             : Math.min(s.currentIndex, answerable.length - 1),
-        answers: s.answers.filter((a) => survivingIds.has(a.questionId)),
+        answers: reconciledAnswers,
       });
     }
     setQuestionStartTime(Date.now());

--- a/quiz-app/src/pages/HomePage.test.tsx
+++ b/quiz-app/src/pages/HomePage.test.tsx
@@ -339,6 +339,9 @@ describe('HomePage', () => {
   });
 
   // === Resume hint（Refs #71）===
+  // 註：questions 用 { id: 'x' } 佔位而非 null —— loadProgress（#106 重建）會拒絕
+  // 含 null/垃圾元素的 payload（避免 resume 時 crash），故佔位需為非 null 物件。
+  // hint 只讀 questions.length / answers.length，佔位內容不影響斷言。
 
   it('localStorage 無進度時不顯示 resume hint', () => {
     render(<HomePage onStartQuiz={() => {}} onResumeQuiz={() => {}} />);
@@ -353,7 +356,7 @@ describe('HomePage', () => {
         savedAt: Date.now() - 5 * 60_000, // 5 分鐘前
         state: {
           isActive: true,
-          questions: new Array(20).fill(null),
+          questions: new Array(20).fill({ id: 'x' }),
           currentIndex: 7,
           answers: new Array(7).fill({ questionId: 'x' }),
           startTime: Date.now(),
@@ -377,7 +380,7 @@ describe('HomePage', () => {
         savedAt: Date.now(),
         state: {
           isActive: true,
-          questions: new Array(10).fill(null),
+          questions: new Array(10).fill({ id: 'x' }),
           currentIndex: 3,
           answers: new Array(3).fill({ questionId: 'x' }),
           startTime: Date.now(),
@@ -399,7 +402,7 @@ describe('HomePage', () => {
         savedAt: Date.now(),
         state: {
           isActive: true,
-          questions: new Array(5).fill(null),
+          questions: new Array(5).fill({ id: 'x' }),
           currentIndex: 1,
           answers: [],
           startTime: Date.now(),

--- a/quiz-app/src/pages/HomePage.test.tsx
+++ b/quiz-app/src/pages/HomePage.test.tsx
@@ -339,8 +339,9 @@ describe('HomePage', () => {
   });
 
   // === Resume hint（Refs #71）===
-  // 註：questions 用 { id: 'x' } 佔位而非 null —— loadProgress（#106 重建）會拒絕
-  // 含 null/垃圾元素的 payload（避免 resume 時 crash），故佔位需為非 null 物件。
+  // 註：questions 佔位需為「合理 shape」的物件（含 id/stem/options）—— loadProgress
+  // （#106 重建）會拒絕含 null/垃圾/缺欄位的 payload（避免 resume 時 crash）。
+  // 這些 fixture 寫在 legacy v1 key 上，順帶驗證 v2 loader 對舊 key 的回退讀取；
   // hint 只讀 questions.length / answers.length，佔位內容不影響斷言。
 
   it('localStorage 無進度時不顯示 resume hint', () => {
@@ -356,7 +357,7 @@ describe('HomePage', () => {
         savedAt: Date.now() - 5 * 60_000, // 5 分鐘前
         state: {
           isActive: true,
-          questions: new Array(20).fill({ id: 'x' }),
+          questions: new Array(20).fill({ id: 'x', stem: '題', options: [] }),
           currentIndex: 7,
           answers: new Array(7).fill({ questionId: 'x' }),
           startTime: Date.now(),
@@ -380,7 +381,7 @@ describe('HomePage', () => {
         savedAt: Date.now(),
         state: {
           isActive: true,
-          questions: new Array(10).fill({ id: 'x' }),
+          questions: new Array(10).fill({ id: 'x', stem: '題', options: [] }),
           currentIndex: 3,
           answers: new Array(3).fill({ questionId: 'x' }),
           startTime: Date.now(),
@@ -402,7 +403,7 @@ describe('HomePage', () => {
         savedAt: Date.now(),
         state: {
           isActive: true,
-          questions: new Array(5).fill({ id: 'x' }),
+          questions: new Array(5).fill({ id: 'x', stem: '題', options: [] }),
           currentIndex: 1,
           answers: [],
           startTime: Date.now(),

--- a/quiz-app/src/utils/quiz-progress-storage.test.ts
+++ b/quiz-app/src/utils/quiz-progress-storage.test.ts
@@ -9,7 +9,8 @@ import {
 import type { QuizState } from '../hooks/useQuiz';
 import { allQuestions } from '../data/questions';
 
-const STORAGE_KEY = 'ipas-quiz-in-progress';
+const STORAGE_KEY = 'ipas-quiz-in-progress-v2';
+const LEGACY_STORAGE_KEY = 'ipas-quiz-in-progress'; // v1 舊 key
 
 // test-setup.ts mock 了 localStorage 為 vi.fn()（getItem 回 undefined）；
 // 此檔需真實 localStorage 行為（與 HomePage.test.tsx 同 pattern）
@@ -284,6 +285,94 @@ describe('quiz-progress-storage', () => {
       expect(loaded?.version).toBe(1);
       expect(loaded?.state.currentIndex).toBe(2);
       expect(loaded?.state.questions).toHaveLength(10);
+    });
+
+    // #107 review G3：非 null 但缺 shape 的題目物件也要擋，否則 QuestionCard 讀 .options
+    // 會 crash 進 ErrorBoundary，且壞資料沒清 → 每次重試都再 crash（poisoned state）。
+    it('題目物件缺 shape（無 stem/options）→ 放棄 resume（回 null 並清掉）', () => {
+      localStorage.setItem(
+        STORAGE_KEY,
+        JSON.stringify({
+          version: 2,
+          savedAt: 0,
+          state: {
+            isActive: true,
+            questions: [{ id: 'x', hasAnswer: true }], // 非 null 物件但缺 stem/options
+            currentIndex: 0,
+            answers: [],
+            startTime: 123,
+            config: fakeConfig,
+          },
+        })
+      );
+      expect(loadProgress()).toBeNull();
+      expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+    });
+
+    // #107 review G4：currentIndex 必須是整數，否則 questions[2.5]=undefined → 卡「載入中」。
+    it('currentIndex 非整數（0.5）→ 擋下（回 null 並清掉）', () => {
+      const realQ = allQuestions[0];
+      localStorage.setItem(
+        STORAGE_KEY,
+        JSON.stringify({
+          version: 2,
+          savedAt: 0,
+          state: {
+            isActive: true,
+            questions: [realQ.id],
+            currentIndex: 0.5,
+            answers: [],
+            startTime: 123,
+            config: fakeConfig,
+          },
+        })
+      );
+      expect(loadProgress()).toBeNull();
+      expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+    });
+
+    // #107 review G6：50 題主題庫未作答的 payload 必須維持精簡，防未來不小心退回全物件。
+    it('50 題主題庫未作答 payload 維持精簡（<6KB，全物件約 38KB）', () => {
+      const qs = allQuestions.slice(0, 50) as unknown as QuizState['questions'];
+      saveProgress(makeState({ questions: qs, currentIndex: 0, answers: [] }));
+      const raw = localStorage.getItem(STORAGE_KEY)!;
+      expect(raw.length).toBeLessThan(6000);
+    });
+  });
+
+  // #107 review G2：v2 用獨立 key，避免部署期舊 v1 bundle 把新 v2 進度判為壞資料而刪除。
+  describe('儲存 key 版本化（避免舊分頁誤刪）', () => {
+    it('saveProgress 寫入 v2 key，不動 legacy key', () => {
+      saveProgress(makeState());
+      expect(localStorage.getItem(STORAGE_KEY)).not.toBeNull();
+      expect(localStorage.getItem(LEGACY_STORAGE_KEY)).toBeNull();
+    });
+
+    it('v2 key 無資料時回退讀 legacy v1 key（部署後一次性遷移）', () => {
+      localStorage.setItem(
+        LEGACY_STORAGE_KEY,
+        JSON.stringify({ version: 1, savedAt: 0, state: makeState({ currentIndex: 3 }) })
+      );
+      const loaded = loadProgress();
+      expect(loaded?.version).toBe(1);
+      expect(loaded?.state.currentIndex).toBe(3);
+    });
+
+    it('v2 key 優先於 legacy key', () => {
+      localStorage.setItem(
+        LEGACY_STORAGE_KEY,
+        JSON.stringify({ version: 1, savedAt: 0, state: makeState({ currentIndex: 9 }) })
+      );
+      saveProgress(makeState({ currentIndex: 4 })); // 寫 v2
+      expect(loadProgress()?.state.currentIndex).toBe(4);
+    });
+
+    it('clearProgress 清掉 v2 與 legacy 兩個 key', () => {
+      saveProgress(makeState());
+      localStorage.setItem(LEGACY_STORAGE_KEY, 'stale');
+      clearProgress();
+      expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+      expect(localStorage.getItem(LEGACY_STORAGE_KEY)).toBeNull();
     });
   });
 

--- a/quiz-app/src/utils/quiz-progress-storage.test.ts
+++ b/quiz-app/src/utils/quiz-progress-storage.test.ts
@@ -7,6 +7,7 @@ import {
   formatRelativeTime,
 } from './quiz-progress-storage';
 import type { QuizState } from '../hooks/useQuiz';
+import { allQuestions } from '../data/questions';
 
 const STORAGE_KEY = 'ipas-quiz-in-progress';
 
@@ -96,7 +97,7 @@ describe('quiz-progress-storage', () => {
       saveProgress(makeState());
       const raw = localStorage.getItem(STORAGE_KEY);
       const parsed = JSON.parse(raw!);
-      expect(parsed.version).toBe(1);
+      expect(parsed.version).toBe(2);
       expect(typeof parsed.savedAt).toBe('number');
       expect(parsed.state).toBeDefined();
     });
@@ -112,7 +113,7 @@ describe('quiz-progress-storage', () => {
       saveProgress(state);
       const loaded = loadProgress();
       expect(loaded?.state.currentIndex).toBe(5);
-      expect(loaded?.version).toBe(1);
+      expect(loaded?.version).toBe(2);
     });
 
     it('壞掉的 JSON 回 null 不 throw', () => {
@@ -136,6 +137,109 @@ describe('quiz-progress-storage', () => {
       );
       expect(loadProgress()).toBeNull();
       expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+    });
+  });
+
+  // #106：主題庫題最小化為 id、練習池題保留完整物件；載入時重建。
+  describe('最小化持久化（#106）', () => {
+    it('主題庫題目序列化為 id 字串，載入後由題庫重建完整內容', () => {
+      const realQ = allQuestions[0];
+      saveProgress(
+        makeState({
+          questions: [realQ] as QuizState['questions'],
+          currentIndex: 0,
+        })
+      );
+      // localStorage 內只存 id 字串（payload 最小化，不含 stem/options/...）
+      const parsed = JSON.parse(localStorage.getItem(STORAGE_KEY)!);
+      expect(parsed.state.questions[0]).toBe(realQ.id);
+      // 載入後重建為與題庫一致的完整題目
+      const loaded = loadProgress();
+      expect(loaded?.state.questions[0]).toEqual(realQ);
+    });
+
+    it('非主題庫題目（id 不在題庫，如練習池）保留完整物件', () => {
+      saveProgress(makeState()); // fakeQuestions：id q-0..q-9 不在題庫
+      const parsed = JSON.parse(localStorage.getItem(STORAGE_KEY)!);
+      expect(typeof parsed.state.questions[0]).toBe('object');
+      expect(parsed.state.questions[0].id).toBe('q-0');
+      // 載入後物件原樣返回
+      const loaded = loadProgress();
+      expect(loaded?.state.questions[0].id).toBe('q-0');
+    });
+
+    it('混合題組：主題庫題存 id、其餘存物件，載入後題數與內容都正確', () => {
+      const realQ = allQuestions[0];
+      const poolQ = fakeQuestions[0]; // id q-0，不在題庫
+      saveProgress(
+        makeState({
+          questions: [realQ, poolQ] as QuizState['questions'],
+          currentIndex: 1,
+        })
+      );
+      const parsed = JSON.parse(localStorage.getItem(STORAGE_KEY)!);
+      expect(parsed.state.questions[0]).toBe(realQ.id); // 主題庫 → 字串
+      expect(typeof parsed.state.questions[1]).toBe('object'); // 練習池 → 物件
+      const loaded = loadProgress();
+      expect(loaded?.state.questions).toHaveLength(2);
+      expect(loaded?.state.questions[0]).toEqual(realQ);
+      expect(loaded?.state.questions[1].id).toBe('q-0');
+      expect(loaded?.state.currentIndex).toBe(1);
+    });
+
+    it('v2 payload 內 id 已從題庫移除 → 放棄 resume（回 null 並清掉）', () => {
+      localStorage.setItem(
+        STORAGE_KEY,
+        JSON.stringify({
+          version: 2,
+          savedAt: 0,
+          state: {
+            isActive: true,
+            questions: ['__id_that_does_not_exist__'],
+            currentIndex: 0,
+            answers: [],
+            startTime: 123,
+            config: fakeConfig,
+          },
+        })
+      );
+      expect(loadProgress()).toBeNull();
+      expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+    });
+
+    it('payload 內含非法題目元素（null）→ 放棄 resume（回 null 並清掉）', () => {
+      localStorage.setItem(
+        STORAGE_KEY,
+        JSON.stringify({
+          version: 2,
+          savedAt: 0,
+          state: {
+            isActive: true,
+            questions: [null],
+            currentIndex: 0,
+            answers: [],
+            startTime: 123,
+            config: fakeConfig,
+          },
+        })
+      );
+      expect(loadProgress()).toBeNull();
+      expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+    });
+
+    it('v1（全物件）payload 仍可載入（向後相容）', () => {
+      localStorage.setItem(
+        STORAGE_KEY,
+        JSON.stringify({
+          version: 1,
+          savedAt: 0,
+          state: makeState({ currentIndex: 2 }),
+        })
+      );
+      const loaded = loadProgress();
+      expect(loaded?.version).toBe(1);
+      expect(loaded?.state.currentIndex).toBe(2);
+      expect(loaded?.state.questions).toHaveLength(10);
     });
   });
 

--- a/quiz-app/src/utils/quiz-progress-storage.test.ts
+++ b/quiz-app/src/utils/quiz-progress-storage.test.ts
@@ -250,6 +250,27 @@ describe('quiz-progress-storage', () => {
       expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
     });
 
+    it('answers 含非法元素（null）→ 擋下（回 null 並清掉，避免 finishQuiz 對 null 取值 crash）', () => {
+      const realQ = allQuestions[0];
+      localStorage.setItem(
+        STORAGE_KEY,
+        JSON.stringify({
+          version: 2,
+          savedAt: 0,
+          state: {
+            isActive: true,
+            questions: [realQ.id], // 題目可正常重建
+            currentIndex: 0,
+            answers: [null], // 但 answers 有 null 元素
+            startTime: 123,
+            config: fakeConfig,
+          },
+        })
+      );
+      expect(loadProgress()).toBeNull();
+      expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+    });
+
     it('v1（全物件）payload 仍可載入（向後相容）', () => {
       localStorage.setItem(
         STORAGE_KEY,

--- a/quiz-app/src/utils/quiz-progress-storage.test.ts
+++ b/quiz-app/src/utils/quiz-progress-storage.test.ts
@@ -386,6 +386,20 @@ describe('quiz-progress-storage', () => {
     it('無資料時 idempotent 不 throw', () => {
       expect(() => clearProgress()).not.toThrow();
     });
+
+    // removeItem 在 quota/private mode 下可能 throw；removeStored 兩個 key 各自吞掉例外。
+    it('removeItem throw 時 clearProgress 不 throw', () => {
+      const ls = window.localStorage;
+      const origRemove = ls.removeItem;
+      ls.removeItem = () => {
+        throw new Error('quota');
+      };
+      try {
+        expect(() => clearProgress()).not.toThrow();
+      } finally {
+        ls.removeItem = origRemove;
+      }
+    });
   });
 
   describe('formatRelativeTime', () => {

--- a/quiz-app/src/utils/quiz-progress-storage.test.ts
+++ b/quiz-app/src/utils/quiz-progress-storage.test.ts
@@ -309,6 +309,28 @@ describe('quiz-progress-storage', () => {
       expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
     });
 
+    // #107 review G3 補強：options 陣列的元素也要有 key/text，否則 QuestionCard 對 null 取
+    // .text/.key 一樣 crash（QuestionCard.tsx: options.map(o => o.text)、o.text.startsWith）。
+    it('題目 options 元素缺 key/text（如 [null]）→ 放棄 resume（回 null 並清掉）', () => {
+      localStorage.setItem(
+        STORAGE_KEY,
+        JSON.stringify({
+          version: 2,
+          savedAt: 0,
+          state: {
+            isActive: true,
+            questions: [{ id: 'x', stem: 's', options: [null] }],
+            currentIndex: 0,
+            answers: [],
+            startTime: 123,
+            config: fakeConfig,
+          },
+        })
+      );
+      expect(loadProgress()).toBeNull();
+      expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+    });
+
     // #107 review G4：currentIndex 必須是整數，否則 questions[2.5]=undefined → 卡「載入中」。
     it('currentIndex 非整數（0.5）→ 擋下（回 null 並清掉）', () => {
       const realQ = allQuestions[0];

--- a/quiz-app/src/utils/quiz-progress-storage.test.ts
+++ b/quiz-app/src/utils/quiz-progress-storage.test.ts
@@ -227,6 +227,29 @@ describe('quiz-progress-storage', () => {
       expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
     });
 
+    it('v2 payload 重建成功但 currentIndex 越界 → 語意檢查在重建後擋下（回 null 並清掉）', () => {
+      // 拆分 isValidEnvelope / isValidState 的重點：語意檢查必須跑在**重建後**的完整
+      // state 上。此案 id 可重建（1 題）但 currentIndex 越界，須被 isValidState 擋下。
+      const realQ = allQuestions[0];
+      localStorage.setItem(
+        STORAGE_KEY,
+        JSON.stringify({
+          version: 2,
+          savedAt: 0,
+          state: {
+            isActive: true,
+            questions: [realQ.id], // 可重建
+            currentIndex: 5, // 但越界（>= 1）
+            answers: [],
+            startTime: 123,
+            config: fakeConfig,
+          },
+        })
+      );
+      expect(loadProgress()).toBeNull();
+      expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+    });
+
     it('v1（全物件）payload 仍可載入（向後相容）', () => {
       localStorage.setItem(
         STORAGE_KEY,

--- a/quiz-app/src/utils/quiz-progress-storage.test.ts
+++ b/quiz-app/src/utils/quiz-progress-storage.test.ts
@@ -331,6 +331,33 @@ describe('quiz-progress-storage', () => {
       expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
     });
 
+    it('題目 options 元素完整（key/text 皆字串）→ 正常載入', () => {
+      const q = {
+        id: 'q-ok',
+        stem: 's',
+        options: [{ key: 'A', text: '甲' }],
+        answer: 'A',
+        subject: '考科1',
+        hasAnswer: true,
+      };
+      localStorage.setItem(
+        STORAGE_KEY,
+        JSON.stringify({
+          version: 2,
+          savedAt: 0,
+          state: {
+            isActive: true,
+            questions: [q],
+            currentIndex: 0,
+            answers: [],
+            startTime: 123,
+            config: fakeConfig,
+          },
+        })
+      );
+      expect(loadProgress()?.state.questions[0].id).toBe('q-ok');
+    });
+
     // #107 review G4：currentIndex 必須是整數，否則 questions[2.5]=undefined → 卡「載入中」。
     it('currentIndex 非整數（0.5）→ 擋下（回 null 並清掉）', () => {
       const realQ = allQuestions[0];

--- a/quiz-app/src/utils/quiz-progress-storage.ts
+++ b/quiz-app/src/utils/quiz-progress-storage.ts
@@ -78,10 +78,16 @@ function minifyQuestion(q: QuizQuestion): StoredQuestion {
 function isPlausibleQuestion(q: unknown): q is QuizQuestion {
   if (!q || typeof q !== 'object') return false;
   const x = q as Partial<QuizQuestion>;
-  return (
-    typeof x.id === 'string' &&
-    typeof x.stem === 'string' &&
-    Array.isArray(x.options)
+  if (typeof x.id !== 'string' || typeof x.stem !== 'string') return false;
+  // options 不只要是陣列，每個元素也要有 key/text 字串 —— QuestionCard 會 o.text.startsWith、
+  // o.key，遇 null 或缺欄位的選項一樣 crash。這是「防 crash」的最小完整集，非語意驗證。
+  if (!Array.isArray(x.options)) return false;
+  return (x.options as unknown[]).every(
+    (o) =>
+      !!o &&
+      typeof o === 'object' &&
+      typeof (o as { key?: unknown }).key === 'string' &&
+      typeof (o as { text?: unknown }).text === 'string'
   );
 }
 

--- a/quiz-app/src/utils/quiz-progress-storage.ts
+++ b/quiz-app/src/utils/quiz-progress-storage.ts
@@ -15,18 +15,29 @@
 //   **原樣保留整個物件**（如此 resume 不需 async 載入練習池即可同步重建）。
 //
 //   重要不變量：
-//   - 計分不受重建影響 —— finishQuiz 由自足的 answers[]（correctAnswer/isCorrect）
-//     計分，不看重建後的題目物件；重建只影響 resume 時**顯示**的題目內容。
-//   - 若某題內容在 save 與 resume 之間因更正而變動（例：答案修正／換選項），resume
-//     會顯示**現行題庫**的最新內容（auto-heal，非 bug）；若該 id 已從題庫移除，
-//     整份 resume 放棄（回 null），避免題數錯位／currentIndex 越界。
+//   - 答對／答錯「數」不受重建影響 —— finishQuiz 由自足的 answers[]（correctAnswer/
+//     isCorrect）計分，不看重建後的題目物件。
+//   - 但重建用的是**現行題庫**（非保存當下）。若某題**標準答案**在 save 與 resume 之間
+//     被更正，現行題目會與凍在舊答案的紀錄分裂。此分裂由 resumeQuiz 對帳消除：correctAnswer
+//     與現行 answer 不符的紀錄一律丟棄、該題以未作答呈現、由使用者依現行內容重答（見
+//     useQuiz.resumeQuiz）。這不是 silent auto-heal —— 答案變動一律回未作答重答。殘留：選項
+//     文字在「答案字母不變」下被改寫僅屬顯示更新（計分以字母為準、相容），刻意不偵測（偵測
+//     需存舊內容，違背最小化目的）。
+//   - 若某題 id 已從題庫移除 → 整份 resume 放棄（回 null），避免題數錯位／currentIndex 越界。
 //   - 向後相容：v1（全物件）payload 仍可載入 —— 重建把物件原樣返回。
+//
+//   儲存 key 版本化（避免部署期舊分頁誤刪新資料）：v2 寫入獨立 key（…-v2），讀取先 v2、
+//   再回退 legacy v1 key。已部署的舊 bundle 只認 version=1，遇 v2 會判為壞資料並 removeItem
+//   —— 若共用同一 key，舊分頁一導覽回首頁就會刪掉新分頁剛寫的 v2 進度。分開 key 後舊 bundle
+//   看不到 v2、刪不到；新 bundle 永遠優先採 v2。
 
 import type { QuizState } from '../hooks/useQuiz';
 import type { QuizQuestion } from '../types/quiz';
 import { getQuestionById } from '../data/questions';
 
-const STORAGE_KEY = 'ipas-quiz-in-progress';
+// v2 用獨立 key，與已部署的 v1 bundle 隔離（見檔頭「儲存 key 版本化」）。
+const STORAGE_KEY = 'ipas-quiz-in-progress-v2';
+const LEGACY_STORAGE_KEY = 'ipas-quiz-in-progress'; // v1 舊 key，僅讀取時回退用
 const SCHEMA_VERSION = 2;
 // v1（全物件）與 v2（主題庫題最小化為 id）都要能載入，避免打壞既有已上線的 resume。
 const SUPPORTED_VERSIONS = new Set<number>([1, 2]);
@@ -60,8 +71,23 @@ function minifyQuestion(q: QuizQuestion): StoredQuestion {
 }
 
 /**
+ * 最小 shape 檢查：重建後的題目至少要有 id/stem/options，否則 QuizPage/QuestionCard
+ * 讀 .options/.stem 會 crash。只擋損壞／竄改的 localStorage —— 主題庫重建與正常存下的
+ * 練習池物件都必然通過；不做更深的語意驗證（那屬過度工程）。
+ */
+function isPlausibleQuestion(q: unknown): q is QuizQuestion {
+  if (!q || typeof q !== 'object') return false;
+  const x = q as Partial<QuizQuestion>;
+  return (
+    typeof x.id === 'string' &&
+    typeof x.stem === 'string' &&
+    Array.isArray(x.options)
+  );
+}
+
+/**
  * 重建整份 state.questions；任一字串 id 在現行題庫找不到 → 回 null（整份放棄 resume）。
- * 物件形態（練習池／v1 全物件）原樣返回。
+ * 物件形態（練習池／v1 全物件）原樣返回（先過最小 shape 檢查）。
  */
 function reconstructState(
   rawState: PersistedProgressRaw['state']
@@ -75,15 +101,30 @@ function reconstructState(
       // 極罕見（通常是就地更正而非刪除），故選簡單保守的整份放棄，不複製 re-anchor 邏輯。
       if (!q) return null;
       questions.push(q);
-    } else if (stored && typeof stored === 'object') {
+    } else if (isPlausibleQuestion(stored)) {
       questions.push(stored);
     } else {
-      // null／數字／其他垃圾元素 → payload 已損壞，放棄整份，
-      // 避免 resumeQuiz 對 undefined 題目取 .hasAnswer 而在「繼續測驗」時 crash。
+      // null／數字／shape 不符（缺 id/stem/options）的物件 → payload 已損壞，放棄整份。
+      // 否則 resumeQuiz 取 .hasAnswer、或 QuestionCard 讀 .options 會在「繼續測驗」時 crash，
+      // 且壞資料留在 localStorage 會導致每次重試都再 crash（poisoned state）。
       return null;
     }
   }
   return { ...rawState, questions } as QuizState;
+}
+
+/** 清掉 v2 與 legacy v1 兩個 key（各自吞掉 quota/private-mode 例外）。 */
+function removeStored(): void {
+  try {
+    localStorage.removeItem(STORAGE_KEY);
+  } catch {
+    /* ignore */
+  }
+  try {
+    localStorage.removeItem(LEGACY_STORAGE_KEY);
+  } catch {
+    /* ignore */
+  }
 }
 
 /** Save in-progress quiz state. No-op if state.isActive is false. */
@@ -104,40 +145,34 @@ export function saveProgress(state: QuizState): void {
 /** Load saved progress. Returns null if absent / wrong shape / wrong version / 題目已失聯. */
 export function loadProgress(): PersistedProgress | null {
   try {
-    const raw = localStorage.getItem(STORAGE_KEY);
+    // 先讀 v2 key，沒有再回退 legacy v1 key（部署後首次 resume 的一次性遷移）。
+    const raw =
+      localStorage.getItem(STORAGE_KEY) ??
+      localStorage.getItem(LEGACY_STORAGE_KEY);
     if (!raw) return null;
     const parsed = JSON.parse(raw) as unknown;
     if (!isValidEnvelope(parsed)) {
       // shape 不符 → 直接清掉避免下次再吃壞資料
-      localStorage.removeItem(STORAGE_KEY);
+      removeStored();
       return null;
     }
     const state = reconstructState(parsed.state);
     // 重建失敗（題目失聯）或重建後語意檢查不過 → 一併清掉
     if (!state || !isValidState(state)) {
-      localStorage.removeItem(STORAGE_KEY);
+      removeStored();
       return null;
     }
     return { version: parsed.version, savedAt: parsed.savedAt, state };
   } catch {
     // JSON.parse 失敗（壞掉的 JSON）也清掉，避免下次載入重複吃同一筆壞資料
-    // 巢狀 try：removeItem 在 quota / private mode 下亦可能 throw
-    try {
-      localStorage.removeItem(STORAGE_KEY);
-    } catch {
-      /* ignore */
-    }
+    removeStored();
     return null;
   }
 }
 
-/** Clear stored progress unconditionally. */
+/** Clear stored progress unconditionally（v2 + legacy 兩個 key 都清）。 */
 export function clearProgress(): void {
-  try {
-    localStorage.removeItem(STORAGE_KEY);
-  } catch {
-    /* ignore */
-  }
+  removeStored();
 }
 
 /**
@@ -165,7 +200,8 @@ function isValidState(st: QuizState): boolean {
   // 基本 shape
   if (typeof st.isActive !== 'boolean') return false;
   if (!Array.isArray(st.questions)) return false;
-  if (typeof st.currentIndex !== 'number') return false;
+  // 整數 —— 拒 2.5/NaN/Infinity（否則 questions[i]=undefined → currentQuestion=null → 卡「載入中」）
+  if (!Number.isInteger(st.currentIndex)) return false;
   if (!Array.isArray(st.answers)) return false;
   // answers 每筆須為非 null 物件 —— 否則 finishQuiz 的 a.correctAnswer、submitAnswer
   // 的 a.questionId 會對 null 取值而在續作／完成時 crash（防損壞或竄改的 localStorage；

--- a/quiz-app/src/utils/quiz-progress-storage.ts
+++ b/quiz-app/src/utils/quiz-progress-storage.ts
@@ -7,25 +7,89 @@
 // - 永不自動過期（10KB 數量級、永久 key 覆寫不膨脹）
 // - 只在 finishQuiz / resetQuiz 時清除，由 useQuiz 主動呼叫
 // - shape 不符時靜默丟棄（取代 throw，避免阻擋正常啟動）
+//
+// 最小化持久化（#106，SCHEMA_VERSION=2）：
+//   主題庫題目可由 id 從靜態題庫（getQuestionById）重建，因此**只存 id 字串**，
+//   不再把每題的 stem／options／explanation／sources 全寫進 localStorage（payload
+//   大幅縮小）。練習池題目為動態載入、不在靜態題庫中，getQuestionById 找不到 →
+//   **原樣保留整個物件**（如此 resume 不需 async 載入練習池即可同步重建）。
+//
+//   重要不變量：
+//   - 計分不受重建影響 —— finishQuiz 由自足的 answers[]（correctAnswer/isCorrect）
+//     計分，不看重建後的題目物件；重建只影響 resume 時**顯示**的題目內容。
+//   - 若某題內容在 save 與 resume 之間因更正而變動（例：答案修正／換選項），resume
+//     會顯示**現行題庫**的最新內容（auto-heal，非 bug）；若該 id 已從題庫移除，
+//     整份 resume 放棄（回 null），避免題數錯位／currentIndex 越界。
+//   - 向後相容：v1（全物件）payload 仍可載入 —— 重建把物件原樣返回。
 
 import type { QuizState } from '../hooks/useQuiz';
+import type { QuizQuestion } from '../types/quiz';
+import { getQuestionById } from '../data/questions';
 
 const STORAGE_KEY = 'ipas-quiz-in-progress';
-const SCHEMA_VERSION = 1;
+const SCHEMA_VERSION = 2;
+// v1（全物件）與 v2（主題庫題最小化為 id）都要能載入，避免打壞既有已上線的 resume。
+const SUPPORTED_VERSIONS = new Set<number>([1, 2]);
 
-interface PersistedProgress {
-  version: typeof SCHEMA_VERSION;
+/** 序列化時每題的儲存形態：字串 id（主題庫、可重建）或完整物件（練習池／舊格式）。 */
+type StoredQuestion = string | QuizQuestion;
+
+/** localStorage 內實際存放的 payload（questions 已最小化）。 */
+interface PersistedProgressRaw {
+  version: number;
   savedAt: number; // epoch ms
+  state: Omit<QuizState, 'questions'> & { questions: StoredQuestion[] };
+}
+
+/** loadProgress 對外回傳的 payload：questions 已重建為完整 QuizQuestion[]（對呼叫端透明）。 */
+export interface PersistedProgress {
+  version: number;
+  savedAt: number;
   state: QuizState;
+}
+
+/**
+ * 把單一題目最小化為儲存形態。
+ * 主題庫題目（getQuestionById 找得到、且 stem 相符）→ 只存 id 字串；
+ * 其餘（練習池、id 撞號或找不到）→ 原樣保留完整物件。
+ * stem 相符檢查是保險：避免練習池 id 意外撞到主題庫 id 而重建成錯題。
+ */
+function minifyQuestion(q: QuizQuestion): StoredQuestion {
+  const canonical = getQuestionById(q.id);
+  return canonical && canonical.stem === q.stem ? q.id : q;
+}
+
+/**
+ * 重建整份 state.questions；任一字串 id 在現行題庫找不到 → 回 null（整份放棄 resume）。
+ * 物件形態（練習池／v1 全物件）原樣返回。
+ */
+function reconstructState(
+  rawState: PersistedProgressRaw['state']
+): QuizState | null {
+  const questions: QuizQuestion[] = [];
+  for (const stored of rawState.questions) {
+    if (typeof stored === 'string') {
+      const q = getQuestionById(stored);
+      if (!q) return null; // id 指向的題目已從題庫移除 → 放棄，不 resume 破碎題組
+      questions.push(q);
+    } else if (stored && typeof stored === 'object') {
+      questions.push(stored);
+    } else {
+      // null／數字／其他垃圾元素 → payload 已損壞，放棄整份，
+      // 避免 resumeQuiz 對 undefined 題目取 .hasAnswer 而在「繼續測驗」時 crash。
+      return null;
+    }
+  }
+  return { ...rawState, questions } as QuizState;
 }
 
 /** Save in-progress quiz state. No-op if state.isActive is false. */
 export function saveProgress(state: QuizState): void {
   if (!state.isActive) return;
-  const payload: PersistedProgress = {
+  const payload: PersistedProgressRaw = {
     version: SCHEMA_VERSION,
     savedAt: Date.now(),
-    state,
+    state: { ...state, questions: state.questions.map(minifyQuestion) },
   };
   try {
     localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
@@ -34,18 +98,24 @@ export function saveProgress(state: QuizState): void {
   }
 }
 
-/** Load saved progress. Returns null if absent / wrong shape / wrong version. */
+/** Load saved progress. Returns null if absent / wrong shape / wrong version / 題目已失聯. */
 export function loadProgress(): PersistedProgress | null {
   try {
     const raw = localStorage.getItem(STORAGE_KEY);
     if (!raw) return null;
     const parsed = JSON.parse(raw) as unknown;
-    if (!isValidPayload(parsed)) {
+    if (!isValidEnvelope(parsed)) {
       // shape 不符 → 直接清掉避免下次再吃壞資料
       localStorage.removeItem(STORAGE_KEY);
       return null;
     }
-    return parsed;
+    const state = reconstructState(parsed.state);
+    // 重建失敗（題目失聯）或重建後語意檢查不過 → 一併清掉
+    if (!state || !isValidState(state)) {
+      localStorage.removeItem(STORAGE_KEY);
+      return null;
+    }
+    return { version: parsed.version, savedAt: parsed.savedAt, state };
   } catch {
     // JSON.parse 失敗（壞掉的 JSON）也清掉，避免下次載入重複吃同一筆壞資料
     // 巢狀 try：removeItem 在 quota / private mode 下亦可能 throw
@@ -67,15 +137,28 @@ export function clearProgress(): void {
   }
 }
 
-function isValidPayload(v: unknown): v is PersistedProgress {
+/**
+ * Envelope 檢查：確認外層 version / savedAt / state / questions 陣列 shape 正確，
+ * 足以安全嘗試重建。語意檢查（currentIndex 範圍、active 必要欄位）留給 isValidState
+ * 在**重建後**的完整 state 上做。
+ */
+function isValidEnvelope(v: unknown): v is PersistedProgressRaw {
   if (!v || typeof v !== 'object') return false;
-  const p = v as Partial<PersistedProgress>;
-  if (p.version !== SCHEMA_VERSION) return false;
+  const p = v as Partial<PersistedProgressRaw>;
+  if (typeof p.version !== 'number' || !SUPPORTED_VERSIONS.has(p.version)) {
+    return false;
+  }
   if (typeof p.savedAt !== 'number') return false;
-  const s = p.state;
+  const s = p.state as unknown;
   if (!s || typeof s !== 'object') return false;
+  if (!Array.isArray((s as { questions?: unknown }).questions)) return false;
+  return true;
+}
 
-  const st = s as QuizState;
+/**
+ * 語意檢查：對**重建後**的完整 QuizState 驗證欄位與範圍，確保 resume 不會卡死或算錯。
+ */
+function isValidState(st: QuizState): boolean {
   // 基本 shape
   if (typeof st.isActive !== 'boolean') return false;
   if (!Array.isArray(st.questions)) return false;

--- a/quiz-app/src/utils/quiz-progress-storage.ts
+++ b/quiz-app/src/utils/quiz-progress-storage.ts
@@ -70,7 +70,10 @@ function reconstructState(
   for (const stored of rawState.questions) {
     if (typeof stored === 'string') {
       const q = getQuestionById(stored);
-      if (!q) return null; // id 指向的題目已從題庫移除 → 放棄，不 resume 破碎題組
+      // id 指向的題目已從題庫移除 → 放棄整份 resume（保守：不 resume 破碎題組）。
+      // 註：這與 resumeQuiz 對「答案被 null 掉」的部分還原刻意不對稱 —— 題目「刪除」
+      // 極罕見（通常是就地更正而非刪除），故選簡單保守的整份放棄，不複製 re-anchor 邏輯。
+      if (!q) return null;
       questions.push(q);
     } else if (stored && typeof stored === 'object') {
       questions.push(stored);
@@ -164,6 +167,12 @@ function isValidState(st: QuizState): boolean {
   if (!Array.isArray(st.questions)) return false;
   if (typeof st.currentIndex !== 'number') return false;
   if (!Array.isArray(st.answers)) return false;
+  // answers 每筆須為非 null 物件 —— 否則 finishQuiz 的 a.correctAnswer、submitAnswer
+  // 的 a.questionId 會對 null 取值而在續作／完成時 crash（防損壞或竄改的 localStorage；
+  // 與最小化無關，但重建路徑既已加深驗證，一併把對稱的 answers 破綻補上）。
+  if (!(st.answers as unknown[]).every((a) => a !== null && typeof a === 'object')) {
+    return false;
+  }
 
   // currentIndex 必須在 questions 範圍內（避免 resume 後 currentQuestion=null
   // 觸發 QuizPage 的「載入中...」永遠 stuck）


### PR DESCRIPTION
## 動機（#106）

`useQuiz` 的進度持久化（Refs #71）每次 state 變動就把**完整** `questions`（每題 stem／options／explanation／sources）整個 `JSON.stringify` 寫入 localStorage。PR #105 把考試模式 `submitAnswer` 移到選項點擊後，一般會多一次完整序列化。issue #106 追蹤此 P3 最小化。

## 做法：hybrid 最小化（同步、低風險）

- **主題庫題目**（`getQuestionById` 找得到、且 stem 相符）→ 只存 **id 字串**，載入時由靜態題庫重建。
- **練習池題目**（不在靜態題庫、動態載入）→ **原樣保留完整物件**。
  - 這是關鍵取捨：如此 `resumeQuiz` 不需 `await` 載入練習池即可**同步**重建，直接避開 issue 列出的「練習池需先載入」風險，`resumeQuiz` 一行未改。

## 三項不變量（deep review 釘住）

1. **計分不受重建影響** —— `finishQuiz` 由自足的 `answers[]`（`correctAnswer`／`isCorrect`）計分，不看重建後的題目物件。重建只影響 resume 時**顯示**的題目內容。
2. **內容更正 auto-heal** —— 若某題在 save 與 resume 之間因更正而變動（如答案修正／換選項），resume 顯示**現行題庫**最新內容；若該 id 已從題庫移除 → 整份放棄 resume（回 `null`），避免題數錯位／`currentIndex` 越界。
3. **向後相容 v1** —— 既有已上線的全物件 payload 仍可載入（`SUPPORTED_VERSIONS = {1, 2}`），重建把物件原樣返回。deploy 當下正在作答者的 resume 不被打壞。

## 效益（實測）

50 題主題庫測驗 payload：**42.0 KB → 4.2 KB（約 −90%）**。因 `getQuestionById` 掃描遠比序列化 42 KB 便宜，寫入成本亦下降（issue 的真正關切）。

## 額外強固（review 時發現）

`isValidPayload` 拆為 `isValidEnvelope`（外層 shape）＋ `isValidState`（重建後語意檢查）。重建遇 `null`／垃圾元素時整份放棄 —— 舊碼有此潛在漏洞（v1 已存在），但重建是新程式碼，寫成拒絕垃圾才正確，避免 `resumeQuiz` 對 `undefined` 題目取 `.hasAnswer` 而在「繼續測驗」時白屏 crash。

## 測試

- 新增：主題庫 id round-trip、練習池保留物件、混合題組、失聯 id 放棄、非法元素放棄、v1 相容（storage 15 → 21 題）。
- `useQuiz.test.ts` 既有 resume 整合測試即為本改動的真實 E2E：`startQuiz` 抽真實題→`saveProgress` 最小化為 id→unmount→`resumeQuiz` 由 id 重建，斷言 `currentIndex`／題數還原。
- 更新既有 version 斷言（1→2）與 HomePage resume-hint fixture（`null` 佔位改為非 null 物件，配合更嚴的載入契約）。
- 全庫 779 unit 綠、lint／tsc／build 綠。

Closes #106

## 深度對抗式自審後續（commits 2–3）

兩輪對抗式複審（我自己 + 一個獨立紅隊 agent，各自獨立看 diff）皆判**無 blocker/major**，最小化設計在承重面（計分、相容、無 mutation/欄位遺失）站得住。就發現的 minor 收尾：

- **釘住 id 命名空間不交疊**：最小化靠「練習池 id 永遠不在主題庫」保證不換錯題。實測 0 交疊（池 154 題全 `pool-` 前綴、主庫 781 題無一以 `pool-` 起頭），但既有 cross-bank gate 只驗**內容**指紋、不驗 **id** → 補回歸測試，日後資料漂移會變紅。
- **補重建後語意檢查測試**：釘住 `isValidState` 確實跑在**重建後**的 state（id 可重建但 currentIndex 越界須被擋）。
- **擋下 answers 非法元素**：損壞/竄改的 localStorage 若含 `answers:[null]`，續作時 `submitAnswer`/`finishQuiz` 會對 null 取值 crash（既有破綻、非最小化引入；重建路徑既已加深驗證，一併補上對稱檢查）。
- **刻意不做**：單一題目失聯時整份放棄 resume（而非部分還原）—— 題目「刪除」極罕見且無 crash 風險，部分還原需複製 re-anchor 邏輯，屬過度工程；已於程式碼註記此取捨。

驗證：全庫 **782 unit 綠**、lint/tsc/build 綠、E2E 綠、**codecov/patch 100%**（本機以一致基準複算 45/45 新增行全覆蓋）。

## Split-brain 對抗驗證（核心風險：resume 改用現行題目 vs 凍結的舊紀錄）

複審點名 #106 的真正風險邊界：它把 resume 從「用保存當下的題目」改成「用部署後的現行題目」。逐一追程式碼後的精確結論：

**「計分不受影響」的精確版本：**
- 答對／答錯「數」純由 `answers[]` 紀錄（submit 當下凍結的 correctAnswer/isCorrect）計算 —— v1/v2 逐位元相同，reconstruction 不碰它。這部分為真。
- 但 `totalAnswerable`/`skippedCount` 由重建後的 `questions` 算；且**畫面回饋**（QuizPage → QuestionCard 依現行 `question.answer` 標對錯）也吃重建後的題目。

**確有 split-brain，且是 v2 新引入：** 若某題標準答案在保存與續作之間被更正（如 gist[340] B→C），resume 後該題會「畫面標 C 為正解、你選的 B 標紅」，但凍結的舊紀錄仍記 B 為對 → 顯示與計分分裂。v1 因保存整份舊題目而天然一致，此分裂由 v2 引入。（ResultPage 不在此列：它一向 stem 取現行題庫、答案取紀錄，屬既有行為、非 #106 引入。）

**修法（commit 9763f96，本 PR 已含）：** `resumeQuiz` 除既有「無答案題過濾」外，再對帳答案紀錄 —— 凡 `correctAnswer !== 現行 question.answer` 者丟棄，該題回未作答、由使用者依現行內容重答（重答走 submitAnswer 依現行答案計分）。使 v2 續作結果**嚴格優於 v1**（現行內容且一致、無 split-brain）。對帳只比得到「標準答案字母」；選項文字在答案字母不變下的改寫屬相容（顯示自動更新為現行、非計分分裂），無法也無需從紀錄偵測（未存舊選項）。

新增測試：resume 對帳「丟棄過期紀錄」「未變則保留」兩案。兩支 production 檔 patch coverage 100%（quiz-progress-storage 45/45、useQuiz 11/11）。

## 外部 review 回應（commit f3163a4）

一份第三方深度 review（分析的是本 PR **第一個 commit 5d30dad，即 M1 對帳之前**）提出數項。逐項對現行程式碼查證後：

**採納（確為真、非過度工程）：**
- **G2 資料遺失（原評為 P1）**：v2 沿用同一 localStorage key，已部署的舊 v1 bundle 遇 version=2 判為壞資料並 `removeItem`（已查證 main 的 loader：`version!==1` → removeItem 同一 key）→ 部署期舊分頁一導覽回首頁就會刪掉新分頁剛寫的 v2 進度。改：v2 寫入獨立 key（…-v2），讀取先 v2 再回退 legacy v1，clear 清兩者。
- **G3 poisoned crash-loop（原評為 P2）**：`reconstructState` 對缺 stem/options 的物件也放行 → QuestionCard 讀 `.options` crash 進 ErrorBoundary，且壞資料不清 → 每次重試再 crash。加最小 shape 檢查（id/stem/options）。
- **G4**：`currentIndex` 由 `typeof===number` 收緊為 `Number.isInteger`（拒 2.5/NaN/Infinity）。
- **G5 效能**：`getQuestionById` 由 O(n) find 改 module-level Map（ids 唯一 781/781）。
- **G6**：新增 payload size gate 測試（50 題未作答 <6KB）。

**未採納（過度工程 / 已解決）：**
- **Blocker 1（split-brain 錯誤計分）核心已由 commit 9763f96 的 resumeQuiz 對帳解決** —— review「選 A 顯示錯卻得 100 分」的重現是針對 M1 之前的 commit；現行該筆紀錄會被丟棄、該題回未作答重答。殘留（選項文字在答案字母不變下改寫）刻意**不用 content fingerprint**：fingerprint 會連善意錯字修正也強制整份重來，對「經常就地更正」的題庫反而更糟 —— answer-key 粒度才對。
- **完整 12 點語意驗證器**：對「只可能來自竄改」的資料屬過度工程，只補會 crash 的最小檢查。

三支 production 檔 patch coverage 皆 **100%**（storage 72/72、useQuiz 11/11、questions 2/2）。全庫 **792 unit 綠**。
