### PR TITLE
色覺模式：Settings 即時預覽色塊 + 修下拉選單箭頭/文字位置

### DIFF
--- a/.github/workflows/quiz-app-ci.yml
+++ b/.github/workflows/quiz-app-ci.yml
@@ -397,8 +397,9 @@ jobs:
           name: dist
           path: quiz-app/dist/
 
+      # chromium 跑全套；firefox + webkit 只跑 Settings 跨瀏覽器 smoke（PR #108）
       - name: Install Playwright browsers
-        run: pnpm exec playwright install --with-deps chromium
+        run: pnpm exec playwright install --with-deps chromium firefox webkit
 
       - name: Run E2E tests
         run: pnpm test:e2e

--- a/quiz-app/playwright.config.ts
+++ b/quiz-app/playwright.config.ts
@@ -22,16 +22,20 @@ export default defineConfig({
       name: 'chromium',
       use: { ...devices['Desktop Chrome'] },
     },
-    // 如需測試更多瀏覽器可取消註解
-    // {
-    //   name: 'firefox',
-    //   use: { ...devices['Desktop Firefox'] },
-    // },
-    // {
-    //   name: 'webkit',
-    //   use: { ...devices['Desktop Safari'] },
-    // },
-    // 行動裝置測試
+    // Firefox / WebKit 只跑 Settings smoke（PR #108：驗自訂 <select> + 色覺模式的跨瀏覽器
+    // 行為），透過 testMatch 限制 —— 不把整套 E2E 乘三，只有 settings-smoke.spec.ts 會在
+    // 這兩個 project 執行。
+    {
+      name: 'firefox-smoke',
+      use: { ...devices['Desktop Firefox'] },
+      testMatch: /settings-smoke\.spec\.ts/,
+    },
+    {
+      name: 'webkit-smoke',
+      use: { ...devices['Desktop Safari'] },
+      testMatch: /settings-smoke\.spec\.ts/,
+    },
+    // 行動裝置測試（如需可取消註解）
     // {
     //   name: 'Mobile Chrome',
     //   use: { ...devices['Pixel 5'] },

--- a/quiz-app/src/pages/SettingsPage.css
+++ b/quiz-app/src/pages/SettingsPage.css
@@ -132,14 +132,83 @@
   outline-offset: 2px;
 }
 
-/* Select */
+/* Select — 用自訂 chevron 取代原生箭頭：原生箭頭會與文字擠在一起、位置不正（跨瀏覽器不一致）。 */
 .setting-item select {
-  padding: var(--spacing-sm) var(--spacing-md);
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  /* 右側多留 40px 給箭頭，文字不會壓到箭頭 */
+  padding: var(--spacing-sm) 40px var(--spacing-sm) var(--spacing-md);
   border: 1px solid var(--color-border);
   border-radius: var(--radius-sm);
-  background: var(--color-surface);
+  /* 用 background-color（非 background 簡寫）避免蓋掉下面的箭頭 background-image */
+  background-color: var(--color-surface);
+  background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%2379767a' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 14px center;
+  background-size: 16px 16px;
+  color: var(--color-text-primary);
   font-size: var(--font-size-sm);
   min-width: 150px;
+  cursor: pointer;
+}
+
+/* 色覺模式：控制列 + 即時預覽垂直堆疊 */
+.setting-item--stack {
+  flex-direction: column;
+  align-items: stretch;
+  gap: var(--spacing-md);
+}
+
+.setting-item__row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-md);
+  flex-wrap: wrap;
+}
+
+/* 作答回饋色即時預覽：chip 直接吃 --color-success / --color-error，
+   而 [data-cvd-mode] 覆寫的正是這兩個變數，故切換色覺模式時 chip 會即時換色。 */
+.cvd-preview {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  flex-wrap: wrap;
+}
+
+.cvd-preview__label {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
+}
+
+.cvd-preview__chip {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+  padding: var(--spacing-xs) var(--spacing-sm);
+  border: 2px solid;
+  border-radius: var(--radius-sm);
+  font-size: var(--font-size-sm);
+  font-weight: 500;
+  transition: color var(--transition-fast), border-color var(--transition-fast),
+    background-color var(--transition-fast);
+}
+
+.cvd-preview__chip .material-icons {
+  font-size: 18px;
+}
+
+.cvd-preview__chip--correct {
+  background: var(--color-success-bg);
+  border-color: var(--color-success);
+  color: var(--color-success);
+}
+
+.cvd-preview__chip--incorrect {
+  background: var(--color-error-bg);
+  border-color: var(--color-error);
+  color: var(--color-error);
 }
 
 /* 關於區塊 */

