### PR TITLE
a11y #111：info/warning 拆 role-based token + 修 excellent/pass 分數卡對比

### DIFF
--- a/quiz-app/src/components/PracticePoolHistogram/PracticePoolHistogram.css
+++ b/quiz-app/src/components/PracticePoolHistogram/PracticePoolHistogram.css
@@ -62,7 +62,8 @@
 
 .pool-histogram__pct {
   font-size: var(--font-size-xs);
-  color: var(--color-text-quiet);
+  /* --color-text-quiet 未定義（原本靜默繼承）；用既有的 secondary 文字色 */
+  color: var(--color-text-secondary);
   font-variant-numeric: tabular-nums;
   text-align: right;
 }

--- a/quiz-app/src/components/QuestionCard/QuestionCard.css
+++ b/quiz-app/src/components/QuestionCard/QuestionCard.css
@@ -66,13 +66,16 @@
 }
 
 .subject-1 {
+  /* 12px 藍字疊 12% 藍 tint 在多主題 <4.5:1（且此規則 specificity 與 .badge-info 同、較晚出現會蓋掉
+     #112 的 --color-info-fg）。改用可讀前景，藍色識別留在 tint 底。 */
   background: rgba(25, 118, 210, 0.12);
-  color: #1976d2;
+  color: var(--color-text-primary);
 }
 
 .subject-2 {
+  /* 同上：無紫色 role token，紫色識別留在 tint 底、文字用可讀前景（原 #9c27b0 dark 僅約 2.47:1） */
   background: rgba(156, 39, 176, 0.12);
-  color: #9c27b0;
+  color: var(--color-text-primary);
 }
 
 /* 題幹 */
@@ -273,7 +276,10 @@
 .ai-response-header .confidence-badge {
   margin-left: auto;
   padding: 2px 8px;
-  background: rgba(255, 255, 255, 0.2);
+  /* 不疊 20% 白底（會沖淡 header 實色、使 12px 白字在 primary/error header 上 <4.5:1）；
+     改透明底 + currentColor 邊框，文字沿用 header 已驗證的 on-color 對比 */
+  background: transparent;
+  border: 1px solid currentColor;
   border-radius: var(--radius-full);
   font-size: var(--font-size-xs);
 }
@@ -393,7 +399,8 @@
 
 [data-theme="dark"] .question-sources {
   background: rgba(59, 130, 246, 0.08);
-  border-left-color: var(--color-info-fg-dark, #93c5fd);
+  /* 原 var(--color-info-fg-dark) 未定義、永遠落到硬編 fallback；--color-info-fg 深色本就是亮藍 */
+  border-left-color: var(--color-info-fg);
 }
 
 /* 小螢幕（≤640px）— question-card padding 收緊、option-item tap target */

--- a/quiz-app/src/components/QuestionCard/QuestionCard.css
+++ b/quiz-app/src/components/QuestionCard/QuestionCard.css
@@ -218,7 +218,7 @@
   padding: var(--spacing-sm) var(--spacing-md);
   background: var(--color-warning-bg);
   border-radius: var(--radius-sm);
-  color: var(--color-warning);
+  color: var(--color-warning-fg);
   font-size: var(--font-size-sm);
 }
 

--- a/quiz-app/src/components/SourceBadge/SourceBadge.css
+++ b/quiz-app/src/components/SourceBadge/SourceBadge.css
@@ -46,6 +46,8 @@
   background: rgba(0, 0, 0, 0.08);
 }
 
-.flag-time_sensitive { background: rgba(239, 68, 68, 0.15); color: #b91c1c; }
-.flag-ambiguous     { background: rgba(168, 85, 247, 0.15); color: #6b21a8; }
-.flag-low_confidence{ background: rgba(107, 114, 128, 0.15); color: #4b5563; }
+/* 旗標文字用可讀前景（原本固定深色文字無深色變體，巢狀在 tone-mock/tone-ai badge 內、深色主題
+   實測僅約 1.25–1.88:1）；分類仍靠背景 hue + 文字內容傳達，不靠顏色單一管道。 */
+.flag-time_sensitive { background: rgba(239, 68, 68, 0.15); color: var(--color-text-primary); }
+.flag-ambiguous     { background: rgba(168, 85, 247, 0.15); color: var(--color-text-primary); }
+.flag-low_confidence{ background: rgba(107, 114, 128, 0.15); color: var(--color-text-primary); }

--- a/quiz-app/src/components/SourceBanner/SourceBanner.css
+++ b/quiz-app/src/components/SourceBanner/SourceBanner.css
@@ -11,13 +11,13 @@
 
 .source-banner--mock {
   background: var(--color-info-bg);
-  border-left-color: var(--color-info);
+  border-left-color: var(--color-info-fg);
   color: var(--color-text-primary);
 }
 
 .source-banner--ai {
   background: var(--color-warning-bg);
-  border-left-color: var(--color-warning);
+  border-left-color: var(--color-warning-fg);
   color: var(--color-text-primary);
 }
 
@@ -32,8 +32,8 @@
   margin-top: 2px;
 }
 
-.source-banner--mock .source-banner__icon { color: var(--color-info); }
-.source-banner--ai .source-banner__icon { color: var(--color-warning); }
+.source-banner--mock .source-banner__icon { color: var(--color-info-fg); }
+.source-banner--ai .source-banner__icon { color: var(--color-warning-fg); }
 .source-banner--flagged .source-banner__icon { color: var(--color-error-fg); }
 
 .source-banner__body {

--- a/quiz-app/src/components/SourceBanner/SourceBanner.css
+++ b/quiz-app/src/components/SourceBanner/SourceBanner.css
@@ -56,7 +56,8 @@
 }
 
 .source-banner__sources {
-  color: var(--color-text-quiet);
+  /* --color-text-quiet 未定義（原本靜默繼承其他色）；用既有的 secondary 文字色 */
+  color: var(--color-text-secondary);
 }
 
 .source-banner__flags {

--- a/quiz-app/src/pages/HomePage.css
+++ b/quiz-app/src/pages/HomePage.css
@@ -69,7 +69,7 @@
   padding: var(--spacing-sm) var(--spacing-md);
   margin-bottom: var(--spacing-md);
   background: var(--color-info-bg, var(--color-surface));
-  border-left: 3px solid var(--color-info, var(--color-primary));
+  border-left: 3px solid var(--color-info-fg, var(--color-primary));
   font-size: var(--font-size-sm);
 }
 
@@ -92,7 +92,7 @@
   padding: var(--spacing-md) var(--spacing-lg);
   margin-bottom: var(--spacing-lg);
   background: var(--color-warning-bg);
-  border-left: 4px solid var(--color-warning);
+  border-left: 4px solid var(--color-warning-fg);
   transition: background-color 200ms ease, border-color 200ms ease;
 }
 
@@ -108,8 +108,8 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  background: var(--color-warning);
-  color: var(--color-on-primary);
+  background: var(--color-warning-solid);
+  color: var(--color-on-warning);
   border-radius: var(--radius-full);
   transition: background-color 200ms ease;
 }

