### PR TITLE
a11y #113：分數卡漸層由 tint 衍生（CVD 一致）+ Settings 預覽改用 role token

### DIFF
--- a/quiz-app/src/pages/SettingsPage.css
+++ b/quiz-app/src/pages/SettingsPage.css
@@ -168,8 +168,8 @@
   flex-wrap: wrap;
 }
 
-/* 作答回饋色即時預覽：chip 直接吃 --color-success / --color-error，
-   而 [data-cvd-mode] 覆寫的正是這兩個變數，故切換色覺模式時 chip 會即時換色。 */
+/* 作答回饋色即時預覽：chip 吃 role token（tint 底 --color-*-bg + 左側 --color-*-fg 實色條），
+   與真實選項回饋同源；[data-cvd-mode] 會 remap 這些變數，故切換色覺模式時 chip 即時換色。 */
 .cvd-preview {
   display: flex;
   align-items: center;
@@ -205,12 +205,12 @@
 
 .cvd-preview__chip--correct {
   background: var(--color-success-bg);
-  box-shadow: inset 4px 0 0 var(--color-success);
+  box-shadow: inset 4px 0 0 var(--color-success-fg);
 }
 
 .cvd-preview__chip--incorrect {
   background: var(--color-error-bg);
-  box-shadow: inset 4px 0 0 var(--color-error);
+  box-shadow: inset 4px 0 0 var(--color-error-fg);
 }
 
 /* 關於區塊 */

--- a/quiz-app/src/pages/SettingsPage.tsx
+++ b/quiz-app/src/pages/SettingsPage.tsx
@@ -166,8 +166,8 @@ export function SettingsPage({ accessibility, onClose }: SettingsPageProps) {
               <option value="tritanopia">藍色盲 (Tritanopia)</option>
             </select>
           </div>
-          {/* 即時預覽：作答對/錯的回饋色會隨模式即時換色（chip 直接吃 --color-success/
-              --color-error，而 CVD 模式覆寫的正是這兩個變數）—— 讓使用者切換當下就看到效果。
+          {/* 即時預覽：作答對/錯的回饋色會隨模式即時換色（chip 吃 role token --color-*-bg/-fg，
+              與真實選項回饋同源，CVD 模式會 remap 這些變數）—— 讓使用者切換當下就看到效果。
               附 icon + 文字，不靠顏色單一管道（符合無障礙本意）。 */}
           <div className="cvd-preview" data-testid="cvd-preview">
             <span className="cvd-preview__label">作答回饋色預覽</span>

--- a/quiz-app/src/styles/semantic-token-usage.test.ts
+++ b/quiz-app/src/styles/semantic-token-usage.test.ts
@@ -103,6 +103,7 @@ const BARE_BASE = /var\(\s*--color-(?:success|error|info|warning)\s*(?:,|\))/;
 // 白名單：唯一允許裸 base token 的裝飾用途，以「檔名 + 精確 selector + 屬性」比對（非 substring）。
 // substring 會誤放行 .pool-histogram__bar-track（含 'bar' 前綴），或同組其他 selector
 // （如 `.pool-histogram__bar, .danger { background: var(--color-success) }` 整組被放行）。
+// 註：CVD 預覽色條已在本 PR 改吃 --color-*-fg（非裸 base），故不再需要白名單豁免。
 const ALLOW: { file: string; selector: string; prop: string }[] = [
   { file: 'PracticePoolHistogram.css', selector: '.pool-histogram__row--main .pool-histogram__bar', prop: 'background' },
   { file: 'PracticePoolHistogram.css', selector: '.pool-histogram__row--mock .pool-histogram__bar', prop: 'background' },
@@ -111,9 +112,6 @@ const ALLOW: { file: string; selector: string; prop: string }[] = [
   { file: 'SourceBreakdown.css', selector: '.source-breakdown__row--mock .source-breakdown__bar', prop: 'background' },
   { file: 'SourceBreakdown.css', selector: '.source-breakdown__row--ai .source-breakdown__bar', prop: 'background' },
   { file: 'SourceBreakdown.css', selector: '.source-breakdown__row--low .source-breakdown__bar', prop: 'background' },
-  // CVD 預覽左側實色條（#112 仍吃裸 base；#113/#114 會改 -fg 後移除這兩條）
-  { file: 'SettingsPage.css', selector: '.cvd-preview__chip--correct', prop: 'box-shadow' },
-  { file: 'SettingsPage.css', selector: '.cvd-preview__chip--incorrect', prop: 'box-shadow' },
 ];
 
 const normSel = (s: string): string => s.replace(/\s+/g, ' ').trim();

--- a/quiz-app/src/styles/variables.css
+++ b/quiz-app/src/styles/variables.css
@@ -41,7 +41,10 @@
      - -solid：白字安全的深色實填（徽章底）；其上的文字/icon 用 --color-on-success/-error（純白）。
      - -fg：文字/icon/邊界前景，淺色/深色各自定義（deut 的 fg 比 solid 更深 —— 要在 tint、
        surface-variant、page-bg、score 漸層上都達 4.5，不能只對純白 surface 驗）。
-     - -score：分數卡漸層（theme-aware，深色主題換深底），讓其上的 -fg 也達標。
+     - -score：分數卡漸層，改由 tint→surface 衍生（linear-gradient(--color-X-bg, --color-surface)）。
+       tint 與 surface 皆隨 theme/CVD 自動 remap，故分數卡背景與 tint 永遠同源、切 CVD 也一致換色
+       （根因修掉「背景不隨 CVD 換色」的漂移）；兩端點即 tint-over-page 與 surface，a11y-contrast
+       e2e 已分別驗過 -fg 對其 >= 4.5，無需再逐主題/逐 CVD 手調漸層。
      - -bg（tint）與 base --color-success/-error（裝飾 bar）維持不變。
      全部值用 WCAG 公式對「真實前景/背景對」跨 light/dark × 4 CVD 驗過（見 a11y-contrast e2e）。 */
   --color-success-solid: #2e7d32;
@@ -51,8 +54,8 @@
   --color-error-fg: #b71c1c;
   --color-on-success: #ffffff;
   --color-on-error: #ffffff;
-  --color-success-score: linear-gradient(135deg, #e8f5e9 0%, #f1f8e9 100%);
-  --color-error-score: linear-gradient(135deg, #ffebee 0%, #fce4ec 100%);
+  --color-success-score: linear-gradient(135deg, var(--color-success-bg), var(--color-surface));
+  --color-error-score: linear-gradient(135deg, var(--color-error-bg), var(--color-surface));
   --color-info: #2196f3;
   --color-info-bg: rgba(33, 150, 243, 0.12);
 
@@ -61,11 +64,11 @@
   --color-info-fg: #0d47a1;
   --color-info-solid: #1565c0;
   --color-on-info: #ffffff;
-  --color-info-score: linear-gradient(135deg, #e3f2fd 0%, #e8eaf6 100%);
+  --color-info-score: linear-gradient(135deg, var(--color-info-bg), var(--color-surface));
   --color-warning-fg: #8f5700;
   --color-warning-solid: #bf5000;
   --color-on-warning: #ffffff;
-  --color-warning-score: linear-gradient(135deg, #fff8e1 0%, #fffde7 100%);
+  --color-warning-score: linear-gradient(135deg, var(--color-warning-bg), var(--color-surface));
 
   /* 中性色 */
   --neutral-0: #000000;
@@ -144,16 +147,13 @@
   --color-primary-light: var(--primary-80);
   --color-on-primary: var(--neutral-10);
 
-  /* 深色表面上的可讀語意前景（亮色）；-solid（徽章底）維持深色，白字仍安全 */
+  /* 深色表面上的可讀語意前景（亮色）；-solid（徽章底）維持深色，白字仍安全。
+     -score 已改為 tint→surface 衍生（見 :root）；tint 與 surface 皆 theme-aware，
+     深色分數卡背景自動變深底、與亮 -fg 對比達標，故此處不需再覆寫 -score。 */
   --color-success-fg: #81c784;
   --color-error-fg: #ef9a9a;
-  /* 分數卡漸層換深底 —— 原本固定淺底會與深色主題的亮 -fg 撞成 <2:1 低對比 */
-  --color-success-score: linear-gradient(135deg, #12281a 0%, #16301f 100%);
-  --color-error-score: linear-gradient(135deg, #2a1416 0%, #301a1e 100%);
   --color-info-fg: #64b5f6;
   --color-warning-fg: #ffb74d;
-  --color-info-score: linear-gradient(135deg, #0d2137 0%, #12263a 100%);
-  --color-warning-score: linear-gradient(135deg, #2a2010 0%, #302615 100%);
 
   --color-background: #121212;
   --color-surface: #1e1e1e;

--- a/quiz-app/tests/e2e/a11y-contrast.spec.ts
+++ b/quiz-app/tests/e2e/a11y-contrast.spec.ts
@@ -77,10 +77,24 @@ function splitTopLevel(str: string): string[] {
   return out;
 }
 
-/** 從 gradient 抽出**所有** color stop（不只 hex）。每個 stop 走 fail-closed parseColor：
- * 帶 alpha 的 stop 會丟錯而非被忽略；無法解析的 segment（如具名色）也丟錯 —— 符合 fail-closed
- * 宣稱，不會靜默漏掉某個低對比 stop。第一段若無顏色視為方向（135deg / to right）。 */
-function gradientStops(g: string, label: string): number[][] {
+/** gradient 單一 stop → 不透明 rgb：半透明 stop（如衍生分數卡的 tint 端點）疊在 backdrop 上；
+ * 不透明 stop（hex / rgb / rgba a=1）走 fail-closed parseColor。 */
+function resolveStop(tok: string, backdrop: number[], label: string): number[] {
+  const m = tok.match(/^rgba?\(\s*([^)]+)\)$/i);
+  if (m) {
+    const p = m[1].split(',').map((x) => parseFloat(x));
+    const a = p.length >= 4 ? p[3] : 1;
+    if (p.length >= 3 && p.slice(0, 3).every((n) => Number.isFinite(n)) && a !== 1) {
+      return alphaOver(tok, backdrop, label); // 半透明 → 疊底
+    }
+  }
+  return parseColor(tok, label); // 不透明
+}
+
+/** 從 gradient 抽出**所有** color stop（不只 hex）。半透明 stop（衍生分數卡的 tint 端點）疊在
+ * backdrop（分數卡背後的 page-background）上再算對比；無法解析的 segment（如具名色）丟錯 ——
+ * 不靜默漏掉低對比 stop。第一段若無顏色視為方向（135deg / to right）。 */
+function gradientStops(g: string, label: string, backdrop: number[]): number[][] {
   const s = (g ?? '').trim();
   const m = s.match(/^(?:repeating-)?(?:linear|radial|conic)-gradient\(([\s\S]*)\)$/i);
   if (!m) throw new Error(`Not a gradient for ${label}: "${s}"`);
@@ -93,7 +107,7 @@ function gradientStops(g: string, label: string): number[][] {
       if (stops.length === 0) continue; // 方向段（如 135deg），非顏色
       throw new Error(`Gradient segment without parseable color for ${label}: "${t}"`);
     }
-    stops.push(parseColor(cm[1], `${label} stop "${cm[1]}"`));
+    stops.push(resolveStop(cm[1], backdrop, `${label} stop "${cm[1]}"`));
   }
   if (stops.length < 2) {
     throw new Error(`Expected >= 2 color stops in gradient for ${label}: "${s}"`);
@@ -179,7 +193,7 @@ test('語意 token：每個真實 fg/bg 配對跨 16 組（theme×CVD×HC）達 
         [bg, 'page-background'],
         [alphaOver(r.tintBg, surf, `${c.mode} ${r.name}-bg`), 'tint'],
         [alphaOver(r.tintBg, bg, `${c.mode} ${r.name}-bg/page`), 'tint-over-page'],
-        ...gradientStops(r.score, `${c.mode} ${r.name}-score`).map(
+        ...gradientStops(r.score, `${c.mode} ${r.name}-score`, bg).map(
           (g, i): [number[], string] => [g, `score#${i}`]
         ),
       ];

--- a/quiz-app/tests/e2e/a11y-contrast.spec.ts
+++ b/quiz-app/tests/e2e/a11y-contrast.spec.ts
@@ -40,8 +40,16 @@ function parseColor(s: string, label: string): number[] {
   const m = t.match(/^rgba?\(\s*([^)]+)\)$/i);
   if (m) {
     const p = m[1].split(',').map((x) => parseFloat(x));
-    if (p.length >= 3 && p.slice(0, 3).every((n) => Number.isFinite(n))) {
-      const a = p.length >= 4 ? p[3] : 1;
+    // arity 必須是 3 或 4；否則不接受（避免 rgb(1,2,3,4,5) 之類被誤解析）
+    if ((p.length === 3 || p.length === 4) && p.every((n) => Number.isFinite(n))) {
+      // channel 範圍：瀏覽器會把超界值 clamp（rgb(999,0,0)→255），若不驗會測到假高對比、與實際渲染不符
+      if (p.slice(0, 3).some((v) => v < 0 || v > 255)) {
+        throw new Error(`RGB channel out of 0–255 for ${label}: "${t}"`);
+      }
+      const a = p.length === 4 ? p[3] : 1;
+      if (a < 0 || a > 1) {
+        throw new Error(`Alpha out of 0–1 for ${label}: "${t}"`);
+      }
       if (a !== 1) {
         throw new Error(`Non-opaque color where opaque expected for ${label}: "${t}"`);
       }
@@ -104,7 +112,14 @@ function gradientStops(g: string, label: string, backdrop: number[]): number[][]
     if (!t) continue;
     const cm = t.match(/^(#[0-9a-fA-F]{3,8}|(?:rgb|rgba|hsl|hsla)\([^)]*\))/i);
     if (!cm) {
-      if (stops.length === 0) continue; // 方向段（如 135deg），非顏色
+      // 只有「明確方向語法」的第一段才可略過；其他無法解析的段（如具名色 green）一律 fail-closed，
+      // 不再把非方向的第一段當方向跳過（否則 linear-gradient(green, #fff, #fff) 會漏掉 green 這個 stop）
+      const isDirection =
+        stops.length === 0 &&
+        /^(-?\d*\.?\d+(?:deg|rad|grad|turn)|to\s+(?:left|right|top|bottom)(?:\s+(?:left|right|top|bottom))?)$/i.test(
+          t
+        );
+      if (isDirection) continue;
       throw new Error(`Gradient segment without parseable color for ${label}: "${t}"`);
     }
     stops.push(resolveStop(cm[1], backdrop, `${label} stop "${cm[1]}"`));
@@ -207,5 +222,54 @@ test('語意 token：每個真實 fg/bg 配對跨 16 組（theme×CVD×HC）達 
         .toBeGreaterThanOrEqual(4.5);
     }
   }
+});
+
+// #113 的核心不是只有對比，而是「分數卡背景要跟著 CVD remap」。上面的對比矩陣即使把 -score
+// 改回固定但高對比的灰色仍會全綠，抓不到這個回歸；故這裡直接斷言 computed backgroundImage 的變化。
+test('分數卡背景隨 CVD remap：good/fail 換色、excellent/pass 不變（#113）', async ({
+  page,
+}) => {
+  await page.goto('/');
+  // CSS 全域打包，任一頁都載得到 .score-section；注入四張卡後讀 computed backgroundImage。
+  await page.evaluate(() => {
+    const d = document.createElement('div');
+    d.id = 'score-remap-probe';
+    d.innerHTML = ['good', 'fail', 'excellent', 'pass']
+      .map((c) => `<div class="score-section ${c}"></div>`)
+      .join('');
+    document.body.appendChild(d);
+  });
+  // set 與 read 分兩次 evaluate，讓 style recalc 完成（避免同一拍讀到舊值）
+  const grads = async (cvd: string): Promise<Record<string, string>> => {
+    await page.evaluate(
+      (m) => document.documentElement.setAttribute('data-cvd-mode', m),
+      cvd
+    );
+    return page.evaluate(() => {
+      const out: Record<string, string> = {};
+      for (const c of ['good', 'fail', 'excellent', 'pass']) {
+        out[c] = getComputedStyle(
+          document.querySelector(`.score-section.${c}`) as HTMLElement
+        ).backgroundImage;
+      }
+      return out;
+    });
+  };
+  const none = await grads('none');
+  const prot = await grads('protanopia');
+  await page.evaluate(() => {
+    document.getElementById('score-remap-probe')?.remove();
+    document.documentElement.setAttribute('data-cvd-mode', 'none');
+  });
+
+  // 必須是漸層（防止把 -score 改回固定色卻仍「不同」的假象）
+  expect(none.good).toContain('gradient');
+  expect(none.fail).toContain('gradient');
+  // good/fail（success/error）受 CVD remap → 背景必須不同
+  expect(none.good, 'good 分數卡背景應隨 CVD 換色').not.toBe(prot.good);
+  expect(none.fail, 'fail 分數卡背景應隨 CVD 換色').not.toBe(prot.fail);
+  // excellent/pass（warning/info）依設計不受 CVD 影響 → 必須相同
+  expect(prot.excellent, 'excellent 不應隨 CVD 改變').toBe(none.excellent);
+  expect(prot.pass, 'pass 不應隨 CVD 改變').toBe(none.pass);
 });
 

--- a/quiz-app/tests/e2e/quiz-flow.spec.ts
+++ b/quiz-app/tests/e2e/quiz-flow.spec.ts
@@ -179,10 +179,11 @@ test.describe('無障礙功能', () => {
     const cvdSelect = page.getByLabel('色覺辨認模式');
     await expect(cvdSelect).toBeVisible();
 
-    const successVar = () =>
+    // 預覽色條改吃 --color-success-fg（與真實選項回饋同源）；-fg 一樣受 CVD remap
+    const successFg = () =>
       page.evaluate(() =>
         getComputedStyle(document.documentElement)
-          .getPropertyValue('--color-success')
+          .getPropertyValue('--color-success-fg')
           .trim()
           .toLowerCase()
       );
@@ -191,14 +192,14 @@ test.describe('無障礙功能', () => {
         .locator('.cvd-preview__chip--correct')
         .evaluate((el) => getComputedStyle(el).boxShadow);
 
-    // none：綠 #4caf50 / rgb(76, 175, 80)
-    await expect.poll(successVar).toBe('#4caf50');
-    await expect.poll(correctBar).toContain('76, 175, 80');
+    // none：-fg #1b5e20 / rgb(27, 94, 32)
+    await expect.poll(successFg).toBe('#1b5e20');
+    await expect.poll(correctBar).toContain('27, 94, 32');
 
-    // 切綠色盲 → 藍 #0288d1 / rgb(2, 136, 209)（poll 容忍 style recalc 的一拍延遲）
+    // 切綠色盲 → -fg #01579b / rgb(1, 87, 155)（poll 容忍 style recalc 的一拍延遲）
     await cvdSelect.selectOption('deuteranopia');
-    await expect.poll(successVar).toBe('#0288d1');
-    await expect.poll(correctBar).toContain('2, 136, 209');
+    await expect.poll(successFg).toBe('#01579b');
+    await expect.poll(correctBar).toContain('1, 87, 155');
   });
 });
 

--- a/quiz-app/tests/e2e/quiz-flow.spec.ts
+++ b/quiz-app/tests/e2e/quiz-flow.spec.ts
@@ -179,27 +179,39 @@ test.describe('無障礙功能', () => {
     const cvdSelect = page.getByLabel('色覺辨認模式');
     await expect(cvdSelect).toBeVisible();
 
-    // 預覽色條改吃 --color-success-fg（與真實選項回饋同源）；-fg 一樣受 CVD remap
-    const successFg = () =>
-      page.evaluate(() =>
-        getComputedStyle(document.documentElement)
-          .getPropertyValue('--color-success-fg')
-          .trim()
-          .toLowerCase()
+    // 預覽色條改吃 --color-*-fg（與真實選項回饋同源）；-fg 一樣受 CVD remap。
+    // correct 與 incorrect 都要驗 —— 否則 incorrect chip 誤接 success-fg 仍會全綠。
+    const cssVar = (name: string) => () =>
+      page.evaluate(
+        (n) =>
+          getComputedStyle(document.documentElement)
+            .getPropertyValue(n)
+            .trim()
+            .toLowerCase(),
+        name
       );
-    const correctBar = () =>
+    const successFg = cssVar('--color-success-fg');
+    const errorFg = cssVar('--color-error-fg');
+    const bar = (which: 'correct' | 'incorrect') => () =>
       page
-        .locator('.cvd-preview__chip--correct')
+        .locator(`.cvd-preview__chip--${which}`)
         .evaluate((el) => getComputedStyle(el).boxShadow);
+    const correctBar = bar('correct');
+    const incorrectBar = bar('incorrect');
 
-    // none：-fg #1b5e20 / rgb(27, 94, 32)
+    // none：correct=success-fg #1b5e20 / rgb(27,94,32)；incorrect=error-fg #b71c1c / rgb(183,28,28)
     await expect.poll(successFg).toBe('#1b5e20');
     await expect.poll(correctBar).toContain('27, 94, 32');
+    await expect.poll(errorFg).toBe('#b71c1c');
+    await expect.poll(incorrectBar).toContain('183, 28, 28');
 
-    // 切綠色盲 → -fg #01579b / rgb(1, 87, 155)（poll 容忍 style recalc 的一拍延遲）
+    // 切綠色盲 → correct #01579b / rgb(1,87,155)；incorrect #a52a00 / rgb(165,42,0)
+    // （poll 容忍 style recalc 的一拍延遲）
     await cvdSelect.selectOption('deuteranopia');
     await expect.poll(successFg).toBe('#01579b');
     await expect.poll(correctBar).toContain('1, 87, 155');
+    await expect.poll(errorFg).toBe('#a52a00');
+    await expect.poll(incorrectBar).toContain('165, 42, 0');
   });
 });
 


### PR DESCRIPTION
Closes #113。**疊在 #112 之上**（base 設為 #112 分支，diff 僅本次 A/B 變更；#112 合併後我會 retarget 到 main）。

修兩處與 role-based 真實回饋漂移的一致性缺陷（皆非 WCAG 對比失敗）。

## A. 分數卡背景在 CVD 模式不換色 → 由 tint 衍生
`--color-*-score` 原只有 light/dark、無 CVD 變體。protanopia 下 pass 卡是綠底藍字、fail 卡紅底橘字，最大著色面無視 CVD。

改成 `linear-gradient(135deg, var(--color-X-bg), var(--color-surface))` —— 背景與會 remap 的 tint 同源，CVD/主題自動一致；刪掉 8 條 hardcoded 逐主題漸層（根因修復）。

| | none | protanopia |
|---|---|---|
| `.score-section.good` 首端點 | `rgba(76,175,80,.12)` 綠 | `rgba(25,118,210,.12)` 藍 |
| `.score-section.fail` 首端點 | `rgba(244,67,54,.12)` 紅 | `rgba(230,81,0,.12)` 橘 |

（excellent/pass = warning/info 依設計不受 CVD 影響，維持不變。）

## B. Settings 預覽色條 base → role token
`.cvd-preview__chip` 左側實色條由 base `--color-success/error` 改吃 `--color-*-fg`，對齊真實選項邊界/icon 色。

## 守門
- a11y-contrast `gradientStops`：半透明 stop 疊 backdrop(page-bg) 再算，仍 fail-closed。**mutation**：把衍生端點換低對比色 → `score#1` 全 16 組轉紅。
- source-scan：移除 cvd-preview chip 的裸-base 白名單豁免（收緊）。
- CVD 切換 e2e：預期改為 `-fg` 值。

本機全綠：797 unit、a11y-contrast + option-key-cascade + quiz-flow e2e、build、tsc、eslint。