--- a/quiz-app/src/pages/SettingsPage.css
+++ b/quiz-app/src/pages/SettingsPage.css
@@ -186,13 +186,17 @@
   display: inline-flex;
   align-items: center;
   gap: var(--spacing-xs);
-  padding: var(--spacing-xs) var(--spacing-sm);
-  border: 2px solid;
+  /* 左側留白容納實色條 */
+  padding: var(--spacing-xs) var(--spacing-sm) var(--spacing-xs) 10px;
+  border: 1px solid var(--color-border);
   border-radius: var(--radius-sm);
   font-size: var(--font-size-sm);
   font-weight: 500;
-  transition: color var(--transition-fast), border-color var(--transition-fast),
-    background-color var(--transition-fast);
+  /* 文字與 icon 用可讀前景（達 WCAG AA）。語意色改由「背景 tint + 左側實色條」表現，
+     切換 CVD 模式時色條與底色即時換色。避免原本「同 hue 彩字疊 12% 同色底」的低對比
+     （實測 16 組中 14 組 < 4.5:1）；且 text-primary 會被高對比模式覆寫，一併修好高對比路徑。 */
+  color: var(--color-text-primary);
+  transition: background-color var(--transition-fast), box-shadow var(--transition-fast);
 }
 
 .cvd-preview__chip .material-icons {
@@ -201,14 +205,12 @@
 
 .cvd-preview__chip--correct {
   background: var(--color-success-bg);
-  border-color: var(--color-success);
-  color: var(--color-success);
+  box-shadow: inset 4px 0 0 var(--color-success);
 }
 
 .cvd-preview__chip--incorrect {
   background: var(--color-error-bg);
-  border-color: var(--color-error);
-  color: var(--color-error);
+  box-shadow: inset 4px 0 0 var(--color-error);
 }
 
 /* 關於區塊 */

--- a/quiz-app/src/pages/SettingsPage.test.tsx
+++ b/quiz-app/src/pages/SettingsPage.test.tsx
@@ -86,6 +86,26 @@ describe('SettingsPage', () => {
     expect(localStorage.getItem('practice-pool-enabled')).toBe('0');
   });
 
+  // 色覺辨認模式即時預覽 — 讓使用者切換當下就看到回饋色變化
+  describe('色覺辨認模式預覽', () => {
+    it('顯示正確/錯誤回饋色預覽 chip', () => {
+      renderSettings();
+      const preview = screen.getByTestId('cvd-preview');
+      expect(preview).toBeInTheDocument();
+      expect(preview).toHaveTextContent('正確');
+      expect(preview).toHaveTextContent('錯誤');
+    });
+
+    it('切換模式會套用 data-cvd-mode 到 documentElement（預覽色即時生效）', () => {
+      renderSettings();
+      const select = screen.getByLabelText('色覺辨認模式');
+      fireEvent.change(select, { target: { value: 'deuteranopia' } });
+      expect(document.documentElement.getAttribute('data-cvd-mode')).toBe(
+        'deuteranopia'
+      );
+    });
+  });
+
   // 清除作答統計（Refs #64）— state-driven dialog，取代 window.confirm
   describe('清除作答統計', () => {
     const STATS_KEY = 'ipas-question-stats';

--- a/quiz-app/src/pages/SettingsPage.test.tsx
+++ b/quiz-app/src/pages/SettingsPage.test.tsx
@@ -11,7 +11,6 @@ vi.mock('../hooks/usePracticePool', () => ({
 
 import { SettingsPage } from './SettingsPage';
 import { useAccessibility } from '../hooks/useAccessibility';
-import { renderHook } from '@testing-library/react';
 
 
 // 還原真實 localStorage 行為（test-setup.ts 把它 mock 成空函式）
@@ -38,9 +37,16 @@ afterEach(() => {
   localStorage.clear();
 });
 
+// 在「同一棵 React tree」內呼叫 useAccessibility 並傳給 SettingsPage —— 這樣 setCvdMode 等
+// 更新 hook state 時 SettingsPage 會真的 rerender（舊寫法用獨立 renderHook 傳 snapshot，
+// state 更新不會回流到 component，UI wiring 壞掉也測不出來）。
+function SettingsHarness({ onClose = () => {} }: { onClose?: () => void }) {
+  const accessibility = useAccessibility();
+  return <SettingsPage accessibility={accessibility} onClose={onClose} />;
+}
+
 function renderSettings(onClose = () => {}) {
-  const { result: accResult } = renderHook(() => useAccessibility());
-  return render(<SettingsPage accessibility={accResult.current} onClose={onClose} />);
+  return render(<SettingsHarness onClose={onClose} />);
 }
 
 describe('SettingsPage', () => {
@@ -96,10 +102,13 @@ describe('SettingsPage', () => {
       expect(preview).toHaveTextContent('錯誤');
     });
 
-    it('切換模式會套用 data-cvd-mode 到 documentElement（預覽色即時生效）', () => {
+    it('切換模式後 select 顯示新值並套用 data-cvd-mode（同棵 tree 真的 rerender）', () => {
       renderSettings();
-      const select = screen.getByLabelText('色覺辨認模式');
+      const select = screen.getByLabelText('色覺辨認模式') as HTMLSelectElement;
+      expect(select.value).toBe('none');
       fireEvent.change(select, { target: { value: 'deuteranopia' } });
+      // controlled component：value 跟著 hook state rerender → 證明 UI wiring 完整
+      expect(select.value).toBe('deuteranopia');
       expect(document.documentElement.getAttribute('data-cvd-mode')).toBe(
         'deuteranopia'
       );

--- a/quiz-app/src/pages/SettingsPage.tsx
+++ b/quiz-app/src/pages/SettingsPage.tsx
@@ -142,27 +142,44 @@ export function SettingsPage({ accessibility, onClose }: SettingsPageProps) {
           </label>
         </div>
 
-        <div className="setting-item">
-          <div className="setting-info">
-            <span className="material-icons">visibility</span>
-            <div>
-              <p className="setting-title">色覺辨認模式</p>
-              <p className="setting-desc">針對色覺辨認障礙調整配色</p>
+        <div className="setting-item setting-item--stack">
+          <div className="setting-item__row">
+            <div className="setting-info">
+              <span className="material-icons">visibility</span>
+              <div>
+                <p className="setting-title">色覺辨認模式</p>
+                <p className="setting-desc">針對色覺辨認障礙調整配色</p>
+              </div>
             </div>
+            <select
+              aria-label="色覺辨認模式"
+              value={settings.cvdMode}
+              onChange={(e) =>
+                setCvdMode(
+                  e.target.value as 'none' | 'protanopia' | 'deuteranopia' | 'tritanopia'
+                )
+              }
+            >
+              <option value="none">無</option>
+              <option value="protanopia">紅色盲 (Protanopia)</option>
+              <option value="deuteranopia">綠色盲 (Deuteranopia)</option>
+              <option value="tritanopia">藍色盲 (Tritanopia)</option>
+            </select>
           </div>
-          <select
-            value={settings.cvdMode}
-            onChange={(e) =>
-              setCvdMode(
-                e.target.value as 'none' | 'protanopia' | 'deuteranopia' | 'tritanopia'
-              )
-            }
-          >
-            <option value="none">無</option>
-            <option value="protanopia">紅色盲 (Protanopia)</option>
-            <option value="deuteranopia">綠色盲 (Deuteranopia)</option>
-            <option value="tritanopia">藍色盲 (Tritanopia)</option>
-          </select>
+          {/* 即時預覽：作答對/錯的回饋色會隨模式即時換色（chip 直接吃 --color-success/
+              --color-error，而 CVD 模式覆寫的正是這兩個變數）—— 讓使用者切換當下就看到效果。
+              附 icon + 文字，不靠顏色單一管道（符合無障礙本意）。 */}
+          <div className="cvd-preview" data-testid="cvd-preview">
+            <span className="cvd-preview__label">作答回饋色預覽</span>
+            <span className="cvd-preview__chip cvd-preview__chip--correct">
+              <span className="material-icons" aria-hidden="true">check_circle</span>
+              正確
+            </span>
+            <span className="cvd-preview__chip cvd-preview__chip--incorrect">
+              <span className="material-icons" aria-hidden="true">cancel</span>
+              錯誤
+            </span>
+          </div>
         </div>
       </section>
 

--- a/quiz-app/tests/e2e/quiz-flow.spec.ts
+++ b/quiz-app/tests/e2e/quiz-flow.spec.ts
@@ -170,6 +170,36 @@ test.describe('無障礙功能', () => {
     const radios = page.getByRole('radio');
     await expect(radios).toHaveCount(4);
   });
+
+  // 色覺辨認模式：切換後語意色 token 與預覽 chip 的實色條要真的換色（jsdom 算不出 CSS 變數，
+  // 只有真瀏覽器測得到）。守住「切了沒反應」這個原始痛點的回歸。
+  test('色覺辨認模式切換即時改變回饋語意色', async ({ page }) => {
+    await gotoHome(page);
+    await page.getByRole('button', { name: '開啟設定' }).click();
+    const cvdSelect = page.getByLabel('色覺辨認模式');
+    await expect(cvdSelect).toBeVisible();
+
+    const successVar = () =>
+      page.evaluate(() =>
+        getComputedStyle(document.documentElement)
+          .getPropertyValue('--color-success')
+          .trim()
+          .toLowerCase()
+      );
+    const correctBar = () =>
+      page
+        .locator('.cvd-preview__chip--correct')
+        .evaluate((el) => getComputedStyle(el).boxShadow);
+
+    // none：綠 #4caf50 / rgb(76, 175, 80)
+    await expect.poll(successVar).toBe('#4caf50');
+    await expect.poll(correctBar).toContain('76, 175, 80');
+
+    // 切綠色盲 → 藍 #0288d1 / rgb(2, 136, 209)（poll 容忍 style recalc 的一拍延遲）
+    await cvdSelect.selectOption('deuteranopia');
+    await expect.poll(successVar).toBe('#0288d1');
+    await expect.poll(correctBar).toContain('2, 136, 209');
+  });
 });
 
 test.describe('響應式設計', () => {

--- a/quiz-app/tests/e2e/settings-smoke.spec.ts
+++ b/quiz-app/tests/e2e/settings-smoke.spec.ts
@@ -23,6 +23,13 @@ test.describe('Settings 跨瀏覽器 smoke', () => {
     const select = page.getByLabel('色覺辨認模式');
     await expect(select).toBeVisible();
 
+    // select 高度要合理 —— WebKit 對 appearance:none 的 <select> 高度/文字垂直位置歷來較
+    // 敏感（正是本 PR 改自訂樣式要顧的點）。抓 bounding box 擋「塌成 0 / 撐爆」的跨瀏覽器破圖。
+    const box = await select.boundingBox();
+    expect(box).not.toBeNull();
+    expect(box!.height).toBeGreaterThan(28);
+    expect(box!.height).toBeLessThan(60);
+
     // 自訂 chevron（data-URI SVG）取代原生箭頭 —— Firefox/WebKit 也要能渲染出來。
     // 用 background-image 有無 svg 判定（比 computed `appearance` 跨瀏覽器可靠）。
     const bgImage = await select.evaluate(

--- a/quiz-app/tests/e2e/settings-smoke.spec.ts
+++ b/quiz-app/tests/e2e/settings-smoke.spec.ts
@@ -1,0 +1,53 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Settings 頁的跨瀏覽器 smoke（chromium + firefox + webkit）。
+ *
+ * 動機：PR #108 把 `<select>` 改為 appearance:none + data-URI SVG chevron，理由正是
+ * 「原生箭頭跨瀏覽器位置不一致」；但全套 E2E 只跑 Chromium。這支 smoke 專門在 Firefox
+ * 與 WebKit 上驗自訂 select 與色覺模式的核心行為（不把整套 E2E 乘三）。
+ * Firefox/WebKit 只跑本檔（playwright.config 的 testMatch）。
+ */
+async function gotoSettings(page: import('@playwright/test').Page): Promise<void> {
+  await page.addInitScript(() => {
+    window.localStorage.setItem('practice-pool-disclosure-seen', '1');
+  });
+  await page.goto('/');
+  await page.getByRole('button', { name: '開啟設定' }).click();
+}
+
+test.describe('Settings 跨瀏覽器 smoke', () => {
+  test('色覺模式 select 自訂樣式 + 換色 + 預覽文字可讀', async ({ page }) => {
+    await gotoSettings(page);
+
+    const select = page.getByLabel('色覺辨認模式');
+    await expect(select).toBeVisible();
+
+    // 自訂 chevron（data-URI SVG）取代原生箭頭 —— Firefox/WebKit 也要能渲染出來。
+    // 用 background-image 有無 svg 判定（比 computed `appearance` 跨瀏覽器可靠）。
+    const bgImage = await select.evaluate(
+      (el) => getComputedStyle(el).backgroundImage
+    );
+    expect(bgImage).toContain('svg');
+
+    // 預覽 chip 文字用可讀前景（text-primary），不是語意綠 rgb(76,175,80) —— 對比修正
+    // 跨瀏覽器都要成立。
+    const chip = page.locator('.cvd-preview__chip--correct');
+    await expect(chip).toBeVisible();
+    const chipColor = await chip.evaluate((el) => getComputedStyle(el).color);
+    expect(chipColor).not.toContain('76, 175, 80');
+
+    // 功能：切「綠色盲」→ 語意色 token 換色（poll 容忍 style recalc 一拍延遲）。
+    await select.selectOption('deuteranopia');
+    await expect
+      .poll(() =>
+        page.evaluate(() =>
+          getComputedStyle(document.documentElement)
+            .getPropertyValue('--color-success')
+            .trim()
+            .toLowerCase()
+        )
+      )
+      .toBe('#0288d1');
+  });
+});


### PR DESCRIPTION
## 背景

「色覺辨認模式」功能其實**早已完整實作**（型別／useAccessibility／SettingsPage 選單／`[data-cvd-mode]` CSS 換 `--color-success`/`--color-error`，且對錯回饋 UI 確實吃這兩個變數）。但**感覺沒實作**，因為：切換模式後，唯一會變色的地方（練習模式對錯回饋、結果頁）在 Settings 頁上看不到 → 切下去畫面沒反應。

## 本 PR

1. **即時預覽色塊**：在 CVD 選單下方加「作答回饋色預覽」的 `正確`/`錯誤` chip。chip 直接吃 `--color-success`/`--color-error`，而 CVD 模式覆寫的正是這兩個變數 → **切換當下就即時換色**，直接消除「好像沒實作」的錯覺。chip 附 icon + 文字，不靠顏色單一管道（符合無障礙本意）。
2. **修下拉選單位置**（使用者回報）：原生 `<select>`（`appearance:auto`）的箭頭由瀏覽器畫、與文字擠在一起、跨瀏覽器位置不一致。改 `appearance:none` + 自訂 chevron（右側固定 14px）+ 右側 40px 留白，文字左對齊、箭頭定位正確；補 `color: var(--color-text-primary)` 讓深色模式文字正確。

## 驗證（Playwright 實跑打包後 dist）

- 切「綠色盲」→ `data-cvd-mode=deuteranopia` → `--color-success` 由 `#4caf50`(綠) 變 `#0288d1`(藍)，預覽 chip computed color 實測 `rgb(2,136,209)`。四種模式的 success/error hex 全部如設計。
- 下拉選單修正後：`appearance:none`、`padding-right:40px`、自訂 chevron 存在；淺色/深色模式截圖皆正常（文字左對齊、箭頭右側定位、深色文字白色可讀）。
- 全庫 796 unit 綠、lint/tsc/build 綠。SettingsPage 補「預覽 chip 顯示」「切換套用 data-cvd-mode」兩案。

## 外部 review 回應（commit 96b4997）

逐項用 WCAG 公式**實算查證**後：

**採納（確為真）：**
- **P1 對比 blocker**：原 chip 用語意色當 14px 文字疊 12% 同色底 —— 我獨立重算對比矩陣，**逐格與 reviewer 相符**（none 淺 2.48、tritanopia 暗 2.76…），16 組中 14 組 < 4.5:1，確為我這 PR 引入的 WCAG failure。改：文字/icon 用 `--color-text-primary`（可讀），語意色改由 background tint + 左側 4px 實色條表現，切模式時色條/底色即時換色。**修正後 16 組全部 10.9–14.6:1**。文字改用 text-primary 也一併修好「高對比模式沒覆寫 success/error」的路徑。（Playwright 實測：deuteranopia 下 chip 文字 `rgba(0,0,0,0.87)`、色條 `rgb(2,136,209)`。）
- **P2 測試效力**：`renderSettings` 改成在**同一棵 tree** 呼叫 `useAccessibility` 的 wrapper（舊寫法用獨立 `renderHook` 傳 snapshot、state 更新不回流 → wiring 壞也測不出）；新測斷言切換後 `select.value` 真的更新。
- **P2 缺真實變色測試**：補一支 Playwright computed-style e2e —— 切綠色盲後 `--color-success` 由 `#4caf50` 變 `#0288d1`、預覽 chip 實色條同步換色（`expect.poll` 容忍 recalc 一拍延遲）。

**未採納（判定過度工程 / 屬另案）：**
- **全瀏覽器 E2E matrix（Firefox/WebKit）**：`appearance:none` + data-URI SVG chevron 是**跨瀏覽器標準做法**、風險低；擴 CI browser matrix 屬 infra 決策。**誠實修正宣稱**：本 PR 的自動化只覆蓋 Chromium，跨瀏覽器一致性靠標準技術而非 CI 三倍化。
- **forced-colors media query**：chip 有文字 label（正確/錯誤）作 fallback，forced-colors 下仍可辨別，不阻擋。
- **semantic token 拆 fg/bg/border/on-color**：既有 QuestionCard/ResultPage 技術債，另開 **#109** 追蹤；本 PR 用局部修法避開，刻意不動全域 `--color-success`/`--color-error`（避免大範圍回歸）。

驗證：SettingsPage 11 unit、**e2e 11（含新 CVD computed-style）** 綠；全庫 796、lint/tsc/build 綠。

## 追加：跨瀏覽器 smoke（commit 77ed802）

原 review 的 P2「跨瀏覽器只跑 Chromium」我一開始判為另案，經你指示補上：
- 新增 `settings-smoke.spec.ts`：驗自訂 `<select>` 的 SVG chevron 有渲染、預覽 chip 文字為可讀前景、切綠色盲後 `--color-success` 換色。
- `playwright.config`：新增 `firefox-smoke` / `webkit-smoke` project，`testMatch` 限制**只跑這支 smoke**（quiz-flow 重案仍只跑 chromium，不把 E2E 乘三）。
- CI：`playwright install` 加裝 firefox + webkit。
- **本機實測（已裝 firefox/webkit）：smoke 在 chromium + firefox + webkit 三瀏覽器皆綠。** 至此「跨瀏覽器一致性」有 CI 保護，PR 描述不再只靠標準技術背書。