--- a/quiz-app/src/pages/ResultPage.css
+++ b/quiz-app/src/pages/ResultPage.css
@@ -395,14 +395,15 @@
 }
 
 .btn-small.btn-generate {
-  border-color: var(--accent-50);
-  color: var(--accent-50);
+  /* 原 --accent-50 (#ff9800) 當 12px 文字/邊界僅約 2.16:1；改用 warning role token */
+  border-color: var(--color-warning-fg);
+  color: var(--color-warning-fg);
 }
 
 .btn-small.btn-generate:hover {
-  background: var(--accent-50);
-  color: white;
-  border-color: var(--accent-50);
+  background: var(--color-warning-solid);
+  color: var(--color-on-warning);
+  border-color: var(--color-warning-solid);
 }
 
 .ai-loading-inline {
@@ -489,11 +490,11 @@
 
 /* AI 生成題目專用樣式 */
 .ai-response-inline.generated {
-  border-color: var(--accent-50);
+  border-color: var(--color-warning-fg);
 }
 
 .ai-response-inline.generated .ai-response-header-inline {
-  color: var(--accent-50);
+  color: var(--color-warning-fg);
 }
 
 .generated-content {

--- a/quiz-app/src/pages/ResultPage.css
+++ b/quiz-app/src/pages/ResultPage.css
@@ -41,16 +41,16 @@
 
 /* 分數等級顏色 */
 .score-section.excellent {
-  background: linear-gradient(135deg, #fff8e1 0%, #fffde7 100%);
+  background: var(--color-warning-score);
 }
 
 .score-section.excellent .score-icon .material-icons {
-  color: #ffc107;
+  color: var(--color-warning-fg);
 }
 
 .score-section.excellent .score-value,
 .score-section.excellent .score-comment {
-  color: #f57c00;
+  color: var(--color-warning-fg);
 }
 
 .score-section.good {
@@ -64,13 +64,13 @@
 }
 
 .score-section.pass {
-  background: linear-gradient(135deg, #e3f2fd 0%, #e8eaf6 100%);
+  background: var(--color-info-score);
 }
 
 .score-section.pass .score-icon .material-icons,
 .score-section.pass .score-value,
 .score-section.pass .score-comment {
-  color: var(--color-info);
+  color: var(--color-info-fg);
 }
 
 .score-section.fail {
@@ -129,11 +129,11 @@
 }
 
 .stat-item.total .material-icons {
-  color: var(--color-info);
+  color: var(--color-info-fg);
 }
 
 .stat-item.time .material-icons {
-  color: var(--color-warning);
+  color: var(--color-warning-fg);
 }
 
 .stat-item.skipped .material-icons {
@@ -155,7 +155,7 @@
   align-items: center;
   gap: var(--spacing-xs);
   font-weight: 600;
-  color: var(--color-info);
+  color: var(--color-info-fg);
   margin-bottom: var(--spacing-sm);
 }
 
@@ -200,7 +200,7 @@
   align-items: center;
   gap: var(--spacing-sm);
   font-size: var(--font-size-lg);
-  color: var(--color-warning);
+  color: var(--color-warning-fg);
   margin-bottom: var(--spacing-xs);
 }
 
@@ -226,7 +226,7 @@
   padding: var(--spacing-sm);
   background: var(--color-surface-variant);
   border-radius: var(--radius-sm);
-  border-left: 3px solid var(--color-warning);
+  border-left: 3px solid var(--color-warning-fg);
 }
 
 .weak-rank {
@@ -484,7 +484,7 @@
 .confidence-warning {
   margin-left: auto;
   font-size: var(--font-size-xs);
-  color: var(--color-warning);
+  color: var(--color-warning-fg);
 }
 
 /* AI 生成題目專用樣式 */
@@ -515,14 +515,14 @@
 
 /* 題庫相似題按鈕 */
 .btn-small.btn-bank {
-  border-color: var(--color-info);
-  color: var(--color-info);
+  border-color: var(--color-info-fg);
+  color: var(--color-info-fg);
 }
 
 .btn-small.btn-bank:hover {
-  background: var(--color-info);
-  color: white;
-  border-color: var(--color-info);
+  background: var(--color-info-solid);
+  color: var(--color-on-info);
+  border-color: var(--color-info-fg);
 }
 
 /* 題庫內相似題區塊 */
@@ -531,7 +531,7 @@
   padding: var(--spacing-sm);
   background: var(--color-surface);
   border-radius: var(--radius-sm);
-  border: 1px solid var(--color-info);
+  border: 1px solid var(--color-info-fg);
 }
 
 .bank-similar-header {
@@ -540,7 +540,7 @@
   gap: var(--spacing-xs);
   font-size: var(--font-size-sm);
   font-weight: 500;
-  color: var(--color-info);
+  color: var(--color-info-fg);
   margin-bottom: var(--spacing-sm);
 }
 
@@ -568,7 +568,7 @@
 .similar-index {
   font-size: var(--font-size-sm);
   font-weight: 600;
-  color: var(--color-info);
+  color: var(--color-info-fg);
   min-width: 24px;
 }
 

--- a/quiz-app/src/styles/global.css
+++ b/quiz-app/src/styles/global.css
@@ -247,7 +247,7 @@ textarea {
 
 .badge-warning {
   background: var(--color-warning-bg);
-  color: var(--color-warning);
+  color: var(--color-warning-fg);
 }
 
 .badge-error {
@@ -257,7 +257,7 @@ textarea {
 
 .badge-info {
   background: var(--color-info-bg);
-  color: var(--color-info);
+  color: var(--color-info-fg);
 }
 
 /* 動畫 */

--- a/quiz-app/src/styles/semantic-token-usage.test.ts
+++ b/quiz-app/src/styles/semantic-token-usage.test.ts
@@ -1,8 +1,14 @@
-// #109 守門：掃描所有 CSS，color:/border* 屬性不得使用「裸」--color-success/error。
-// 這類前景/邊界用途必須走 role token（--color-*-fg），否則會像 QuizPage abort button 那樣
-// 漏掉 role-token migration、在多個 theme/CVD 組合低於 4.5:1，而 palette 對比測試又抓不到
-// （因為它驗的是 token 值、不是「哪個 selector 用了哪個 token」）。
-// 裝飾用途（background:/box-shadow: 的 bar、色條）允許裸 token —— 它們沒有文字對比需求。
+// #109/#112 守門：掃描所有 CSS，禁止把「裸」base 語意 token（--color-success/error/info/warning）
+// 用在**非明確允許**的地方。前景/邊界（color/border）用裸 base 會低於 4.5:1（如 QuizPage abort
+// button 曾漏 migrate）；而裸 base 當**實填背景**（background: var(--color-success); color: white）
+// 也正是 #109 的原始缺陷（base 不是白字安全色，那是 -solid 的職責）。
+//
+// 因此改成「預設禁止、白名單放行」：只有明確列出的裝飾用途（histogram bar、breakdown bar、
+// CVD 預覽色條）可以用裸 base token，其餘一律 fail。
+//
+// 解析方式：不用逐行 regex（單行 rule `.foo { color: var(--color-error); }` 與跨行 shorthand 都會
+// 漏抓），改用「大括號深度」宣告解析器 —— 逐字掃、追蹤 { } 巢狀（含 @media/@keyframes）、以 ; 與 }
+// 切出每一條宣告並記其 selector。零相依（postcss 不在 dependency 內）。
 import { describe, it, expect } from 'vitest';
 import { readdirSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
@@ -16,26 +22,85 @@ function collectCss(dir: string, out: string[] = []): string[] {
   return out;
 }
 
-describe('語意 token 用法掃描（a11y #109）', () => {
-  it('color/border 屬性不得使用裸 --color-success/error/info/warning（必須用 --color-*-fg）', () => {
-    // 裸 token：var(--color-success) 或 var(--color-success, fallback)，但**不含** -fg/-solid/-bg
-    const bareToken = /var\(\s*--color-(?:success|error|info|warning)\s*(?:,|\))/;
-    const fgBorderProp =
-      /^\s*(?:color|border|border-color|border-top|border-right|border-bottom|border-left|border-left-color|border-right-color|border-top-color|border-bottom-color|outline|outline-color)\s*:/;
+interface Decl {
+  selector: string;
+  prop: string;
+  value: string;
+  line: number;
+}
+
+/**
+ * 大括號深度解析：回傳每條宣告的 { selector, prop, value, line }。
+ * - selector：最內層（排除 @media/@supports 等 at-rule prelude）之 selector 路徑（以空白 join）。
+ * - 正確處理單行多宣告、跨行 shorthand、@media/@keyframes 巢狀。
+ */
+function parseDeclarations(css: string): Decl[] {
+  const src = css.replace(/\/\*[\s\S]*?\*\//g, ''); // 去註解
+  const decls: Decl[] = [];
+  const stack: string[] = [];
+  let buf = '';
+  let line = 1;
+  const flush = (): void => {
+    const s = buf.trim();
+    buf = '';
+    if (!s) return;
+    const ci = s.indexOf(':');
+    if (ci === -1) return; // 非宣告
+    const prop = s.slice(0, ci).trim().toLowerCase();
+    const value = s.slice(ci + 1).trim();
+    if (!prop) return;
+    const selector = stack.filter((x) => !x.startsWith('@')).join(' ');
+    decls.push({ selector, prop, value, line });
+  };
+  for (let i = 0; i < src.length; i++) {
+    const ch = src[i];
+    if (ch === '\n') line++;
+    if (ch === '{') {
+      stack.push(buf.trim());
+      buf = '';
+    } else if (ch === '}') {
+      flush(); // 收尾無分號的最後一條
+      stack.pop();
+    } else if (ch === ';') {
+      flush();
+    } else {
+      buf += ch;
+    }
+  }
+  return decls;
+}
+
+// 裸 base token：var(--color-success) 或 var(--color-success, fallback)，**不含** -fg/-solid/-bg/-score/-on
+const BARE_BASE = /var\(\s*--color-(?:success|error|info|warning)\s*(?:,|\))/;
+
+// 白名單：唯一允許用裸 base token 的裝飾用途（selector 片段 + 屬性）。其餘一律禁止。
+// 這些是純色塊/色條，其上沒有文字對比需求。
+const ALLOW: { sel: string; prop: string }[] = [
+  { sel: 'pool-histogram__bar', prop: 'background' }, // 抽題分布長條
+  { sel: 'source-breakdown__bar', prop: 'background' }, // 來源占比長條
+  { sel: 'cvd-preview__chip--correct', prop: 'box-shadow' }, // CVD 預覽左側實色條
+  { sel: 'cvd-preview__chip--incorrect', prop: 'box-shadow' },
+];
+
+describe('語意 token 用法掃描（a11y #109/#112）', () => {
+  it('裸 --color-success/error/info/warning 只能用於白名單裝飾用途，其餘一律禁止', () => {
     const violations: string[] = [];
     for (const file of collectCss(join(process.cwd(), 'src'))) {
       const rel = file.slice(file.indexOf('src')).replace(/\\/g, '/');
-      readFileSync(file, 'utf8')
-        .split('\n')
-        .forEach((line, idx) => {
-          if (fgBorderProp.test(line) && bareToken.test(line)) {
-            violations.push(`${rel}:${idx + 1}  ${line.trim()}`);
-          }
-        });
+      for (const d of parseDeclarations(readFileSync(file, 'utf8'))) {
+        if (!BARE_BASE.test(d.value)) continue;
+        const allowed = ALLOW.some(
+          (a) => d.selector.includes(a.sel) && d.prop === a.prop
+        );
+        if (!allowed) {
+          violations.push(`${rel}:${d.line}  {${d.selector}} ${d.prop}: ${d.value}`);
+        }
+      }
     }
     expect(
       violations,
-      `以下把「裸」語意 token 當文字/邊界色，應改用 --color-*-fg：\n${violations.join('\n')}`
+      `以下用了「裸」base 語意 token 但不在裝飾白名單內。` +
+        `前景/邊界請改 --color-*-fg；實填背景請改 --color-*-solid（＋on-color）：\n${violations.join('\n')}`
     ).toEqual([]);
   });
 });

--- a/quiz-app/src/styles/semantic-token-usage.test.ts
+++ b/quiz-app/src/styles/semantic-token-usage.test.ts
@@ -52,9 +52,36 @@ function parseDeclarations(css: string): Decl[] {
     const selector = stack.filter((x) => !x.startsWith('@')).join(' ');
     decls.push({ selector, prop, value, line });
   };
+  let str: string | null = null; // 目前所在字串的引號字元（' 或 "）
+  let paren = 0; // 括號深度（url()/rgb() 等）
   for (let i = 0; i < src.length; i++) {
     const ch = src[i];
     if (ch === '\n') line++;
+    // 字串內：一切照字面收集，直到未跳脫的同款引號（含 data-URI 內的 ; { }）
+    if (str !== null) {
+      buf += ch;
+      if (ch === str && src[i - 1] !== '\\') str = null;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      str = ch;
+      buf += ch;
+      continue;
+    }
+    if (ch === '(') {
+      paren++;
+      buf += ch;
+      continue;
+    }
+    if (ch === ')') {
+      if (paren > 0) paren--;
+      buf += ch;
+      continue;
+    }
+    if (paren > 0) {
+      buf += ch; // 括號內的 ; { } 當字面（未加引號的 data-URI 等）
+      continue;
+    }
     if (ch === '{') {
       stack.push(buf.trim());
       buf = '';
@@ -73,14 +100,23 @@ function parseDeclarations(css: string): Decl[] {
 // 裸 base token：var(--color-success) 或 var(--color-success, fallback)，**不含** -fg/-solid/-bg/-score/-on
 const BARE_BASE = /var\(\s*--color-(?:success|error|info|warning)\s*(?:,|\))/;
 
-// 白名單：唯一允許用裸 base token 的裝飾用途（selector 片段 + 屬性）。其餘一律禁止。
-// 這些是純色塊/色條，其上沒有文字對比需求。
-const ALLOW: { sel: string; prop: string }[] = [
-  { sel: 'pool-histogram__bar', prop: 'background' }, // 抽題分布長條
-  { sel: 'source-breakdown__bar', prop: 'background' }, // 來源占比長條
-  { sel: 'cvd-preview__chip--correct', prop: 'box-shadow' }, // CVD 預覽左側實色條
-  { sel: 'cvd-preview__chip--incorrect', prop: 'box-shadow' },
+// 白名單：唯一允許裸 base token 的裝飾用途，以「檔名 + 精確 selector + 屬性」比對（非 substring）。
+// substring 會誤放行 .pool-histogram__bar-track（含 'bar' 前綴），或同組其他 selector
+// （如 `.pool-histogram__bar, .danger { background: var(--color-success) }` 整組被放行）。
+const ALLOW: { file: string; selector: string; prop: string }[] = [
+  { file: 'PracticePoolHistogram.css', selector: '.pool-histogram__row--main .pool-histogram__bar', prop: 'background' },
+  { file: 'PracticePoolHistogram.css', selector: '.pool-histogram__row--mock .pool-histogram__bar', prop: 'background' },
+  { file: 'PracticePoolHistogram.css', selector: '.pool-histogram__row--ai .pool-histogram__bar', prop: 'background' },
+  { file: 'SourceBreakdown.css', selector: '.source-breakdown__row--main .source-breakdown__bar', prop: 'background' },
+  { file: 'SourceBreakdown.css', selector: '.source-breakdown__row--mock .source-breakdown__bar', prop: 'background' },
+  { file: 'SourceBreakdown.css', selector: '.source-breakdown__row--ai .source-breakdown__bar', prop: 'background' },
+  { file: 'SourceBreakdown.css', selector: '.source-breakdown__row--low .source-breakdown__bar', prop: 'background' },
+  // CVD 預覽左側實色條（#112 仍吃裸 base；#113/#114 會改 -fg 後移除這兩條）
+  { file: 'SettingsPage.css', selector: '.cvd-preview__chip--correct', prop: 'box-shadow' },
+  { file: 'SettingsPage.css', selector: '.cvd-preview__chip--incorrect', prop: 'box-shadow' },
 ];
+
+const normSel = (s: string): string => s.replace(/\s+/g, ' ').trim();
 
 describe('語意 token 用法掃描（a11y #109/#112）', () => {
   it('裸 --color-success/error/info/warning 只能用於白名單裝飾用途，其餘一律禁止', () => {
@@ -90,7 +126,10 @@ describe('語意 token 用法掃描（a11y #109/#112）', () => {
       for (const d of parseDeclarations(readFileSync(file, 'utf8'))) {
         if (!BARE_BASE.test(d.value)) continue;
         const allowed = ALLOW.some(
-          (a) => d.selector.includes(a.sel) && d.prop === a.prop
+          (a) =>
+            rel.endsWith('/' + a.file) &&
+            normSel(d.selector) === a.selector &&
+            d.prop === a.prop
         );
         if (!allowed) {
           violations.push(`${rel}:${d.line}  {${d.selector}} ${d.prop}: ${d.value}`);

--- a/quiz-app/src/styles/semantic-token-usage.test.ts
+++ b/quiz-app/src/styles/semantic-token-usage.test.ts
@@ -17,9 +17,9 @@ function collectCss(dir: string, out: string[] = []): string[] {
 }
 
 describe('語意 token 用法掃描（a11y #109）', () => {
-  it('color/border 屬性不得使用裸 --color-success/error（必須用 --color-*-fg）', () => {
+  it('color/border 屬性不得使用裸 --color-success/error/info/warning（必須用 --color-*-fg）', () => {
     // 裸 token：var(--color-success) 或 var(--color-success, fallback)，但**不含** -fg/-solid/-bg
-    const bareToken = /var\(\s*--color-(?:success|error)\s*(?:,|\))/;
+    const bareToken = /var\(\s*--color-(?:success|error|info|warning)\s*(?:,|\))/;
     const fgBorderProp =
       /^\s*(?:color|border|border-color|border-top|border-right|border-bottom|border-left|border-left-color|border-right-color|border-top-color|border-bottom-color|outline|outline-color)\s*:/;
     const violations: string[] = [];

--- a/quiz-app/src/styles/variables.css
+++ b/quiz-app/src/styles/variables.css
@@ -56,6 +56,17 @@
   --color-info: #2196f3;
   --color-info-bg: rgba(33, 150, 243, 0.12);
 
+  /* info / warning 的 role-based token（a11y #111，比照 success/error）。info/warning 不受 CVD
+     模式重映，故只有 light/dark、無 CVD 變體。值已用 WCAG 對「真實 fg/bg 對」驗過。 */
+  --color-info-fg: #0d47a1;
+  --color-info-solid: #1565c0;
+  --color-on-info: #ffffff;
+  --color-info-score: linear-gradient(135deg, #e3f2fd 0%, #e8eaf6 100%);
+  --color-warning-fg: #8f5700;
+  --color-warning-solid: #bf5000;
+  --color-on-warning: #ffffff;
+  --color-warning-score: linear-gradient(135deg, #fff8e1 0%, #fffde7 100%);
+
   /* 中性色 */
   --neutral-0: #000000;
   --neutral-10: #1c1b1f;
@@ -139,6 +150,10 @@
   /* 分數卡漸層換深底 —— 原本固定淺底會與深色主題的亮 -fg 撞成 <2:1 低對比 */
   --color-success-score: linear-gradient(135deg, #12281a 0%, #16301f 100%);
   --color-error-score: linear-gradient(135deg, #2a1416 0%, #301a1e 100%);
+  --color-info-fg: #64b5f6;
+  --color-warning-fg: #ffb74d;
+  --color-info-score: linear-gradient(135deg, #0d2137 0%, #12263a 100%);
+  --color-warning-score: linear-gradient(135deg, #2a2010 0%, #302615 100%);
 
   --color-background: #121212;
   --color-surface: #1e1e1e;

--- a/quiz-app/tests/e2e/a11y-contrast.spec.ts
+++ b/quiz-app/tests/e2e/a11y-contrast.spec.ts
@@ -87,6 +87,16 @@ test('語意 token：每個真實 fg/bg 配對跨 16 組（theme×CVD×HC）達 
             errorBg: read('--color-error-bg'),
             successScore: read('--color-success-score'),
             errorScore: read('--color-error-score'),
+            infoFg: read('--color-info-fg'),
+            warningFg: read('--color-warning-fg'),
+            infoSolid: read('--color-info-solid'),
+            warningSolid: read('--color-warning-solid'),
+            onInfo: read('--color-on-info'),
+            onWarning: read('--color-on-warning'),
+            infoBg: read('--color-info-bg'),
+            warningBg: read('--color-warning-bg'),
+            infoScore: read('--color-info-score'),
+            warningScore: read('--color-warning-score'),
           });
         }
       }
@@ -103,56 +113,40 @@ test('語意 token：每個真實 fg/bg 配對跨 16 組（theme×CVD×HC）達 
     const surf = parseColor(c.surface, `${c.mode} surface`);
     const surfV = parseColor(c.surfaceVariant, `${c.mode} surface-variant`);
     const bg = parseColor(c.background, `${c.mode} background`);
-    const sFg = parseColor(c.successFg, `${c.mode} success-fg`);
-    const eFg = parseColor(c.errorFg, `${c.mode} error-fg`);
-    const sSol = parseColor(c.successSolid, `${c.mode} success-solid`);
-    const eSol = parseColor(c.errorSolid, `${c.mode} error-solid`);
-    const onS = parseColor(c.onSuccess, `${c.mode} on-success`);
-    const onE = parseColor(c.onError, `${c.mode} on-error`);
-    const sTint = alphaOver(c.successBg, surf, `${c.mode} success-bg`);
-    const eTint = alphaOver(c.errorBg, surf, `${c.mode} error-bg`);
-    // tint 也可能疊在「page background」上（如首頁 .badge-success 的 ancestor 皆透明），
-    // 那比疊在白 surface 上對比更低 —— 一定要驗這一種，否則會像上一版誤綠。
-    const sTintPage = alphaOver(c.successBg, bg, `${c.mode} success-bg/page`);
-    const eTintPage = alphaOver(c.errorBg, bg, `${c.mode} error-bg/page`);
-    const sScore = gradientStops(c.successScore, `${c.mode} success-score`);
-    const eScore = gradientStops(c.errorScore, `${c.mode} error-score`);
 
-    // -fg 文字放在所有可能背景上 >= 4.5:1
-    const successBgs: [number[], string][] = [
-      [surf, 'surface'],
-      [surfV, 'surface-variant'],
-      [bg, 'page-background'],
-      [sTint, 'success-tint'],
-      [sTintPage, 'success-tint-over-page'],
-      ...sScore.map((g, i): [number[], string] => [g, `success-score#${i}`]),
+    // 四個語意角色一起驗（success/error 受 CVD 影響；info/warning 不受、值在各 CVD 相同、
+    // 無害地重複驗）。每個角色的 -fg 文字要在 surface、surface-variant、page-background、
+    // tint 疊 surface、tint 疊 page-background、以及 score 漸層端點上都 >= 4.5:1；
+    // on-color 白字放在 -solid 上也 >= 4.5:1。
+    const roles = [
+      { name: 'success', fg: c.successFg, solid: c.successSolid, on: c.onSuccess, tintBg: c.successBg, score: c.successScore },
+      { name: 'error', fg: c.errorFg, solid: c.errorSolid, on: c.onError, tintBg: c.errorBg, score: c.errorScore },
+      { name: 'info', fg: c.infoFg, solid: c.infoSolid, on: c.onInfo, tintBg: c.infoBg, score: c.infoScore },
+      { name: 'warning', fg: c.warningFg, solid: c.warningSolid, on: c.onWarning, tintBg: c.warningBg, score: c.warningScore },
     ];
-    for (const [b, name] of successBgs) {
+    for (const r of roles) {
+      const fg = parseColor(r.fg, `${c.mode} ${r.name}-fg`);
+      const sol = parseColor(r.solid, `${c.mode} ${r.name}-solid`);
+      const on = parseColor(r.on, `${c.mode} on-${r.name}`);
+      const bgs: [number[], string][] = [
+        [surf, 'surface'],
+        [surfV, 'surface-variant'],
+        [bg, 'page-background'],
+        [alphaOver(r.tintBg, surf, `${c.mode} ${r.name}-bg`), 'tint'],
+        [alphaOver(r.tintBg, bg, `${c.mode} ${r.name}-bg/page`), 'tint-over-page'],
+        ...gradientStops(r.score, `${c.mode} ${r.name}-score`).map(
+          (g, i): [number[], string] => [g, `score#${i}`]
+        ),
+      ];
+      for (const [b, name] of bgs) {
+        expect
+          .soft(contrast(fg, b), `${c.mode} ${r.name}-fg on ${name}`)
+          .toBeGreaterThanOrEqual(4.5);
+      }
       expect
-        .soft(contrast(sFg, b), `${c.mode} success-fg on ${name}`)
+        .soft(contrast(on, sol), `${c.mode} on-${r.name} on ${r.name}-solid`)
         .toBeGreaterThanOrEqual(4.5);
     }
-    const errorBgs: [number[], string][] = [
-      [surf, 'surface'],
-      [surfV, 'surface-variant'],
-      [bg, 'page-background'],
-      [eTint, 'error-tint'],
-      [eTintPage, 'error-tint-over-page'],
-      ...eScore.map((g, i): [number[], string] => [g, `error-score#${i}`]),
-    ];
-    for (const [b, name] of errorBgs) {
-      expect
-        .soft(contrast(eFg, b), `${c.mode} error-fg on ${name}`)
-        .toBeGreaterThanOrEqual(4.5);
-    }
-
-    // 徽章/標頭：on-color 白字放在 -solid 實填上 >= 4.5:1
-    expect
-      .soft(contrast(onS, sSol), `${c.mode} on-success on success-solid`)
-      .toBeGreaterThanOrEqual(4.5);
-    expect
-      .soft(contrast(onE, eSol), `${c.mode} on-error on error-solid`)
-      .toBeGreaterThanOrEqual(4.5);
   }
 });
 

--- a/quiz-app/tests/e2e/a11y-contrast.spec.ts
+++ b/quiz-app/tests/e2e/a11y-contrast.spec.ts
@@ -23,17 +23,28 @@ function contrast(a: number[], b: number[]): number {
   const lb = relLum(b);
   return (Math.max(la, lb) + 0.05) / (Math.min(la, lb) + 0.05);
 }
-/** fail-closed：缺值或無法解析直接丟錯，不回黑色 */
+/** fail-closed：缺值/無法解析/**帶 alpha（非不透明）**一律丟錯 —— 不把 rgba(0,0,0,.01)
+ * 靜默當成不透明黑、也不把含 alpha 的 hex 當不透明。本函式只用於「應為不透明」的色
+ * （surface/fg/solid/on/gradient stop）；帶 alpha 的 tint 走 alphaOver 做合成。 */
 function parseColor(s: string, label: string): number[] {
   const t = (s ?? '').trim();
   if (!t) throw new Error(`Missing color token: ${label}`);
-  if (/^#[0-9a-fA-F]{6}$/.test(t)) {
-    return [1, 3, 5].map((i) => parseInt(t.slice(i, i + 2), 16));
+  const hex = t.match(/^#([0-9a-fA-F]+)$/);
+  if (hex) {
+    const h = hex[1];
+    if (h.length === 6) return [0, 2, 4].map((i) => parseInt(h.slice(i, i + 2), 16));
+    if (h.length === 3) return [0, 1, 2].map((i) => parseInt(h[i] + h[i], 16));
+    // 4 / 8 碼 hex 含 alpha → fail-closed
+    throw new Error(`Non-opaque or invalid hex for ${label}: "${t}"`);
   }
-  const m = t.match(/rgba?\(([^)]+)\)/);
+  const m = t.match(/^rgba?\(\s*([^)]+)\)$/i);
   if (m) {
     const p = m[1].split(',').map((x) => parseFloat(x));
     if (p.length >= 3 && p.slice(0, 3).every((n) => Number.isFinite(n))) {
+      const a = p.length >= 4 ? p[3] : 1;
+      if (a !== 1) {
+        throw new Error(`Non-opaque color where opaque expected for ${label}: "${t}"`);
+      }
       return [p[0], p[1], p[2]];
     }
   }
@@ -47,13 +58,47 @@ function alphaOver(rgba: string, bg: number[], label: string): number[] {
   const a = p.length >= 4 ? p[3] : 1;
   return [p[0], p[1], p[2]].map((c, i) => Math.round(a * c + (1 - a) * bg[i]));
 }
-/** 從 gradient 字串抽出所有 hex endpoint */
-function gradientStops(g: string, label: string): number[][] {
-  const hexes = (g ?? '').match(/#[0-9a-fA-F]{6}/g);
-  if (!hexes || hexes.length === 0) {
-    throw new Error(`No color stops in gradient for ${label}: "${g}"`);
+/** 逗號切分但尊重 rgb()/hsl() 內層括號（供 gradient stop 解析） */
+function splitTopLevel(str: string): string[] {
+  const out: string[] = [];
+  let depth = 0;
+  let cur = '';
+  for (const ch of str) {
+    if (ch === '(') depth++;
+    else if (ch === ')') depth--;
+    if (ch === ',' && depth === 0) {
+      out.push(cur);
+      cur = '';
+    } else {
+      cur += ch;
+    }
   }
-  return hexes.map((h) => [1, 3, 5].map((i) => parseInt(h.slice(i, i + 2), 16)));
+  if (cur.trim()) out.push(cur);
+  return out;
+}
+
+/** 從 gradient 抽出**所有** color stop（不只 hex）。每個 stop 走 fail-closed parseColor：
+ * 帶 alpha 的 stop 會丟錯而非被忽略；無法解析的 segment（如具名色）也丟錯 —— 符合 fail-closed
+ * 宣稱，不會靜默漏掉某個低對比 stop。第一段若無顏色視為方向（135deg / to right）。 */
+function gradientStops(g: string, label: string): number[][] {
+  const s = (g ?? '').trim();
+  const m = s.match(/^(?:repeating-)?(?:linear|radial|conic)-gradient\(([\s\S]*)\)$/i);
+  if (!m) throw new Error(`Not a gradient for ${label}: "${s}"`);
+  const stops: number[][] = [];
+  for (const seg of splitTopLevel(m[1])) {
+    const t = seg.trim();
+    if (!t) continue;
+    const cm = t.match(/^(#[0-9a-fA-F]{3,8}|(?:rgb|rgba|hsl|hsla)\([^)]*\))/i);
+    if (!cm) {
+      if (stops.length === 0) continue; // 方向段（如 135deg），非顏色
+      throw new Error(`Gradient segment without parseable color for ${label}: "${t}"`);
+    }
+    stops.push(parseColor(cm[1], `${label} stop "${cm[1]}"`));
+  }
+  if (stops.length < 2) {
+    throw new Error(`Expected >= 2 color stops in gradient for ${label}: "${s}"`);
+  }
+  return stops;
 }
 
 test('語意 token：每個真實 fg/bg 配對跨 16 組（theme×CVD×HC）達 WCAG AA（#109）', async ({

--- a/quiz-app/tests/e2e/option-key-cascade.spec.ts
+++ b/quiz-app/tests/e2e/option-key-cascade.spec.ts
@@ -1,0 +1,131 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * #110/#112 回歸守門（rendered cascade）：被使用者「選中」的正解 / 選錯選項，其 .option-key 的
+ * 背景必須是 --color-success-solid / --color-error-solid（白字安全實填）＋ on-color 文字，
+ * 而**不是** :checked 選中態的 --color-primary。
+ *
+ * 為何非得 rendered：這是 selector 特異性的勝負問題 ——
+ *   `.option-item input:checked + .option-key`（0,4,1，選中態=primary）
+ *   會蓋過 `.option-item.correct .option-key`（0,3,0，success-solid）；
+ * #110 靠再加 `.option-item.correct input:checked + .option-key`（0,5,1）才把正解/選錯搶回來。
+ * token 值測試與 source-scan 都驗不到「某狀態下實際勝出的是哪條規則」；日後有人動特異性、
+ * 只有這條 computed 斷言會轉紅。
+ *
+ * teeth：深色主題下 --color-primary(#81c784) ≠ success-solid(#2e7d32)，且 error-solid ≠ primary
+ * （兩主題皆是）—— 移除 #110 的覆寫規則後，選中 key 會退回 primary，本測即失敗。
+ * -solid 是不透明色，computed backgroundColor 可直接比對、無 tint alpha 合成的脆弱性。
+ *
+ * 用與 OptionButton 實際輸出同構的 replica（input 緊鄰 .option-key，相鄰選擇器 `+` 才成立），
+ * 注入到「已載入 QuestionCard.css 的題目畫面」後讀 computed style —— 命中的是真實 CSS 規則。
+ */
+
+const REPLICA = `
+  <div id="cascade-probe">
+    <label class="option-item correct"><input type="radio" checked /><span class="option-key">A</span></label>
+    <label class="option-item incorrect"><input type="radio" checked /><span class="option-key">B</span></label>
+  </div>`;
+
+function toRgb(s: string): number[] {
+  const t = s.trim();
+  const h6 = t.match(/^#([0-9a-fA-F]{6})$/);
+  if (h6) return [0, 2, 4].map((i) => parseInt(h6[1].slice(i, i + 2), 16));
+  const h3 = t.match(/^#([0-9a-fA-F]{3})$/);
+  if (h3) return [0, 1, 2].map((i) => parseInt(h3[1][i] + h3[1][i], 16));
+  const m = t.match(/-?\d+(?:\.\d+)?/g);
+  if (!m || m.length < 3) throw new Error(`can't parse color: "${s}"`);
+  return [Number(m[0]), Number(m[1]), Number(m[2])];
+}
+function relLum([r, g, b]: number[]): number {
+  const lin = (c: number): number => {
+    const v = c / 255;
+    return v <= 0.03928 ? v / 12.92 : Math.pow((v + 0.055) / 1.055, 2.4);
+  };
+  return 0.2126 * lin(r) + 0.7152 * lin(g) + 0.0722 * lin(b);
+}
+function contrast(a: number[], b: number[]): number {
+  const la = relLum(a);
+  const lb = relLum(b);
+  return (Math.max(la, lb) + 0.05) / (Math.min(la, lb) + 0.05);
+}
+const sameColor = (a: string, b: string): boolean =>
+  JSON.stringify(toRgb(a)) === JSON.stringify(toRgb(b));
+
+test('選中的正解/選錯 key 用 -solid 底 + on-color，勝過 :checked 選中態（#110 rendered，light+dark）', async ({
+  page,
+}) => {
+  await page.addInitScript(() =>
+    window.localStorage.setItem('practice-pool-disclosure-seen', '1')
+  );
+  await page.goto('/');
+  // 進到題目畫面 → 確保 QuestionCard.css 已載入（precondition：真的有 .option-item 被渲染）
+  await page.getByRole('button', { name: /開始測驗/i }).click();
+  await expect(page.locator('.question-card')).toBeVisible();
+
+  for (const theme of ['light', 'dark'] as const) {
+    const probe = await page.evaluate(
+      ({ html, theme }) => {
+        const root = document.documentElement;
+        const prevTheme = root.getAttribute('data-theme');
+        root.setAttribute('data-theme', theme);
+        const host = document.createElement('div');
+        host.innerHTML = html;
+        document.body.appendChild(host);
+        const read = (sel: string) => {
+          const el = host.querySelector(sel) as HTMLElement;
+          const cs = getComputedStyle(el);
+          return { bg: cs.backgroundColor, color: cs.color };
+        };
+        const out = {
+          correct: read('.option-item.correct .option-key'),
+          incorrect: read('.option-item.incorrect .option-key'),
+          successSolid: getComputedStyle(root)
+            .getPropertyValue('--color-success-solid')
+            .trim(),
+          errorSolid: getComputedStyle(root)
+            .getPropertyValue('--color-error-solid')
+            .trim(),
+          onSuccess: getComputedStyle(root)
+            .getPropertyValue('--color-on-success')
+            .trim(),
+          onError: getComputedStyle(root)
+            .getPropertyValue('--color-on-error')
+            .trim(),
+        };
+        host.remove();
+        if (prevTheme === null) root.removeAttribute('data-theme');
+        else root.setAttribute('data-theme', prevTheme);
+        return out;
+      },
+      { html: REPLICA, theme }
+    );
+
+    // 正解 + 選中：底 = success-solid（非 primary 選中態），字 = on-success，對比達 AA
+    expect(
+      sameColor(probe.correct.bg, probe.successSolid),
+      `${theme}: 正解選中 key 底應=success-solid，實得 bg=${probe.correct.bg} / solid=${probe.successSolid}`
+    ).toBe(true);
+    expect(
+      sameColor(probe.correct.color, probe.onSuccess),
+      `${theme}: 正解選中 key 字應=on-success，實得 ${probe.correct.color}`
+    ).toBe(true);
+    expect(
+      contrast(toRgb(probe.correct.color), toRgb(probe.correct.bg)),
+      `${theme}: 正解選中 key 對比`
+    ).toBeGreaterThanOrEqual(4.5);
+
+    // 選錯 + 選中：底 = error-solid，字 = on-error，對比達 AA
+    expect(
+      sameColor(probe.incorrect.bg, probe.errorSolid),
+      `${theme}: 選錯選中 key 底應=error-solid，實得 bg=${probe.incorrect.bg} / solid=${probe.errorSolid}`
+    ).toBe(true);
+    expect(
+      sameColor(probe.incorrect.color, probe.onError),
+      `${theme}: 選錯選中 key 字應=on-error，實得 ${probe.incorrect.color}`
+    ).toBe(true);
+    expect(
+      contrast(toRgb(probe.incorrect.color), toRgb(probe.incorrect.bg)),
+      `${theme}: 選錯選中 key 對比`
+    ).toBeGreaterThanOrEqual(4.5);
+  }
+});


### PR DESCRIPTION
## 背景（#111）

延續 #110 對 success/error 的 role-based token；把 **info/warning** 也一起拆，並修 review 附帶抓到的 4 個**既有**對比失敗（非 #110 引入）：

| 元件 | 修前 | 修後（rendered 實測 light） |
|---|---|---|
| `.badge-info`（藍字疊藍 tint） | 2.58 | **7.11** |
| `.badge-warning`（橘字疊橘 tint） | 1.84 | **5.08** |
| `.score-section.excellent` 評語/icon | 2.55 / 1.53 | **5.60** |
| `.score-section.pass` 評語 | 2.61 | **7.21** |
| 練習池停用 icon（白疊橘）、btn-bank hover（白疊藍） | ~1.9 / ~2.3 | on-color 修正 |

## 做法（比照 #110）
- `variables.css`：新增 `--color-info-fg/-solid/-on/-score`、`--color-warning-fg/-solid/-on/-score`（light/dark；info/warning 不受 CVD 影響 → 無 CVD 變體）。
- 各 CSS：text/icon/border → `-fg`；徽章/實填 icon → `-solid` + `-on-*`；`.excellent` → warning-fg + theme-aware warning-score 漸層；`.pass` → info-fg + info-score。

## 守門
- **source-scan 單元測試擴及 info/warning** —— `color:`/`border:` 用裸 `--color-info/warning` 直接 fail。
- **a11y-contrast e2e 重構成四角色一起驗**：success/error/info/warning × 16 組（theme×CVD×HC）× 所有真實背景（surface/tint/tint-over-page/surface-variant/page-bg/score 漸層）+ on-color 對 solid。

## 驗證
離線 palette 0 失敗；e2e 四角色全過；rendered 實測（見上表）全 ≥ 4.5。全庫 **797 unit 綠**、build 綠。

Closes #111
