### PR TITLE
a11y #109：success/error 語意色拆成 role-based token（fg/solid/on-color/score），修對比

### DIFF
--- a/quiz-app/src/components/BankSimilarQuestionItem/BankSimilarQuestionItem.css
+++ b/quiz-app/src/components/BankSimilarQuestionItem/BankSimilarQuestionItem.css
@@ -40,12 +40,12 @@
 }
 
 .bank-similar-result.ok {
-  color: var(--color-success);
+  color: var(--color-success-fg);
   font-weight: 500;
 }
 
 .bank-similar-result.bad {
-  color: var(--color-error);
+  color: var(--color-error-fg);
   font-weight: 500;
 }
 

--- a/quiz-app/src/components/ErrorBoundary/ErrorBoundary.css
+++ b/quiz-app/src/components/ErrorBoundary/ErrorBoundary.css
@@ -4,7 +4,7 @@
   margin: var(--spacing-xl) auto;
   padding: var(--spacing-lg);
   background: var(--color-error-bg);
-  border-left: 4px solid var(--color-error);
+  border-left: 4px solid var(--color-error-fg);
 }
 
 .error-boundary__header {
@@ -16,7 +16,7 @@
 
 .error-boundary__icon {
   font-size: 32px;
-  color: var(--color-error);
+  color: var(--color-error-fg);
 }
 
 .error-boundary__title {

--- a/quiz-app/src/components/QuestionCard/QuestionCard.css
+++ b/quiz-app/src/components/QuestionCard/QuestionCard.css
@@ -141,9 +141,12 @@
   cursor: default;
 }
 
-.option-item.correct .option-key {
+/* 也涵蓋「使用者選中的那個 key」—— :checked + .option-key 特異性(0,4,1) 比 .correct .option-key
+   (0,3,0) 高，不明確覆寫的話，選中的正解 key 會停在 primary 而非 success solid。 */
+.option-item.correct .option-key,
+.option-item.correct input[type='radio']:checked + .option-key {
   background: var(--color-success-solid);
-  color: white;
+  color: var(--color-on-success);
 }
 
 .option-item.correct .option-icon {
@@ -157,9 +160,10 @@
   cursor: default;
 }
 
-.option-item.incorrect .option-key {
+.option-item.incorrect .option-key,
+.option-item.incorrect input[type='radio']:checked + .option-key {
   background: var(--color-error-solid);
-  color: white;
+  color: var(--color-on-error);
 }
 
 .option-item.incorrect .option-icon {

--- a/quiz-app/src/components/QuestionCard/QuestionCard.css
+++ b/quiz-app/src/components/QuestionCard/QuestionCard.css
@@ -318,6 +318,9 @@
 
 .ai-response.error .ai-response-header {
   background: var(--color-error-solid);
+  /* 標頭前景在深色主題是近黑（--color-on-primary=#1c1b1f），會跟深紅 solid 撞成低對比；
+     實填底一律用純白 on-color */
+  color: var(--color-on-error);
 }
 
 /* 響應式 */

--- a/quiz-app/src/components/QuestionCard/QuestionCard.css
+++ b/quiz-app/src/components/QuestionCard/QuestionCard.css
@@ -137,33 +137,33 @@
 /* 正確答案 */
 .option-item.correct {
   background: var(--color-success-bg);
-  border-color: var(--color-success);
+  border-color: var(--color-success-fg);
   cursor: default;
 }
 
 .option-item.correct .option-key {
-  background: var(--color-success);
+  background: var(--color-success-solid);
   color: white;
 }
 
 .option-item.correct .option-icon {
-  color: var(--color-success);
+  color: var(--color-success-fg);
 }
 
 /* 錯誤答案 */
 .option-item.incorrect {
   background: var(--color-error-bg);
-  border-color: var(--color-error);
+  border-color: var(--color-error-fg);
   cursor: default;
 }
 
 .option-item.incorrect .option-key {
-  background: var(--color-error);
+  background: var(--color-error-solid);
   color: white;
 }
 
 .option-item.incorrect .option-icon {
-  color: var(--color-error);
+  color: var(--color-error-fg);
 }
 
 /* 禁用狀態 */
@@ -313,11 +313,11 @@
   align-items: center;
   gap: var(--spacing-sm);
   padding: var(--spacing-md);
-  color: var(--color-error);
+  color: var(--color-error-fg);
 }
 
 .ai-response.error .ai-response-header {
-  background: var(--color-error);
+  background: var(--color-error-solid);
 }
 
 /* 響應式 */

--- a/quiz-app/src/components/SourceBanner/SourceBanner.css
+++ b/quiz-app/src/components/SourceBanner/SourceBanner.css
@@ -22,7 +22,7 @@
 }
 
 .source-banner--flagged {
-  border-left-color: var(--color-error);
+  border-left-color: var(--color-error-fg);
   background: var(--color-error-bg);
 }
 
@@ -34,7 +34,7 @@
 
 .source-banner--mock .source-banner__icon { color: var(--color-info); }
 .source-banner--ai .source-banner__icon { color: var(--color-warning); }
-.source-banner--flagged .source-banner__icon { color: var(--color-error); }
+.source-banner--flagged .source-banner__icon { color: var(--color-error-fg); }
 
 .source-banner__body {
   flex: 1;
@@ -72,7 +72,7 @@
   display: flex;
   gap: var(--spacing-xs);
   font-size: var(--font-size-xs);
-  color: var(--color-error);
+  color: var(--color-error-fg);
   align-items: flex-start;
   line-height: 1.55;
 }

--- a/quiz-app/src/components/SourceBreakdown/SourceBreakdown.css
+++ b/quiz-app/src/components/SourceBreakdown/SourceBreakdown.css
@@ -69,7 +69,7 @@
 
 .source-breakdown__note {
   font-size: var(--font-size-xs);
-  color: var(--color-error);
+  color: var(--color-error-fg);
 }
 
 .source-breakdown__hint {

--- a/quiz-app/src/pages/HomePage.css
+++ b/quiz-app/src/pages/HomePage.css
@@ -98,7 +98,7 @@
 
 .practice-pool-tip--enabled {
   background: var(--color-success-bg);
-  border-left-color: var(--color-success);
+  border-left-color: var(--color-success-fg);
 }
 
 .practice-pool-tip__icon {
@@ -115,7 +115,7 @@
 }
 
 .practice-pool-tip--enabled .practice-pool-tip__icon {
-  background: var(--color-success);
+  background: var(--color-success-solid);
 }
 
 .practice-pool-tip__icon .material-icons {
@@ -298,7 +298,7 @@
 }
 
 .config-item input[aria-invalid='true'] {
-  border-color: var(--color-error, #d32f2f);
+  border-color: var(--color-error-fg, #d32f2f);
 }
 
 .config-item__hint {
@@ -309,7 +309,7 @@
 }
 
 .config-item__hint--error {
-  color: var(--color-error, #d32f2f);
+  color: var(--color-error-fg, #d32f2f);
 }
 
 .checkbox-item label {

--- a/quiz-app/src/pages/HomePage.css
+++ b/quiz-app/src/pages/HomePage.css
@@ -116,6 +116,8 @@
 
 .practice-pool-tip--enabled .practice-pool-tip__icon {
   background: var(--color-success-solid);
+  /* 深色主題的 --color-on-primary 是近黑，白 icon 假設不成立；一律用純白 on-color */
+  color: var(--color-on-success);
 }
 
 .practice-pool-tip__icon .material-icons {

--- a/quiz-app/src/pages/QuizPage.css
+++ b/quiz-app/src/pages/QuizPage.css
@@ -43,8 +43,8 @@
   transition: all var(--transition-fast);
 }
 .quiz-abort-btn:hover {
-  border-color: var(--color-error, #d32f2f);
-  color: var(--color-error, #d32f2f);
+  border-color: var(--color-error-fg, #b71c1c);
+  color: var(--color-error-fg, #b71c1c);
 }
 .quiz-abort-btn:focus-visible {
   outline: 2px solid var(--color-primary);

--- a/quiz-app/src/pages/ResultPage.css
+++ b/quiz-app/src/pages/ResultPage.css
@@ -54,7 +54,7 @@
 }
 
 .score-section.good {
-  background: linear-gradient(135deg, #e8f5e9 0%, #f1f8e9 100%);
+  background: var(--color-success-score);
 }
 
 .score-section.good .score-icon .material-icons,
@@ -74,7 +74,7 @@
 }
 
 .score-section.fail {
-  background: linear-gradient(135deg, #ffebee 0%, #fce4ec 100%);
+  background: var(--color-error-score);
 }
 
 .score-section.fail .score-icon .material-icons,

--- a/quiz-app/src/pages/ResultPage.css
+++ b/quiz-app/src/pages/ResultPage.css
@@ -60,7 +60,7 @@
 .score-section.good .score-icon .material-icons,
 .score-section.good .score-value,
 .score-section.good .score-comment {
-  color: var(--color-success);
+  color: var(--color-success-fg);
 }
 
 .score-section.pass {
@@ -80,7 +80,7 @@
 .score-section.fail .score-icon .material-icons,
 .score-section.fail .score-value,
 .score-section.fail .score-comment {
-  color: var(--color-error);
+  color: var(--color-error-fg);
 }
 
 /* 統計區 */
@@ -120,12 +120,12 @@
 
 .stat-item.correct .material-icons,
 .stat-item.correct .stat-value {
-  color: var(--color-success);
+  color: var(--color-success-fg);
 }
 
 .stat-item.wrong .material-icons,
 .stat-item.wrong .stat-value {
-  color: var(--color-error);
+  color: var(--color-error-fg);
 }
 
 .stat-item.total .material-icons {
@@ -252,7 +252,7 @@
 .weak-rate {
   font-size: var(--font-size-sm);
   font-weight: 600;
-  color: var(--color-error);
+  color: var(--color-error-fg);
   white-space: nowrap;
 }
 
@@ -273,7 +273,7 @@
   align-items: center;
   gap: var(--spacing-sm);
   font-size: var(--font-size-lg);
-  color: var(--color-error);
+  color: var(--color-error-fg);
   margin-bottom: var(--spacing-md);
 }
 
@@ -289,7 +289,7 @@
   padding: var(--spacing-md);
   background: var(--color-surface-variant);
   border-radius: var(--radius-sm);
-  border-left: 4px solid var(--color-error);
+  border-left: 4px solid var(--color-error-fg);
 }
 
 .wrong-number {
@@ -346,11 +346,11 @@
 }
 
 .text-error {
-  color: var(--color-error);
+  color: var(--color-error-fg);
 }
 
 .text-success {
-  color: var(--color-success);
+  color: var(--color-success-fg);
 }
 
 /* 操作按鈕 */
@@ -448,7 +448,7 @@
 }
 
 .ai-response-inline.error {
-  border-color: var(--color-error);
+  border-color: var(--color-error-fg);
 }
 
 .ai-response-inline .ai-error {
@@ -456,7 +456,7 @@
   align-items: center;
   gap: var(--spacing-xs);
   font-size: var(--font-size-sm);
-  color: var(--color-error);
+  color: var(--color-error-fg);
 }
 
 /* AI 回應標頭 */
@@ -596,7 +596,7 @@
 }
 
 .similar-answer {
-  color: var(--color-success);
+  color: var(--color-success-fg);
   font-weight: 500;
 }
 

--- a/quiz-app/src/styles/global.css
+++ b/quiz-app/src/styles/global.css
@@ -242,7 +242,7 @@ textarea {
 
 .badge-success {
   background: var(--color-success-bg);
-  color: var(--color-success);
+  color: var(--color-success-fg);
 }
 
 .badge-warning {
@@ -252,7 +252,7 @@ textarea {
 
 .badge-error {
   background: var(--color-error-bg);
-  color: var(--color-error);
+  color: var(--color-error-fg);
 }
 
 .badge-info {

--- a/quiz-app/src/styles/semantic-token-usage.test.ts
+++ b/quiz-app/src/styles/semantic-token-usage.test.ts
@@ -1,0 +1,41 @@
+// #109 守門：掃描所有 CSS，color:/border* 屬性不得使用「裸」--color-success/error。
+// 這類前景/邊界用途必須走 role token（--color-*-fg），否則會像 QuizPage abort button 那樣
+// 漏掉 role-token migration、在多個 theme/CVD 組合低於 4.5:1，而 palette 對比測試又抓不到
+// （因為它驗的是 token 值、不是「哪個 selector 用了哪個 token」）。
+// 裝飾用途（background:/box-shadow: 的 bar、色條）允許裸 token —— 它們沒有文字對比需求。
+import { describe, it, expect } from 'vitest';
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+function collectCss(dir: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const p = join(dir, entry.name);
+    if (entry.isDirectory()) collectCss(p, out);
+    else if (entry.name.endsWith('.css')) out.push(p);
+  }
+  return out;
+}
+
+describe('語意 token 用法掃描（a11y #109）', () => {
+  it('color/border 屬性不得使用裸 --color-success/error（必須用 --color-*-fg）', () => {
+    // 裸 token：var(--color-success) 或 var(--color-success, fallback)，但**不含** -fg/-solid/-bg
+    const bareToken = /var\(\s*--color-(?:success|error)\s*(?:,|\))/;
+    const fgBorderProp =
+      /^\s*(?:color|border|border-color|border-top|border-right|border-bottom|border-left|border-left-color|border-right-color|border-top-color|border-bottom-color|outline|outline-color)\s*:/;
+    const violations: string[] = [];
+    for (const file of collectCss(join(process.cwd(), 'src'))) {
+      const rel = file.slice(file.indexOf('src')).replace(/\\/g, '/');
+      readFileSync(file, 'utf8')
+        .split('\n')
+        .forEach((line, idx) => {
+          if (fgBorderProp.test(line) && bareToken.test(line)) {
+            violations.push(`${rel}:${idx + 1}  ${line.trim()}`);
+          }
+        });
+    }
+    expect(
+      violations,
+      `以下把「裸」語意 token 當文字/邊界色，應改用 --color-*-fg：\n${violations.join('\n')}`
+    ).toEqual([]);
+  });
+});

--- a/quiz-app/src/styles/variables.css
+++ b/quiz-app/src/styles/variables.css
@@ -38,14 +38,20 @@
   --color-error-bg: rgba(244, 67, 54, 0.12);
   /* Role-based semantic tokens（a11y #109）：單一 --color-success/-error 同時當小字、icon、
      邊界、白字底會有互斥的對比需求；拆成角色專用 token，各自達 WCAG（文字 4.5:1／非文字 3:1）。
-     - -solid：白字安全的深色實填（徽章底），同時作為「淺色主題」的可讀前景（text/icon/border）。
-     - -fg：文字/icon/邊界前景；淺色 = var(-solid)、深色主題由 [data-theme='dark'] 覆寫成亮色。
-     - -bg（tint，上面已定義）與 base --color-success/-error（裝飾性 bar）維持不變。
-     所有值已用 WCAG 公式跨 light/dark × 4 CVD 模式驗過（見 PR 說明的對比矩陣）。 */
+     - -solid：白字安全的深色實填（徽章底）；其上的文字/icon 用 --color-on-success/-error（純白）。
+     - -fg：文字/icon/邊界前景，淺色/深色各自定義（deut 的 fg 比 solid 更深 —— 要在 tint、
+       surface-variant、page-bg、score 漸層上都達 4.5，不能只對純白 surface 驗）。
+     - -score：分數卡漸層（theme-aware，深色主題換深底），讓其上的 -fg 也達標。
+     - -bg（tint）與 base --color-success/-error（裝飾 bar）維持不變。
+     全部值用 WCAG 公式對「真實前景/背景對」跨 light/dark × 4 CVD 驗過（見 a11y-contrast e2e）。 */
   --color-success-solid: #2e7d32;
   --color-error-solid: #c62828;
-  --color-success-fg: var(--color-success-solid);
-  --color-error-fg: var(--color-error-solid);
+  --color-success-fg: #2e7d32;
+  --color-error-fg: #c62828;
+  --color-on-success: #ffffff;
+  --color-on-error: #ffffff;
+  --color-success-score: linear-gradient(135deg, #e8f5e9 0%, #f1f8e9 100%);
+  --color-error-score: linear-gradient(135deg, #ffebee 0%, #fce4ec 100%);
   --color-info: #2196f3;
   --color-info-bg: rgba(33, 150, 243, 0.12);
 
@@ -129,6 +135,9 @@
   /* 深色表面上的可讀語意前景（亮色）；-solid（徽章底）維持深色，白字仍安全 */
   --color-success-fg: #81c784;
   --color-error-fg: #ef9a9a;
+  /* 分數卡漸層換深底 —— 原本固定淺底會與深色主題的亮 -fg 撞成 <2:1 低對比 */
+  --color-success-score: linear-gradient(135deg, #12281a 0%, #16301f 100%);
+  --color-error-score: linear-gradient(135deg, #2a1416 0%, #301a1e 100%);
 
   --color-background: #121212;
   --color-surface: #1e1e1e;
@@ -170,9 +179,10 @@
   --color-success-bg: rgba(25, 118, 210, 0.12);
   --color-error: #e65100;
   --color-error-bg: rgba(230, 81, 0, 0.12);
-  /* 淺色主題的 -fg 透過 :root 的 var(--color-*-solid) 自動跟隨這裡的 -solid */
   --color-success-solid: #1565c0;
   --color-error-solid: #bf360c;
+  --color-success-fg: #1565c0;
+  --color-error-fg: #bf360c;
 }
 
 [data-cvd-mode='deuteranopia'] {
@@ -182,6 +192,9 @@
   --color-error-bg: rgba(216, 67, 21, 0.12);
   --color-success-solid: #0277bd;
   --color-error-solid: #c73e00;
+  /* fg 比 solid 更深：要在 tint/surface-variant/page-bg/score 漸層上都達 4.5 */
+  --color-success-fg: #01579b;
+  --color-error-fg: #a52a00;
 }
 
 [data-cvd-mode='tritanopia'] {
@@ -191,6 +204,8 @@
   --color-error-bg: rgba(198, 40, 40, 0.12);
   --color-success-solid: #00695c;
   --color-error-solid: #b71c1c;
+  --color-success-fg: #00695c;
+  --color-error-fg: #b71c1c;
 }
 
 /* 深色主題 × CVD：-fg 覆寫為深色表面可讀的亮色（-solid 維持深色，徽章白字仍安全） */

--- a/quiz-app/src/styles/variables.css
+++ b/quiz-app/src/styles/variables.css
@@ -46,8 +46,9 @@
      全部值用 WCAG 公式對「真實前景/背景對」跨 light/dark × 4 CVD 驗過（見 a11y-contrast e2e）。 */
   --color-success-solid: #2e7d32;
   --color-error-solid: #c62828;
-  --color-success-fg: #2e7d32;
-  --color-error-fg: #c62828;
+  /* -fg 比 -solid 更深：要在「tint 疊 page-background(#f5f7fa，非白 surface)」上也達 4.5 */
+  --color-success-fg: #1b5e20;
+  --color-error-fg: #b71c1c;
   --color-on-success: #ffffff;
   --color-on-error: #ffffff;
   --color-success-score: linear-gradient(135deg, #e8f5e9 0%, #f1f8e9 100%);
@@ -182,7 +183,7 @@
   --color-success-solid: #1565c0;
   --color-error-solid: #bf360c;
   --color-success-fg: #1565c0;
-  --color-error-fg: #bf360c;
+  --color-error-fg: #a83000;
 }
 
 [data-cvd-mode='deuteranopia'] {

--- a/quiz-app/src/styles/variables.css
+++ b/quiz-app/src/styles/variables.css
@@ -36,6 +36,16 @@
   --color-warning-bg: rgba(255, 152, 0, 0.12);
   --color-error: #f44336;
   --color-error-bg: rgba(244, 67, 54, 0.12);
+  /* Role-based semantic tokens（a11y #109）：單一 --color-success/-error 同時當小字、icon、
+     邊界、白字底會有互斥的對比需求；拆成角色專用 token，各自達 WCAG（文字 4.5:1／非文字 3:1）。
+     - -solid：白字安全的深色實填（徽章底），同時作為「淺色主題」的可讀前景（text/icon/border）。
+     - -fg：文字/icon/邊界前景；淺色 = var(-solid)、深色主題由 [data-theme='dark'] 覆寫成亮色。
+     - -bg（tint，上面已定義）與 base --color-success/-error（裝飾性 bar）維持不變。
+     所有值已用 WCAG 公式跨 light/dark × 4 CVD 模式驗過（見 PR 說明的對比矩陣）。 */
+  --color-success-solid: #2e7d32;
+  --color-error-solid: #c62828;
+  --color-success-fg: var(--color-success-solid);
+  --color-error-fg: var(--color-error-solid);
   --color-info: #2196f3;
   --color-info-bg: rgba(33, 150, 243, 0.12);
 
@@ -116,6 +126,10 @@
   --color-primary-light: var(--primary-80);
   --color-on-primary: var(--neutral-10);
 
+  /* 深色表面上的可讀語意前景（亮色）；-solid（徽章底）維持深色，白字仍安全 */
+  --color-success-fg: #81c784;
+  --color-error-fg: #ef9a9a;
+
   --color-background: #121212;
   --color-surface: #1e1e1e;
   --color-surface-variant: #2d2d2d;
@@ -156,6 +170,9 @@
   --color-success-bg: rgba(25, 118, 210, 0.12);
   --color-error: #e65100;
   --color-error-bg: rgba(230, 81, 0, 0.12);
+  /* 淺色主題的 -fg 透過 :root 的 var(--color-*-solid) 自動跟隨這裡的 -solid */
+  --color-success-solid: #1565c0;
+  --color-error-solid: #bf360c;
 }
 
 [data-cvd-mode='deuteranopia'] {
@@ -163,6 +180,8 @@
   --color-success-bg: rgba(2, 136, 209, 0.12);
   --color-error: #d84315;
   --color-error-bg: rgba(216, 67, 21, 0.12);
+  --color-success-solid: #0277bd;
+  --color-error-solid: #c73e00;
 }
 
 [data-cvd-mode='tritanopia'] {
@@ -170,6 +189,22 @@
   --color-success-bg: rgba(0, 137, 123, 0.12);
   --color-error: #c62828;
   --color-error-bg: rgba(198, 40, 40, 0.12);
+  --color-success-solid: #00695c;
+  --color-error-solid: #b71c1c;
+}
+
+/* 深色主題 × CVD：-fg 覆寫為深色表面可讀的亮色（-solid 維持深色，徽章白字仍安全） */
+[data-theme='dark'][data-cvd-mode='protanopia'] {
+  --color-success-fg: #64b5f6;
+  --color-error-fg: #ffb74d;
+}
+[data-theme='dark'][data-cvd-mode='deuteranopia'] {
+  --color-success-fg: #4fc3f7;
+  --color-error-fg: #ff8a65;
+}
+[data-theme='dark'][data-cvd-mode='tritanopia'] {
+  --color-success-fg: #4db6ac;
+  --color-error-fg: #ef9a9a;
 }
 
 /* 字體大小偏好 */

--- a/quiz-app/tests/e2e/a11y-contrast.spec.ts
+++ b/quiz-app/tests/e2e/a11y-contrast.spec.ts
@@ -1,9 +1,15 @@
 import { test, expect } from '@playwright/test';
 
 /**
- * #109 回歸守門：語意色 role-based token 的值，在 light/dark × 4 種 CVD 模式下都要達 WCAG AA
- * （文字前景／徽章白字皆 4.5:1）。jsdom 算不出 stylesheet 的 CSS 變數，只有真瀏覽器測得到。
- * 任何人把某個 token 改成低對比值，這支測試就會紅。
+ * #109 回歸守門：語意色 role-based token 在**每一種真實前景/背景配對**下都要達 WCAG AA。
+ *
+ * 這支測試刻意涵蓋「PR #110 第一版漏掉、被外部 review 抓到」的面向：
+ *  - -fg 文字不是只放 --color-surface，還會放在 tint、surface-variant、page background、
+ *    以及分數卡漸層上 —— 全部都要 >= 4.5:1。
+ *  - 徽章/標頭的白字要對 -solid 驗（讀真正的 --color-on-*，不假設是白）。
+ *  - high-contrast on/off 也是獨立維度（2 themes × 4 CVD × 2 HC = 16 組）。
+ *  - parser fail-closed：token 缺失或無法解析就直接 throw，不用黑色 fallback 假裝高對比。
+ * jsdom 算不出 stylesheet 的 CSS 變數，只有真瀏覽器測得到。
  */
 function relLum([r, g, b]: number[]): number {
   const lin = (c: number): number => {
@@ -15,70 +21,132 @@ function relLum([r, g, b]: number[]): number {
 function contrast(a: number[], b: number[]): number {
   const la = relLum(a);
   const lb = relLum(b);
-  const hi = Math.max(la, lb);
-  const lo = Math.min(la, lb);
-  return (hi + 0.05) / (lo + 0.05);
+  return (Math.max(la, lb) + 0.05) / (Math.min(la, lb) + 0.05);
+}
+/** fail-closed：缺值或無法解析直接丟錯，不回黑色 */
+function parseColor(s: string, label: string): number[] {
+  const t = (s ?? '').trim();
+  if (!t) throw new Error(`Missing color token: ${label}`);
+  if (/^#[0-9a-fA-F]{6}$/.test(t)) {
+    return [1, 3, 5].map((i) => parseInt(t.slice(i, i + 2), 16));
+  }
+  const m = t.match(/rgba?\(([^)]+)\)/);
+  if (m) {
+    const p = m[1].split(',').map((x) => parseFloat(x));
+    if (p.length >= 3 && p.slice(0, 3).every((n) => Number.isFinite(n))) {
+      return [p[0], p[1], p[2]];
+    }
+  }
+  throw new Error(`Unsupported color value for ${label}: "${t}"`);
+}
+/** rgba tint 疊在 bg 上的實際色 */
+function alphaOver(rgba: string, bg: number[], label: string): number[] {
+  const m = (rgba ?? '').match(/rgba?\(([^)]+)\)/);
+  if (!m) throw new Error(`Not an rgba value for ${label}: "${rgba}"`);
+  const p = m[1].split(',').map((x) => parseFloat(x));
+  const a = p.length >= 4 ? p[3] : 1;
+  return [p[0], p[1], p[2]].map((c, i) => Math.round(a * c + (1 - a) * bg[i]));
+}
+/** 從 gradient 字串抽出所有 hex endpoint */
+function gradientStops(g: string, label: string): number[][] {
+  const hexes = (g ?? '').match(/#[0-9a-fA-F]{6}/g);
+  if (!hexes || hexes.length === 0) {
+    throw new Error(`No color stops in gradient for ${label}: "${g}"`);
+  }
+  return hexes.map((h) => [1, 3, 5].map((i) => parseInt(h.slice(i, i + 2), 16)));
 }
 
-test('語意 token 角色值：全 mode×theme 達 WCAG AA（#109 contrast matrix）', async ({
+test('語意 token：每個真實 fg/bg 配對跨 16 組（theme×CVD×HC）達 WCAG AA（#109）', async ({
   page,
 }) => {
   await page.goto('/');
 
-  const rows = await page.evaluate(() => {
+  const combos = await page.evaluate(() => {
     const html = document.documentElement;
-    const parse = (s: string): number[] => {
-      const t = s.trim();
-      if (t.startsWith('#')) {
-        return [1, 3, 5].map((i) => parseInt(t.slice(i, i + 2), 16));
-      }
-      const m = t.match(/\d+/g) ?? ['0', '0', '0'];
-      return [Number(m[0]), Number(m[1]), Number(m[2])];
-    };
     const read = (v: string): string =>
       getComputedStyle(html).getPropertyValue(v).trim();
-    const combos: [string, string][] = [
-      ['light', 'none'],
-      ['dark', 'none'],
-      ['light', 'protanopia'],
-      ['dark', 'protanopia'],
-      ['light', 'deuteranopia'],
-      ['dark', 'deuteranopia'],
-      ['light', 'tritanopia'],
-      ['dark', 'tritanopia'],
-    ];
-    const out = combos.map(([theme, cvd]) => {
-      html.setAttribute('data-theme', theme);
-      html.setAttribute('data-cvd-mode', cvd);
-      return {
-        mode: `${theme}/${cvd}`,
-        surf: parse(read('--color-surface')),
-        successFg: parse(read('--color-success-fg')),
-        errorFg: parse(read('--color-error-fg')),
-        successSolid: parse(read('--color-success-solid')),
-        errorSolid: parse(read('--color-error-solid')),
-      };
-    });
+    const rows: Record<string, string>[] = [];
+    for (const theme of ['light', 'dark']) {
+      for (const cvd of ['none', 'protanopia', 'deuteranopia', 'tritanopia']) {
+        for (const hc of ['false', 'true']) {
+          html.setAttribute('data-theme', theme);
+          html.setAttribute('data-cvd-mode', cvd);
+          html.setAttribute('data-high-contrast', hc);
+          rows.push({
+            mode: `${theme}/${cvd}/hc=${hc}`,
+            surface: read('--color-surface'),
+            surfaceVariant: read('--color-surface-variant'),
+            background: read('--color-background'),
+            successFg: read('--color-success-fg'),
+            errorFg: read('--color-error-fg'),
+            successSolid: read('--color-success-solid'),
+            errorSolid: read('--color-error-solid'),
+            onSuccess: read('--color-on-success'),
+            onError: read('--color-on-error'),
+            successBg: read('--color-success-bg'),
+            errorBg: read('--color-error-bg'),
+            successScore: read('--color-success-score'),
+            errorScore: read('--color-error-score'),
+          });
+        }
+      }
+    }
     html.setAttribute('data-theme', 'light');
     html.setAttribute('data-cvd-mode', 'none');
-    return out;
+    html.setAttribute('data-high-contrast', 'false');
+    return rows;
   });
 
-  const WHITE = [255, 255, 255];
-  for (const r of rows) {
-    // 文字前景在表面上 >= 4.5:1
+  expect(combos.length).toBe(16);
+
+  for (const c of combos) {
+    const surf = parseColor(c.surface, `${c.mode} surface`);
+    const surfV = parseColor(c.surfaceVariant, `${c.mode} surface-variant`);
+    const bg = parseColor(c.background, `${c.mode} background`);
+    const sFg = parseColor(c.successFg, `${c.mode} success-fg`);
+    const eFg = parseColor(c.errorFg, `${c.mode} error-fg`);
+    const sSol = parseColor(c.successSolid, `${c.mode} success-solid`);
+    const eSol = parseColor(c.errorSolid, `${c.mode} error-solid`);
+    const onS = parseColor(c.onSuccess, `${c.mode} on-success`);
+    const onE = parseColor(c.onError, `${c.mode} on-error`);
+    const sTint = alphaOver(c.successBg, surf, `${c.mode} success-bg`);
+    const eTint = alphaOver(c.errorBg, surf, `${c.mode} error-bg`);
+    const sScore = gradientStops(c.successScore, `${c.mode} success-score`);
+    const eScore = gradientStops(c.errorScore, `${c.mode} error-score`);
+
+    // -fg 文字放在所有可能背景上 >= 4.5:1
+    const successBgs: [number[], string][] = [
+      [surf, 'surface'],
+      [surfV, 'surface-variant'],
+      [bg, 'page-background'],
+      [sTint, 'success-tint'],
+      ...sScore.map((g, i): [number[], string] => [g, `success-score#${i}`]),
+    ];
+    for (const [b, name] of successBgs) {
+      expect
+        .soft(contrast(sFg, b), `${c.mode} success-fg on ${name}`)
+        .toBeGreaterThanOrEqual(4.5);
+    }
+    const errorBgs: [number[], string][] = [
+      [surf, 'surface'],
+      [surfV, 'surface-variant'],
+      [bg, 'page-background'],
+      [eTint, 'error-tint'],
+      ...eScore.map((g, i): [number[], string] => [g, `error-score#${i}`]),
+    ];
+    for (const [b, name] of errorBgs) {
+      expect
+        .soft(contrast(eFg, b), `${c.mode} error-fg on ${name}`)
+        .toBeGreaterThanOrEqual(4.5);
+    }
+
+    // 徽章/標頭：on-color 白字放在 -solid 實填上 >= 4.5:1
     expect
-      .soft(contrast(r.successFg, r.surf), `${r.mode} success-fg on surface`)
+      .soft(contrast(onS, sSol), `${c.mode} on-success on success-solid`)
       .toBeGreaterThanOrEqual(4.5);
     expect
-      .soft(contrast(r.errorFg, r.surf), `${r.mode} error-fg on surface`)
-      .toBeGreaterThanOrEqual(4.5);
-    // 徽章白字在實填底上 >= 4.5:1
-    expect
-      .soft(contrast(WHITE, r.successSolid), `${r.mode} white on success-solid`)
-      .toBeGreaterThanOrEqual(4.5);
-    expect
-      .soft(contrast(WHITE, r.errorSolid), `${r.mode} white on error-solid`)
+      .soft(contrast(onE, eSol), `${c.mode} on-error on error-solid`)
       .toBeGreaterThanOrEqual(4.5);
   }
 });
+

--- a/quiz-app/tests/e2e/a11y-contrast.spec.ts
+++ b/quiz-app/tests/e2e/a11y-contrast.spec.ts
@@ -111,6 +111,10 @@ test('語意 token：每個真實 fg/bg 配對跨 16 組（theme×CVD×HC）達 
     const onE = parseColor(c.onError, `${c.mode} on-error`);
     const sTint = alphaOver(c.successBg, surf, `${c.mode} success-bg`);
     const eTint = alphaOver(c.errorBg, surf, `${c.mode} error-bg`);
+    // tint 也可能疊在「page background」上（如首頁 .badge-success 的 ancestor 皆透明），
+    // 那比疊在白 surface 上對比更低 —— 一定要驗這一種，否則會像上一版誤綠。
+    const sTintPage = alphaOver(c.successBg, bg, `${c.mode} success-bg/page`);
+    const eTintPage = alphaOver(c.errorBg, bg, `${c.mode} error-bg/page`);
     const sScore = gradientStops(c.successScore, `${c.mode} success-score`);
     const eScore = gradientStops(c.errorScore, `${c.mode} error-score`);
 
@@ -120,6 +124,7 @@ test('語意 token：每個真實 fg/bg 配對跨 16 組（theme×CVD×HC）達 
       [surfV, 'surface-variant'],
       [bg, 'page-background'],
       [sTint, 'success-tint'],
+      [sTintPage, 'success-tint-over-page'],
       ...sScore.map((g, i): [number[], string] => [g, `success-score#${i}`]),
     ];
     for (const [b, name] of successBgs) {
@@ -132,6 +137,7 @@ test('語意 token：每個真實 fg/bg 配對跨 16 組（theme×CVD×HC）達 
       [surfV, 'surface-variant'],
       [bg, 'page-background'],
       [eTint, 'error-tint'],
+      [eTintPage, 'error-tint-over-page'],
       ...eScore.map((g, i): [number[], string] => [g, `error-score#${i}`]),
     ];
     for (const [b, name] of errorBgs) {

--- a/quiz-app/tests/e2e/a11y-contrast.spec.ts
+++ b/quiz-app/tests/e2e/a11y-contrast.spec.ts
@@ -1,0 +1,84 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * #109 回歸守門：語意色 role-based token 的值，在 light/dark × 4 種 CVD 模式下都要達 WCAG AA
+ * （文字前景／徽章白字皆 4.5:1）。jsdom 算不出 stylesheet 的 CSS 變數，只有真瀏覽器測得到。
+ * 任何人把某個 token 改成低對比值，這支測試就會紅。
+ */
+function relLum([r, g, b]: number[]): number {
+  const lin = (c: number): number => {
+    const s = c / 255;
+    return s <= 0.03928 ? s / 12.92 : Math.pow((s + 0.055) / 1.055, 2.4);
+  };
+  return 0.2126 * lin(r) + 0.7152 * lin(g) + 0.0722 * lin(b);
+}
+function contrast(a: number[], b: number[]): number {
+  const la = relLum(a);
+  const lb = relLum(b);
+  const hi = Math.max(la, lb);
+  const lo = Math.min(la, lb);
+  return (hi + 0.05) / (lo + 0.05);
+}
+
+test('語意 token 角色值：全 mode×theme 達 WCAG AA（#109 contrast matrix）', async ({
+  page,
+}) => {
+  await page.goto('/');
+
+  const rows = await page.evaluate(() => {
+    const html = document.documentElement;
+    const parse = (s: string): number[] => {
+      const t = s.trim();
+      if (t.startsWith('#')) {
+        return [1, 3, 5].map((i) => parseInt(t.slice(i, i + 2), 16));
+      }
+      const m = t.match(/\d+/g) ?? ['0', '0', '0'];
+      return [Number(m[0]), Number(m[1]), Number(m[2])];
+    };
+    const read = (v: string): string =>
+      getComputedStyle(html).getPropertyValue(v).trim();
+    const combos: [string, string][] = [
+      ['light', 'none'],
+      ['dark', 'none'],
+      ['light', 'protanopia'],
+      ['dark', 'protanopia'],
+      ['light', 'deuteranopia'],
+      ['dark', 'deuteranopia'],
+      ['light', 'tritanopia'],
+      ['dark', 'tritanopia'],
+    ];
+    const out = combos.map(([theme, cvd]) => {
+      html.setAttribute('data-theme', theme);
+      html.setAttribute('data-cvd-mode', cvd);
+      return {
+        mode: `${theme}/${cvd}`,
+        surf: parse(read('--color-surface')),
+        successFg: parse(read('--color-success-fg')),
+        errorFg: parse(read('--color-error-fg')),
+        successSolid: parse(read('--color-success-solid')),
+        errorSolid: parse(read('--color-error-solid')),
+      };
+    });
+    html.setAttribute('data-theme', 'light');
+    html.setAttribute('data-cvd-mode', 'none');
+    return out;
+  });
+
+  const WHITE = [255, 255, 255];
+  for (const r of rows) {
+    // 文字前景在表面上 >= 4.5:1
+    expect
+      .soft(contrast(r.successFg, r.surf), `${r.mode} success-fg on surface`)
+      .toBeGreaterThanOrEqual(4.5);
+    expect
+      .soft(contrast(r.errorFg, r.surf), `${r.mode} error-fg on surface`)
+      .toBeGreaterThanOrEqual(4.5);
+    // 徽章白字在實填底上 >= 4.5:1
+    expect
+      .soft(contrast(WHITE, r.successSolid), `${r.mode} white on success-solid`)
+      .toBeGreaterThanOrEqual(4.5);
+    expect
+      .soft(contrast(WHITE, r.errorSolid), `${r.mode} white on error-solid`)
+      .toBeGreaterThanOrEqual(4.5);
+  }
+});


### PR DESCRIPTION
## 背景（#109）

單一 `--color-success` / `--color-error` 同時被當作：小字前景、icon 前景、邊界、白字實填底（`.option-key` 徽章）、裝飾 bar。一個色值不可能同時對白字、白底、深底都達 WCAG。實測（PR #108 review 量化）：小字 **16 組有 12 組 < 4.5:1**（最慘預設「正確答案」綠字 **2.78:1**）、部分 icon/邊界 < 3:1。

## 做法：role-based token

`variables.css` 拆出角色專用 token：
- `--color-*-solid`：白字安全的**深色實填**（徽章、白 icon chip 底），同時兼作**淺色主題**的可讀前景。
- `--color-*-fg`：文字/icon/邊界前景。淺色 = `var(-solid)`；深色主題 `[data-theme=dark]` 覆寫為亮色；4 種 CVD 模式各自的 `-solid`/`-fg` 都定義（含 8 個 `[data-theme=dark][data-cvd-mode]` 組合）。
- `--color-*-bg`（tint）與 base `--color-*`（裝飾 bar）不變。

CSS 重新指向：`text/icon/border → -fg`；`.option-key` 徽章 + AI 錯誤標頭 + 練習池 icon（皆白字/白 icon）`→ -solid`；histogram/breakdown 裝飾 bar 保留 base。

## 驗證（全部實算，非估計）

| 檢查 | 結果 |
|---|---|
| 離線 palette WCAG 公式（40 檢查，light/dark × 4 CVD × role） | **0 失敗** |
| Playwright 讀「打包後真實 CSS」token 值：fg-on-surface | **4.80–8.32**（全 ≥ 4.5） |
| 同上：white-on-solid（徽章白字） | **4.80–6.61**（全 ≥ 4.5） |
| 實跑練習題回饋（rendered）：正確徽章 `#2e7d32` 白字 | **5.13:1**，icon/邊界同色可讀 |

修正前預設綠字 2.78 → 修正後 5.13。全庫 **796 unit 綠**、build 綠。

Closes #109
