### PR TITLE
修四個執行期缺陷：AI 回覆 XSS、918 則人工解析不可見、subject null 冒充考科二、練習池解析被丟棄

### DIFF
--- a/quiz-app/src/components/BankSimilarQuestionItem/BankSimilarQuestionItem.tsx
+++ b/quiz-app/src/components/BankSimilarQuestionItem/BankSimilarQuestionItem.tsx
@@ -7,6 +7,7 @@ import {
   type KeyboardEvent,
 } from 'react';
 import type { QuizQuestion, QuizOption } from '../../types/quiz';
+import { subjectLabel } from '../../utils/subject-label';
 import { findRedundantPrefix } from '../../utils/option-prefix';
 import '../QuestionCard/QuestionCard.css';
 import './BankSimilarQuestionItem.css';
@@ -140,7 +141,7 @@ export function BankSimilarQuestionItem({
           <p className="bank-similar-no-options">此題無選項資料</p>
           <div className="similar-meta">
             <span className="similar-subject">
-              {question.subject === '考科1' ? '考科一' : '考科二'}
+              {subjectLabel(question.subject)}
             </span>
           </div>
         </div>
@@ -157,7 +158,7 @@ export function BankSimilarQuestionItem({
         </p>
         <div className="similar-meta similar-meta--top">
           <span className="similar-subject">
-            {question.subject === '考科1' ? '考科一' : '考科二'}
+            {subjectLabel(question.subject)}
           </span>
         </div>
 

--- a/quiz-app/src/components/QuestionCard/QuestionCard.css
+++ b/quiz-app/src/components/QuestionCard/QuestionCard.css
@@ -451,3 +451,35 @@
 .option-item.incorrect .option-text__redundant {
   opacity: 0.6;
 }
+
+/* 題庫解析（人工／來源約束）—— 排在 AI 延伸說明之前 */
+.curated-explanation {
+  margin-top: var(--spacing-md);
+  padding: var(--spacing-md);
+  background: var(--color-success-bg);
+  border-left: 3px solid var(--color-success-fg);
+  border-radius: var(--radius-sm);
+}
+
+.curated-explanation__header {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+  font-size: var(--font-size-sm);
+  font-weight: 600;
+  color: var(--color-success-fg);
+  margin-bottom: var(--spacing-xs);
+}
+
+.curated-explanation__body {
+  margin: 0;
+  font-size: var(--font-size-sm);
+  line-height: 1.8;
+  color: var(--color-text-primary);
+}
+
+/* 未能對應考科的題目 —— 不要冒充任何一科 */
+.subject-unmapped {
+  background: var(--color-surface-variant);
+  color: var(--color-text-secondary);
+}

--- a/quiz-app/src/components/QuestionCard/QuestionCard.css
+++ b/quiz-app/src/components/QuestionCard/QuestionCard.css
@@ -494,6 +494,18 @@
   color: var(--color-warning-fg);
 }
 
+/* 外部模擬題的解析：第三方撰寫、未過本題庫的反捏造閘門。
+   用中性底色與 AI 版一致的「這不是我們寫的」視覺語彙，但不借用警示色 ——
+   它不是機器生成，只是作者不是我們。 */
+.curated-explanation--external {
+  background: var(--color-surface-variant);
+  border-left-color: var(--color-text-secondary);
+}
+
+.curated-explanation--external .curated-explanation__header {
+  color: var(--color-text-secondary);
+}
+
 .curated-explanation__grade {
   margin-left: auto;
   font-size: var(--font-size-xs);

--- a/quiz-app/src/components/QuestionCard/QuestionCard.css
+++ b/quiz-app/src/components/QuestionCard/QuestionCard.css
@@ -483,3 +483,20 @@
   background: var(--color-surface-variant);
   color: var(--color-text-secondary);
 }
+
+/* AI 產題的解析：改用中性底色，並在標頭標明未經人工逐題審核 */
+.curated-explanation--ai {
+  background: var(--color-surface-variant);
+  border-left-color: var(--color-warning-fg);
+}
+
+.curated-explanation--ai .curated-explanation__header {
+  color: var(--color-warning-fg);
+}
+
+.curated-explanation__grade {
+  margin-left: auto;
+  font-size: var(--font-size-xs);
+  font-weight: 500;
+  color: var(--color-text-secondary);
+}

--- a/quiz-app/src/components/QuestionCard/QuestionCard.tsx
+++ b/quiz-app/src/components/QuestionCard/QuestionCard.tsx
@@ -93,10 +93,30 @@ export function QuestionCard({
   );
   const [isLoadingAI, setIsLoadingAI] = useState(false);
 
-  // 練習池的 AI 產題也帶解析（100 題）。那些解析是模型寫的，不能和通過反捏造閘門的
-  // 題庫解析共用同一個標籤 —— 標題本身就是一種背書。
-  const isAiAuthoredExplanation = question.provenance?.source_type === 'ai_generated';
-  const explanationLabel = isAiAuthoredExplanation ? 'AI 產題解析' : '題庫解析';
+  // 解析的標題本身就是一種背書，所以它要說出**這段字是誰寫的**。
+  //
+  //   ai_generated（100 題）  模型寫的
+  //   external_mock（54 題）  第三方模擬題作者寫的，隨題一起匯入
+  //   主題庫                  本題庫撰寫，逐則過 tools/explanation_guard.py
+  //                           （只准用該題已機械驗證的逐字引文，不得引入引文以外的
+  //                            條號／標準編號／百分比／年份／數量）
+  //
+  // 先前只分「AI」與「題庫解析」兩種，等於把外部模擬題的解析也掛上本題庫的名義 ——
+  // 那 54 則從來沒有過我們的閘門。SourceBadge 標的是**題目**來源，這裡標的是**解析**
+  // 作者，兩者不同：題目是模擬題、解析卻可能是我們寫的（反之亦然）。
+  const explanationSource = question.provenance?.source_type;
+  const isAiAuthoredExplanation = explanationSource === 'ai_generated';
+  const isExternalExplanation = explanationSource === 'external_mock';
+  const explanationLabel = isAiAuthoredExplanation
+    ? 'AI 產題解析'
+    : isExternalExplanation
+      ? '外部模擬題解析'
+      : '題庫解析';
+  const explanationCaveat = isAiAuthoredExplanation
+    ? '未經人工逐題審核'
+    : isExternalExplanation
+      ? '第三方撰寫，非本題庫'
+      : null;
 
   const getOptionStatus = useCallback(
     (optionKey: string): 'default' | 'selected' | 'correct' | 'incorrect' => {
@@ -255,7 +275,7 @@ export function QuestionCard({
         <section
           className={`curated-explanation${
             isAiAuthoredExplanation ? ' curated-explanation--ai' : ''
-          }`}
+          }${isExternalExplanation ? ' curated-explanation--external' : ''}`}
           aria-label={explanationLabel}
         >
           <div className="curated-explanation__header">
@@ -263,8 +283,8 @@ export function QuestionCard({
               menu_book
             </span>
             <span>{explanationLabel}</span>
-            {isAiAuthoredExplanation && (
-              <span className="curated-explanation__grade">未經人工逐題審核</span>
+            {explanationCaveat && (
+              <span className="curated-explanation__grade">{explanationCaveat}</span>
             )}
           </div>
           <p className="curated-explanation__body">{question.explanation}</p>

--- a/quiz-app/src/components/QuestionCard/QuestionCard.tsx
+++ b/quiz-app/src/components/QuestionCard/QuestionCard.tsx
@@ -7,18 +7,34 @@ import { SourceBadge } from '../SourceBadge/SourceBadge';
 import { SourceBanner } from '../SourceBanner/SourceBanner';
 import { prettifySourceUrl } from '../../utils/source-label';
 import { findRedundantPrefix } from '../../utils/option-prefix';
+import { subjectClass, subjectLabel } from '../../utils/subject-label';
 import { buildFeedbackUrl } from '../../utils/question-feedback-url';
 import { useAllQuestionStats } from '../../hooks/useQuestionStats';
 import './QuestionCard.css';
 
+/** HTML 實體逸出 —— 這是 renderMarkdown 唯一的安全基礎。 */
+function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
 /**
  * 簡易 Markdown 轉 HTML
  * 支援：**粗體**、*斜體*、`程式碼`、標題、清單
+ *
+ * **輸出會被丟進 dangerouslySetInnerHTML，而輸入來自第三方 AI 服務。**
+ * 因此第一步一定是把原始 HTML 逸出掉：先前沒有這一步，模型只要回
+ * `<img src=x onerror=...>`，那段 HTML 就會被瀏覽器當成標籤執行。
+ * 逸出之後，唯一會出現在輸出裡的標籤是本函式自己插入的 strong / em / code。
  */
-function renderMarkdown(text: string): string {
+export function renderMarkdown(text: string): string {
   if (!text) return '';
 
-  let result = text
+  let result = escapeHtml(text)
     // 標題 ### text 或 ## text
     .replace(/^###\s+(.+)$/gm, '<strong>$1</strong>')
     .replace(/^##\s+(.+)$/gm, '<strong>$1</strong>')
@@ -141,8 +157,8 @@ export function QuestionCard({
       {/* 題目標頭 */}
       <header className="question-header">
         <span className="question-number">第 {questionNumber} 題</span>
-        <span className={`badge badge-info subject-tag subject-${question.subject === '考科1' ? '1' : '2'}`}>
-          {question.subject === '考科1' ? '考科一' : '考科二'}
+        <span className={`badge badge-info subject-tag ${subjectClass(question.subject)}`}>
+          {subjectLabel(question.subject)}
         </span>
         {question.provenance && (
           <SourceBadge
@@ -226,6 +242,52 @@ export function QuestionCard({
         </div>
       )}
 
+      {/* 題庫解析 —— 人工／來源約束寫成，且通過反捏造閘門。
+          先前完全沒有渲染：918 則解析躺在資料裡，畫面上卻只有一顆「AI 解析」按鈕，
+          等於讓未經審核的生成內容取代已審核的內容。順序固定為
+          答案 → 題庫解析 → 答案依據 → 參考來源 → AI 延伸。 */}
+      {showAnswer && question.explanation && (
+        <section className="curated-explanation" aria-label="題庫解析">
+          <div className="curated-explanation__header">
+            <span className="material-icons sm" aria-hidden="true">
+              menu_book
+            </span>
+            <span>題庫解析</span>
+          </div>
+          <p className="curated-explanation__body">{question.explanation}</p>
+        </section>
+      )}
+
+      {/* 答案揭曉後才顯示依據與來源；順序：題庫解析 → 答案依據 → 參考來源 → AI 延伸 */}
+      {showAnswer && (
+        <>
+        <AnswerEvidence evidence={question.evidence} />
+
+        {question.sources && question.sources.length > 0 && (
+          <div className="question-sources" aria-label="參考來源">
+            <div className="question-sources-header">
+          <span className="material-icons sm">menu_book</span>
+          <span>參考來源</span>
+            </div>
+            <ul className="question-sources-list">
+          {sourceLabels.map(({ url, label }) => (
+            <li key={url}>
+              <a
+            href={url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="source-link"
+              >
+            {label}
+              </a>
+            </li>
+          ))}
+            </ul>
+          </div>
+        )}
+        </>
+      )}
+
       {/* AI 解析區 */}
       {showAnswer && (
         <div className="ai-section">
@@ -236,7 +298,7 @@ export function QuestionCard({
               disabled={isLoadingAI}
             >
               <span className="material-icons">smart_toy</span>
-              AI 解析
+              AI 延伸說明（未經人工審核）
             </button>
           )}
 
@@ -276,30 +338,6 @@ export function QuestionCard({
             </div>
           )}
 
-          <AnswerEvidence evidence={question.evidence} />
-
-          {question.sources && question.sources.length > 0 && (
-            <div className="question-sources" aria-label="參考來源">
-              <div className="question-sources-header">
-                <span className="material-icons sm">menu_book</span>
-                <span>參考來源</span>
-              </div>
-              <ul className="question-sources-list">
-                {sourceLabels.map(({ url, label }) => (
-                  <li key={url}>
-                    <a
-                      href={url}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="source-link"
-                    >
-                      {label}
-                    </a>
-                  </li>
-                ))}
-              </ul>
-            </div>
-          )}
         </div>
       )}
     </article>

--- a/quiz-app/src/components/QuestionCard/QuestionCard.tsx
+++ b/quiz-app/src/components/QuestionCard/QuestionCard.tsx
@@ -93,6 +93,11 @@ export function QuestionCard({
   );
   const [isLoadingAI, setIsLoadingAI] = useState(false);
 
+  // 練習池的 AI 產題也帶解析（100 題）。那些解析是模型寫的，不能和通過反捏造閘門的
+  // 題庫解析共用同一個標籤 —— 標題本身就是一種背書。
+  const isAiAuthoredExplanation = question.provenance?.source_type === 'ai_generated';
+  const explanationLabel = isAiAuthoredExplanation ? 'AI 產題解析' : '題庫解析';
+
   const getOptionStatus = useCallback(
     (optionKey: string): 'default' | 'selected' | 'correct' | 'incorrect' => {
       if (!showAnswer) {
@@ -247,12 +252,20 @@ export function QuestionCard({
           等於讓未經審核的生成內容取代已審核的內容。順序固定為
           答案 → 題庫解析 → 答案依據 → 參考來源 → AI 延伸。 */}
       {showAnswer && question.explanation && (
-        <section className="curated-explanation" aria-label="題庫解析">
+        <section
+          className={`curated-explanation${
+            isAiAuthoredExplanation ? ' curated-explanation--ai' : ''
+          }`}
+          aria-label={explanationLabel}
+        >
           <div className="curated-explanation__header">
             <span className="material-icons sm" aria-hidden="true">
               menu_book
             </span>
-            <span>題庫解析</span>
+            <span>{explanationLabel}</span>
+            {isAiAuthoredExplanation && (
+              <span className="curated-explanation__grade">未經人工逐題審核</span>
+            )}
           </div>
           <p className="curated-explanation__body">{question.explanation}</p>
         </section>

--- a/quiz-app/src/components/QuestionCard/QuestionCard.tsx
+++ b/quiz-app/src/components/QuestionCard/QuestionCard.tsx
@@ -266,22 +266,22 @@ export function QuestionCard({
         {question.sources && question.sources.length > 0 && (
           <div className="question-sources" aria-label="參考來源">
             <div className="question-sources-header">
-          <span className="material-icons sm">menu_book</span>
-          <span>參考來源</span>
+              <span className="material-icons sm">menu_book</span>
+              <span>參考來源</span>
             </div>
             <ul className="question-sources-list">
-          {sourceLabels.map(({ url, label }) => (
-            <li key={url}>
-              <a
-            href={url}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="source-link"
-              >
-            {label}
-              </a>
-            </li>
-          ))}
+              {sourceLabels.map(({ url, label }) => (
+                <li key={url}>
+                  <a
+                    href={url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="source-link"
+                  >
+                    {label}
+                  </a>
+                </li>
+              ))}
             </ul>
           </div>
         )}

--- a/quiz-app/src/components/QuestionCard/QuestionCard.tsx
+++ b/quiz-app/src/components/QuestionCard/QuestionCard.tsx
@@ -327,11 +327,10 @@ export function QuestionCard({
               <div className="ai-response-header">
                 <span className="material-icons">smart_toy</span>
                 <span>AI 解析</span>
-                {aiResponse.confidence > 0 && (
-                  <span className="confidence-badge">
-                    信心度 {Math.round(aiResponse.confidence * 100)}%
-                  </span>
-                )}
+                {/* 先前這裡渲染「信心度 85%」。那個數字來自回覆長度與關鍵詞加總，
+                    與答案正確與否無關 —— 一個憑空生成卻看起來精確的百分比，
+                    比不顯示更糟。改為據實說明這段內容的性質。 */}
+                <span className="confidence-badge">未經人工審核</span>
               </div>
               {aiResponse.success ? (
                 <div className="ai-response-content">

--- a/quiz-app/src/components/QuestionCard/ai-response-render.test.tsx
+++ b/quiz-app/src/components/QuestionCard/ai-response-render.test.tsx
@@ -66,13 +66,17 @@ describe('AI 區塊渲染', () => {
     expect(container.textContent).toContain('<img src=x');
   });
 
-  it('有信心度時顯示信心度徽章', async () => {
-    explainQuestion.mockResolvedValue({ success: true, content: '內容', confidence: 0.8 });
+  it('不顯示憑空生成的信心度百分比，只據實說明內容性質', async () => {
+    // estimateConfidence 是依「回覆長度、有沒有出現 A/B、命中幾個關鍵詞」加總出來的，
+    // 與答案正確與否無關。把它渲染成「信心度 85%」，是一個看起來精確卻憑空生成的數字。
+    explainQuestion.mockResolvedValue({ success: true, content: '內容', confidence: 0.85 });
 
     render(<QuestionCard question={question} questionNumber={1} showAnswer onSelectAnswer={vi.fn()} />);
     clickAI();
 
-    expect(await screen.findByText(/信心度/)).toBeInTheDocument();
+    expect(await screen.findByText('未經人工審核')).toBeInTheDocument();
+    expect(screen.queryByText(/信心度/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/85%/)).not.toBeInTheDocument();
   });
 
   it('失敗時顯示錯誤訊息而不是空白', async () => {

--- a/quiz-app/src/components/QuestionCard/ai-response-render.test.tsx
+++ b/quiz-app/src/components/QuestionCard/ai-response-render.test.tsx
@@ -1,0 +1,100 @@
+// AI 區塊的三條渲染路徑：載入中、成功、失敗。
+// 這些路徑先前沒有任何測試走到 —— 而它們正是把第三方輸出放進 DOM 的地方。
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import type { QuizQuestion } from '../../types/quiz';
+
+const explainQuestion = vi.fn();
+vi.mock('../../utils/ai-helper', () => ({
+  explainQuestion: (...args: unknown[]) => explainQuestion(...args),
+}));
+
+const { QuestionCard } = await import('./QuestionCard');
+
+const question: QuizQuestion = {
+  id: 'ai-1',
+  stem: '測試題幹',
+  options: [
+    { key: 'A', text: '甲' },
+    { key: 'B', text: '乙' },
+    { key: 'C', text: '丙' },
+    { key: 'D', text: '丁' },
+  ],
+  answer: 'A',
+  subject: '考科1',
+  sourceType: 'gist',
+  year: null,
+  hasAnswer: true,
+};
+
+function clickAI() {
+  fireEvent.click(screen.getByRole('button', { name: /未經人工審核/ }));
+}
+
+describe('AI 區塊渲染', () => {
+  beforeEach(() => {
+    explainQuestion.mockReset();
+  });
+
+  it('請求中顯示載入狀態', async () => {
+    let resolve: (v: unknown) => void = () => {};
+    explainQuestion.mockReturnValue(new Promise((r) => { resolve = r; }));
+
+    render(<QuestionCard question={question} questionNumber={1} showAnswer onSelectAnswer={vi.fn()} />);
+    clickAI();
+
+    expect(await screen.findByText(/AI 分析中/)).toBeInTheDocument();
+    resolve({ success: true, content: '完成', confidence: 0.9 });
+    await waitFor(() => expect(screen.queryByText(/AI 分析中/)).not.toBeInTheDocument());
+  });
+
+  it('成功時逐段渲染內容，且惡意 HTML 不會變成節點', async () => {
+    explainQuestion.mockResolvedValue({
+      success: true,
+      content: '**第一段**\n<img src=x onerror="window.__xss=1">',
+      confidence: 0.85,
+    });
+
+    const { container } = render(
+      <QuestionCard question={question} questionNumber={1} showAnswer onSelectAnswer={vi.fn()} />
+    );
+    clickAI();
+
+    expect(await screen.findByText('第一段')).toBeInTheDocument();
+    expect(container.querySelector('.ai-response-content strong')).not.toBeNull();
+    expect(container.querySelector('img')).toBeNull();
+    expect(container.textContent).toContain('<img src=x');
+  });
+
+  it('有信心度時顯示信心度徽章', async () => {
+    explainQuestion.mockResolvedValue({ success: true, content: '內容', confidence: 0.8 });
+
+    render(<QuestionCard question={question} questionNumber={1} showAnswer onSelectAnswer={vi.fn()} />);
+    clickAI();
+
+    expect(await screen.findByText(/信心度/)).toBeInTheDocument();
+  });
+
+  it('失敗時顯示錯誤訊息而不是空白', async () => {
+    explainQuestion.mockResolvedValue({
+      success: false,
+      content: '',
+      confidence: 0,
+      error: 'AI 服務暫時無法使用',
+    });
+
+    render(<QuestionCard question={question} questionNumber={1} showAnswer onSelectAnswer={vi.fn()} />);
+    clickAI();
+
+    expect(await screen.findByText('AI 服務暫時無法使用')).toBeInTheDocument();
+  });
+
+  it('explainQuestion 丟例外時也給可讀訊息，不讓畫面炸掉', async () => {
+    explainQuestion.mockRejectedValue(new Error('boom'));
+
+    render(<QuestionCard question={question} questionNumber={1} showAnswer onSelectAnswer={vi.fn()} />);
+    clickAI();
+
+    expect(await screen.findByText(/請求失敗/)).toBeInTheDocument();
+  });
+});

--- a/quiz-app/src/components/QuestionCard/security-and-explanation.test.tsx
+++ b/quiz-app/src/components/QuestionCard/security-and-explanation.test.tsx
@@ -157,6 +157,29 @@ describe('解析的標籤必須誠實反映來源', () => {
     expect(screen.queryByText('未經人工逐題審核')).not.toBeInTheDocument();
   });
 
+  // 練習池有 54 題來自第三方模擬題（vocus 講師），解析是隨題匯入的原作者文字 ——
+  // 那些從來沒有過 tools/explanation_guard.py。掛「題庫解析」等於把它們掛上本題庫的名義。
+  it('外部模擬題的解析標「外部模擬題解析」，並標示第三方撰寫', () => {
+    render(
+      <QuestionCard
+        question={{
+          ...base,
+          sourceType: 'practice_pool',
+          provenance: { source_type: 'external_mock' },
+          explanation: 'vocus 講師寫的解析',
+        }}
+        questionNumber={1}
+        showAnswer
+        onSelectAnswer={vi.fn()}
+      />
+    );
+    expect(screen.getByLabelText('外部模擬題解析')).toBeInTheDocument();
+    expect(screen.getByText('第三方撰寫，非本題庫')).toBeInTheDocument();
+    expect(screen.queryByLabelText('題庫解析')).not.toBeInTheDocument();
+    // 也不該被誤標成 AI 產出 —— 它是人寫的，只是作者不是我們
+    expect(screen.queryByText('未經人工逐題審核')).not.toBeInTheDocument();
+  });
+
   it('練習池 AI 產題的解析改標「AI 產題解析」，並標示未經人工逐題審核', () => {
     // 練習池有 100 題 AI 產題也帶解析。那是模型寫的，不能和通過反捏造閘門的
     // 題庫解析共用同一個標籤 —— 標題本身就是一種背書。
@@ -178,20 +201,21 @@ describe('解析的標籤必須誠實反映來源', () => {
     expect(screen.queryByLabelText('題庫解析')).not.toBeInTheDocument();
   });
 
-  it('練習池的模擬題（非 AI 產題）仍標「題庫解析」', () => {
+  // 這條原本寫成「練習池的模擬題仍標『題庫解析』」—— 那是我第一版的判斷，錯了：
+  // 它把只分「AI／非 AI」的二分法固化成測試，等於用綠燈背書一個超額宣稱。
+  // 現在改成三分（本題庫／外部／AI），由上面那條外部模擬題的測試涵蓋。
+  // 這裡保留的是另一件事：主題庫題（沒有 provenance）不得被誤標成外部或 AI。
+  it('沒有 provenance 的主題庫題不會被誤標成外部或 AI', () => {
     render(
       <QuestionCard
-        question={{
-          ...base,
-          sourceType: 'practice_pool',
-          provenance: { source_type: 'external_mock' },
-          explanation: '人工整理的解析',
-        }}
+        question={{ ...base, explanation: '人工整理的解析' }}
         questionNumber={1}
         showAnswer
         onSelectAnswer={vi.fn()}
       />
     );
     expect(screen.getByLabelText('題庫解析')).toBeInTheDocument();
+    expect(screen.queryByText('第三方撰寫，非本題庫')).not.toBeInTheDocument();
+    expect(screen.queryByText('未經人工逐題審核')).not.toBeInTheDocument();
   });
 });

--- a/quiz-app/src/components/QuestionCard/security-and-explanation.test.tsx
+++ b/quiz-app/src/components/QuestionCard/security-and-explanation.test.tsx
@@ -1,0 +1,98 @@
+// 兩件會安靜出事的事情：
+// 1. AI 回覆是第三方輸入，卻被丟進 dangerouslySetInnerHTML —— 沒有逸出就是 DOM XSS。
+// 2. 918 則人工解析躺在資料裡從不顯示，畫面上只有一顆 AI 按鈕，
+//    等於讓未經審核的生成內容取代已審核的內容。
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { QuestionCard, renderMarkdown } from './QuestionCard';
+import type { QuizQuestion } from '../../types/quiz';
+
+const base: QuizQuestion = {
+  id: 'sec-1',
+  stem: '測試題幹',
+  options: [
+    { key: 'A', text: '甲' },
+    { key: 'B', text: '乙' },
+    { key: 'C', text: '丙' },
+    { key: 'D', text: '丁' },
+  ],
+  answer: 'A',
+  subject: '考科1',
+  sourceType: 'gist',
+  year: null,
+  hasAnswer: true,
+};
+
+describe('AI 輸出不得注入 HTML', () => {
+  it.each([
+    '<img src=x onerror="window.__xss = 1">',
+    '<script>window.__xss = 1</script>',
+    '<a href="javascript:alert(1)">click</a>',
+    '<div onclick="alert(1)">x</div>',
+  ])('逸出惡意輸入：%s', (payload) => {
+    const html = renderMarkdown(payload);
+    // 重點不是字串裡有沒有 onerror 這幾個字（逸出後它只是文字），
+    // 而是 `<` 已被逸出、永遠組不成標籤，因此瀏覽器不會建立任何節點。
+    expect(html).toContain('&lt;');
+
+    const host = document.createElement('div');
+    host.innerHTML = html;
+    expect(host.querySelector('img, script, a, div[onclick]')).toBeNull();
+    expect(host.textContent).toContain('<');
+  });
+
+  it('逸出後仍保留 markdown 粗體/程式碼功能', () => {
+    const html = renderMarkdown('**重點** 與 `code`');
+    expect(html).toContain('<strong>重點</strong>');
+    expect(html).toContain('<code>code</code>');
+  });
+
+  it('把惡意 HTML 當純文字呈現，不建立節點', () => {
+    const { container } = render(
+      <div dangerouslySetInnerHTML={{ __html: renderMarkdown('<img src=x onerror="x">') }} />
+    );
+    expect(container.querySelector('img')).toBeNull();
+    expect(container.textContent).toContain('<img src=x');
+  });
+});
+
+describe('題庫解析必須被看見', () => {
+  it('揭曉答案後顯示人工解析', () => {
+    render(
+      <QuestionCard
+        question={{ ...base, explanation: '這是人工審核過的解析。' }}
+        questionNumber={1}
+        showAnswer
+        onSelectAnswer={vi.fn()}
+      />
+    );
+    expect(screen.getByLabelText('題庫解析')).toBeInTheDocument();
+    expect(screen.getByText('這是人工審核過的解析。')).toBeInTheDocument();
+  });
+
+  it('AI 按鈕明示未經人工審核', () => {
+    render(
+      <QuestionCard question={base} questionNumber={1} showAnswer onSelectAnswer={vi.fn()} />
+    );
+    expect(screen.getByRole('button', { name: /未經人工審核/ })).toBeInTheDocument();
+  });
+
+  it('沒有解析的題目不出現空區塊', () => {
+    render(
+      <QuestionCard question={base} questionNumber={1} showAnswer onSelectAnswer={vi.fn()} />
+    );
+    expect(screen.queryByLabelText('題庫解析')).not.toBeInTheDocument();
+  });
+
+  it('未分類的考科顯示「待分類」，不冒充考科二', () => {
+    render(
+      <QuestionCard
+        question={{ ...base, subject: null }}
+        questionNumber={1}
+        onSelectAnswer={vi.fn()}
+      />
+    );
+    expect(screen.getByText('待分類')).toBeInTheDocument();
+    expect(screen.queryByText('考科二')).not.toBeInTheDocument();
+  });
+});

--- a/quiz-app/src/components/QuestionCard/security-and-explanation.test.tsx
+++ b/quiz-app/src/components/QuestionCard/security-and-explanation.test.tsx
@@ -142,3 +142,56 @@ describe('來源與練習池徽章', () => {
     expect(document.querySelector('.source-badge')).not.toBeNull();
   });
 });
+
+describe('解析的標籤必須誠實反映來源', () => {
+  it('主題庫的解析標「題庫解析」', () => {
+    render(
+      <QuestionCard
+        question={{ ...base, explanation: '通過反捏造閘門的解析' }}
+        questionNumber={1}
+        showAnswer
+        onSelectAnswer={vi.fn()}
+      />
+    );
+    expect(screen.getByLabelText('題庫解析')).toBeInTheDocument();
+    expect(screen.queryByText('未經人工逐題審核')).not.toBeInTheDocument();
+  });
+
+  it('練習池 AI 產題的解析改標「AI 產題解析」，並標示未經人工逐題審核', () => {
+    // 練習池有 100 題 AI 產題也帶解析。那是模型寫的，不能和通過反捏造閘門的
+    // 題庫解析共用同一個標籤 —— 標題本身就是一種背書。
+    render(
+      <QuestionCard
+        question={{
+          ...base,
+          sourceType: 'practice_pool',
+          provenance: { source_type: 'ai_generated' },
+          explanation: '模型寫的解析',
+        }}
+        questionNumber={1}
+        showAnswer
+        onSelectAnswer={vi.fn()}
+      />
+    );
+    expect(screen.getByLabelText('AI 產題解析')).toBeInTheDocument();
+    expect(screen.getByText('未經人工逐題審核')).toBeInTheDocument();
+    expect(screen.queryByLabelText('題庫解析')).not.toBeInTheDocument();
+  });
+
+  it('練習池的模擬題（非 AI 產題）仍標「題庫解析」', () => {
+    render(
+      <QuestionCard
+        question={{
+          ...base,
+          sourceType: 'practice_pool',
+          provenance: { source_type: 'external_mock' },
+          explanation: '人工整理的解析',
+        }}
+        questionNumber={1}
+        showAnswer
+        onSelectAnswer={vi.fn()}
+      />
+    );
+    expect(screen.getByLabelText('題庫解析')).toBeInTheDocument();
+  });
+});

--- a/quiz-app/src/components/QuestionCard/security-and-explanation.test.tsx
+++ b/quiz-app/src/components/QuestionCard/security-and-explanation.test.tsx
@@ -96,3 +96,49 @@ describe('題庫解析必須被看見', () => {
     expect(screen.queryByText('考科二')).not.toBeInTheDocument();
   });
 });
+
+describe('來源與練習池徽章', () => {
+  const withSources: QuizQuestion = {
+    ...base,
+    sources: [
+      'https://law.moj.gov.tw/LawClass/LawAll.aspx?pcode=O0020098',
+      'https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32023R0956',
+    ],
+  };
+
+  it('揭曉答案後把來源渲染成可讀標籤連結', () => {
+    render(
+      <QuestionCard question={withSources} questionNumber={1} showAnswer onSelectAnswer={vi.fn()} />
+    );
+    const list = screen.getByLabelText('參考來源');
+    expect(list).toBeInTheDocument();
+    const links = screen.getAllByRole('link');
+    expect(links.length).toBeGreaterThanOrEqual(2);
+    for (const a of links) {
+      expect(a).toHaveAttribute('rel', 'noopener noreferrer');
+      expect(a.getAttribute('href')).toMatch(/^https:\/\//);
+    }
+  });
+
+  it('未揭曉答案前不顯示來源', () => {
+    render(<QuestionCard question={withSources} questionNumber={1} onSelectAnswer={vi.fn()} />);
+    expect(screen.queryByLabelText('參考來源')).not.toBeInTheDocument();
+  });
+
+  it('練習池題目顯示來源徽章', () => {
+    render(
+      <QuestionCard
+        question={{
+          ...base,
+          sourceType: 'practice_pool',
+          provenance: { source_type: 'ai_generated' },
+          qualityFlags: ['low_confidence'],
+        }}
+        questionNumber={1}
+        onSelectAnswer={vi.fn()}
+      />
+    );
+    // 練習池題目應出現來源徽章（AI 產題），主題庫題不顯示
+    expect(document.querySelector('.source-badge')).not.toBeNull();
+  });
+});

--- a/quiz-app/src/hooks/useQuiz.test.ts
+++ b/quiz-app/src/hooks/useQuiz.test.ts
@@ -3,6 +3,8 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 import { useQuiz, defaultConfig } from './useQuiz';
 import type { QuizConfig } from '../types/quiz';
+import { __setPracticePoolForTesting } from '../utils/practice-pool';
+import { buildFixturePool } from '../utils/__fixtures__/practice-pool-fixture';
 
 describe('useQuiz Hook', () => {
   beforeEach(() => {
@@ -456,6 +458,63 @@ describe('useQuiz Hook', () => {
       expect(fresh.result.current.isActive).toBe(true);
       expect(fresh.result.current.currentIndex).toBe(expectedIndex);
       expect(fresh.result.current.questions.length).toBe(expectedQuestionCount);
+    });
+
+    // 主題庫題在 localStorage 裡存的是 id，續作時會用現行題庫重建；練習池題存的是
+    // 整包物件 —— 而那些物件是**存檔當下那版 adapter** 的產物。修好 adapter 之後，
+    // 跨版本續作的那一場仍然帶著舊資料：解析是空的、subject 被冒充成考科二。
+    it('續作時練習池題會用現行池資料補回解析與考科（舊快照不會一直帶著舊 bug）', async () => {
+      __setPracticePoolForTesting(buildFixturePool());
+      const staleQuestion = {
+        id: 'fixture-1',
+        stem: 'Fixture 題目 1：請選擇正確答案',
+        options: [
+          { key: 'A', text: '選 A' },
+          { key: 'B', text: '選 B' },
+          { key: 'C', text: '選 C' },
+          { key: 'D', text: '選 D' },
+        ],
+        answer: 'A',
+        // 存檔當下 adapter 的產物：解析被丟掉，subject 被 fallback 成考科二
+        explanation: null,
+        subject: '考科2',
+        sourceType: 'practice_pool',
+        hasAnswer: true,
+      };
+      window.localStorage.setItem(
+        STORAGE_KEY,
+        JSON.stringify({
+          version: 2,
+          savedAt: 1,
+          state: {
+            questions: [staleQuestion],
+            currentIndex: 0,
+            answers: [],
+            isActive: true,
+            startTime: 1,
+            config: defaultConfig,
+          },
+        })
+      );
+
+      const { result } = renderHook(() => useQuiz());
+      act(() => {
+        expect(result.current.resumeQuiz()).toBe(true);
+      });
+      // 續作本身是同步的：先照舊快照顯示，不讓載入池阻擋使用者
+      expect(result.current.questions[0].explanation).toBeNull();
+
+      // 池載入完成後補上顯示欄位
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      expect(result.current.questions[0].explanation).toBe('fixture explanation');
+      expect(result.current.questions[0].subject).toBe('考科1');
+      // 計分相關欄位不得被動到（動了會與 answers 記錄的 correctAnswer 分裂）
+      expect(result.current.questions[0].answer).toBe('A');
+      expect(result.current.questions[0].stem).toBe(staleQuestion.stem);
+      __setPracticePoolForTesting(null);
     });
 
     it('localStorage 有壞掉資料時 resumeQuiz 回 false', () => {

--- a/quiz-app/src/hooks/useQuiz.ts
+++ b/quiz-app/src/hooks/useQuiz.ts
@@ -275,6 +275,7 @@ export function useQuiz() {
       endTime,
       totalTime: endTime - startTime,
       answers,
+      questions,
       score:
         totalAnswerable > 0
           ? Math.round((correctCount / totalAnswerable) * 100)

--- a/quiz-app/src/hooks/useQuiz.ts
+++ b/quiz-app/src/hooks/useQuiz.ts
@@ -329,6 +329,13 @@ export function useQuiz() {
    * 只補顯示用欄位（解析／考科／來源／出處徽章），不動 answer / options / stem ——
    * 那三者一動就會與 answers 裡已記錄的 correctAnswer 分裂（見上方 #106 對帳說明）；
    * 顯示欄位沒有這個風險。池是 dynamic import，這裡不會把它拉進主 bundle。
+   *
+   * **已知限制**：qualityFlags 也不補。若某題在存檔後被標成爭議類旗標，這一場續作仍會
+   * 沿用舊旗標而照常計分。理由是本函式在 setState 之後才非同步完成，此時 resumeQuiz 的
+   * 可計分過濾與 currentIndex 重錨定都已經跑完；只換旗標而不重跑那兩步，會做出
+   * 「畫面說不計分、finishQuiz 仍計分」的分裂狀態，比沿用舊旗標更糟。
+   * 主題庫題不受影響（它們存的是 id，續作時本來就用現行題庫重建，旗標是新的）。
+   * 真正要修得靠「續作時重跑一次過濾」，那會動到 resumeQuiz 的重錨定邏輯，另案處理。
    */
   const rehydratePoolQuestions = useCallback((questions: QuizQuestion[]): void => {
     if (!questions.some((q) => q.sourceType === 'practice_pool')) return;

--- a/quiz-app/src/hooks/useQuiz.ts
+++ b/quiz-app/src/hooks/useQuiz.ts
@@ -319,6 +319,51 @@ export function useQuiz() {
   }, []);
 
   /**
+   * 續作時把練習池題重新水合。
+   *
+   * 主題庫題在 localStorage 裡存的是 id，續作時本來就會用**現行題庫**重建；
+   * 練習池題存的是整包物件，而那些物件是**存檔當下那版 adapter** 的產物 ——
+   * 解析被丟掉、subject 被 fallback 成考科二。不補的話，這次修好的東西
+   * 對「跨版本續作的那一場」永遠不成立，而使用者不會知道自己看的是舊資料。
+   *
+   * 只補顯示用欄位（解析／考科／來源／出處徽章），不動 answer / options / stem ——
+   * 那三者一動就會與 answers 裡已記錄的 correctAnswer 分裂（見上方 #106 對帳說明）；
+   * 顯示欄位沒有這個風險。池是 dynamic import，這裡不會把它拉進主 bundle。
+   */
+  const rehydratePoolQuestions = useCallback((questions: QuizQuestion[]): void => {
+    if (!questions.some((q) => q.sourceType === 'practice_pool')) return;
+    void loadPracticePool()
+      .then((pool) => {
+        const byId = new Map(pool.items.map((it) => [it.id, it]));
+        setState((prev) => {
+          if (!prev.isActive) return prev;
+          let changed = false;
+          const next = prev.questions.map((q) => {
+            if (q.sourceType !== 'practice_pool') return q;
+            const item = byId.get(q.id);
+            if (!item) return q;
+            const fresh = toQuizQuestion(item);
+            if (q.explanation === fresh.explanation && q.subject === fresh.subject) {
+              return q;
+            }
+            changed = true;
+            return {
+              ...q,
+              explanation: fresh.explanation,
+              subject: fresh.subject,
+              sources: fresh.sources,
+              provenance: fresh.provenance,
+            };
+          });
+          return changed ? { ...prev, questions: next } : prev;
+        });
+      })
+      .catch(() => {
+        // 池載不進來只影響「解析顯示得比較舊」，續作本身照常 —— 不打斷使用者。
+      });
+  }, []);
+
+  /**
    * 從 localStorage 還原中斷的測驗（Refs #71）。
    * 找到合法 saved progress 時 restore 並回 true；否則回 false。
    * 由 App.tsx 在使用者點「繼續測驗」時呼叫。
@@ -371,9 +416,10 @@ export function useQuiz() {
         answers: reconciledAnswers,
       });
     }
+    rehydratePoolQuestions(answerable);
     setQuestionStartTime(Date.now());
     return true;
-  }, []);
+  }, [rehydratePoolQuestions]);
 
   // 衍生狀態
   const currentQuestion = useMemo(

--- a/quiz-app/src/pages/ResultPage.css
+++ b/quiz-app/src/pages/ResultPage.css
@@ -676,3 +676,33 @@
     width: 100%;
   }
 }
+
+/* 錯題卡上的題庫解析 —— 考試模式下，這是使用者唯一看得到解析的地方 */
+.wrong-explanation {
+  margin-top: var(--spacing-sm);
+  padding: var(--spacing-sm);
+  background: var(--color-success-bg);
+  border-left: 3px solid var(--color-success-fg);
+  border-radius: var(--radius-sm);
+}
+
+.wrong-explanation__header {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+  font-size: var(--font-size-xs);
+  font-weight: 600;
+  color: var(--color-success-fg);
+  margin-bottom: 2px;
+}
+
+.wrong-explanation__body {
+  margin: 0 0 var(--spacing-xs);
+  font-size: var(--font-size-xs);
+  line-height: 1.7;
+  color: var(--color-text-primary);
+}
+
+.wrong-explanation__body:last-child {
+  margin-bottom: 0;
+}

--- a/quiz-app/src/pages/ResultPage.css
+++ b/quiz-app/src/pages/ResultPage.css
@@ -482,12 +482,6 @@
   font-weight: 400;
 }
 
-.confidence-warning {
-  margin-left: auto;
-  font-size: var(--font-size-xs);
-  color: var(--color-warning-fg);
-}
-
 /* AI 生成題目專用樣式 */
 .ai-response-inline.generated {
   border-color: var(--color-warning-fg);

--- a/quiz-app/src/pages/ResultPage.test.tsx
+++ b/quiz-app/src/pages/ResultPage.test.tsx
@@ -120,6 +120,7 @@ function makeResult(overrides: Partial<QuizResult> = {}): QuizResult {
     endTime: 1_700_000_065_000,
     totalTime: 65_000,
     answers: [],
+    questions: [],
     score: 100,
     totalAnswerable: 1,
     correctCount: 1,
@@ -456,5 +457,62 @@ describe('ResultPage 答案依據', () => {
     expect(
       screen.getByText(/固定測試用逐字引文/)
     ).toBeInTheDocument();
+  });
+});
+
+describe('考試模式的錯題檢討', () => {
+  const poolQuestion = {
+    id: 'pool-only-1',
+    stem: '這是一題練習池題目，主題庫索引查不到',
+    options: [
+      { key: 'A', text: '甲' },
+      { key: 'B', text: '乙' },
+    ],
+    answer: 'B',
+    subject: '考科2',
+    sourceType: 'practice_pool',
+    year: null,
+    hasAnswer: true,
+    explanation: '第一段解析。\n\n第二段解析。',
+  } as unknown as QuizQuestion;
+
+  it('練習池錯題不會整張消失（結果頁改用當次題目快照）', () => {
+    // 先前結果頁用 getQuestionById() 反查，而那個索引只由主題庫組成：
+    // 練習池題查不到就 return null，題幹／正解／解析／來源／回報連結全部不見。
+    render(
+      <ResultPage
+        result={makeResult({
+          answers: [makeAnswer({ questionId: 'pool-only-1', correctAnswer: 'B' })],
+          questions: [poolQuestion],
+          wrongCount: 1,
+          correctCount: 0,
+          score: 0,
+        })}
+        onGoHome={vi.fn()}
+        onRetry={vi.fn()}
+      />
+    );
+    expect(screen.getByText(/這是一題練習池題目/)).toBeInTheDocument();
+  });
+
+  it('考試模式看得到題庫解析，且多段解析不會被壓成一段', () => {
+    // 練習模式靠 showAnswer 在題目頁顯示解析；考試模式 showAnswerImmediately=false，
+    // 題目頁不顯示，因此結果頁是使用者唯一看得到解析的地方。
+    render(
+      <ResultPage
+        result={makeResult({
+          answers: [makeAnswer({ questionId: 'pool-only-1', correctAnswer: 'B' })],
+          questions: [poolQuestion],
+          wrongCount: 1,
+          correctCount: 0,
+          score: 0,
+        })}
+        onGoHome={vi.fn()}
+        onRetry={vi.fn()}
+      />
+    );
+    expect(screen.getByLabelText('題庫解析')).toBeInTheDocument();
+    expect(screen.getByText('第一段解析。')).toBeInTheDocument();
+    expect(screen.getByText('第二段解析。')).toBeInTheDocument();
   });
 });

--- a/quiz-app/src/pages/ResultPage.test.tsx
+++ b/quiz-app/src/pages/ResultPage.test.tsx
@@ -299,11 +299,15 @@ describe('ResultPage', () => {
       );
     }
 
-    it('success response → 渲染題目內容；低信心度顯示警示徽章', async () => {
+    // 這兩條原本釘的是「低信心度時顯示警示、高信心度時不顯示」。那個分數是
+    // estimateConfidence() 依回覆長度與關鍵詞加減出來的啟發式值，ai-helper 的註解
+    // 已寫明不對使用者呈現。條件式顯示比顯示數值更糟：沒有徽章等於暗示「這題信心高」，
+    // 而我們沒有任何依據講這句話。改為無條件揭露「未經人工審核」，與 AI 解析路徑一致。
+    it('success response → 渲染題目內容，並無條件標示未經人工審核', async () => {
       const fakeResponse: AIResponse = {
         success: true,
         content: '新題目：下列何者屬於範疇一直接排放？\nA. 公務車柴油燃燒\nB. 外購電力',
-        confidence: 0.5, // 介於 0 和 0.7 之間 → 觸發 低信心度 branch
+        confidence: 0.5,
         error: '',
       };
       vi.mocked(generateSimilarQuestionStream).mockResolvedValueOnce(fakeResponse);
@@ -316,10 +320,11 @@ describe('ResultPage', () => {
       });
       expect(screen.getByText(/新題目：下列何者屬於範疇一直接排放？/)).toBeInTheDocument();
       expect(screen.getByText(/A\. 公務車柴油燃燒/)).toBeInTheDocument();
-      expect(screen.getByText(/低信心度/)).toBeInTheDocument();
+      expect(screen.getAllByText('未經人工審核').length).toBeGreaterThan(0);
+      expect(screen.queryByText(/低信心度/)).not.toBeInTheDocument();
     });
 
-    it('success response 高信心度 → 不顯示警示徽章', async () => {
+    it('啟發式分數高時同樣標示未經人工審核（不會因分數高就默默背書）', async () => {
       vi.mocked(generateSimilarQuestionStream).mockResolvedValueOnce({
         success: true,
         content: '高信心題目內容',
@@ -334,6 +339,7 @@ describe('ResultPage', () => {
         expect(screen.getByText(/AI 生成的相似題/)).toBeInTheDocument();
       });
       expect(screen.queryByText(/低信心度/)).not.toBeInTheDocument();
+      expect(screen.getAllByText('未經人工審核').length).toBeGreaterThan(0);
     });
 
     it('failure response → 渲染 ai-error 區塊與錯誤訊息', async () => {

--- a/quiz-app/src/pages/ResultPage.tsx
+++ b/quiz-app/src/pages/ResultPage.tsx
@@ -25,6 +25,10 @@ interface ResultPageProps {
   onRetry: () => void;
 }
 
+// 解析可能含多段（#121 新增了不少帶條文引文的長解析）。用常數避免每次 render 重建 RegExp，
+// 也避免在 JSX 內寫逸出序列。
+const PARAGRAPH_BREAK = new RegExp(String.fromCharCode(10) + '{2,}');
+
 export function ResultPage({ result, onGoHome, onRetry }: ResultPageProps) {
   const { score, correctCount, wrongCount, totalAnswerable, skippedCount, answers, totalTime } =
     result;
@@ -65,6 +69,17 @@ export function ResultPage({ result, onGoHome, onRetry }: ResultPageProps) {
     [answers]
   );
 
+  // 先查當次快照，再退回靜態題庫。前者才涵蓋練習池題 ——
+  // getQuestionById() 的索引只由主題庫組成。
+  const sessionQuestions = useMemo(
+    () => new Map((result.questions ?? []).map((q) => [q.id, q])),
+    [result.questions]
+  );
+  const lookupQuestion = useCallback(
+    (id: string) => sessionQuestions.get(id) ?? getQuestionById(id),
+    [sessionQuestions]
+  );
+
   // 累積最常答錯（Refs #64）— pure 篩選/排序在 selectWeakQuestions，
   // 此處只負責 id → 題幹查找（沒查到的就過濾掉，多為已被刪除題或 pool 題未載入）
   // 透過 useAllQuestionStats 訂閱跨 tab 變更：別的分頁清除統計時，本頁也即時更新
@@ -77,7 +92,7 @@ export function ResultPage({ result, onGoHome, onRetry }: ResultPageProps) {
     });
     return weak
       .map((w) => {
-        const q = getQuestionById(w.id);
+        const q = lookupQuestion(w.id);
         return q ? { ...w, stem: q.stem } : null;
       })
       .filter((x): x is NonNullable<typeof x> => x !== null);
@@ -167,7 +182,7 @@ export function ResultPage({ result, onGoHome, onRetry }: ResultPageProps) {
       totalQuestions: answers.length,
       totalTime,
       wrongQuestions: wrongAnswers.map((a) => {
-        const q = getQuestionById(a.questionId);
+        const q = lookupQuestion(a.questionId);
         return {
           questionId: a.questionId,
           stem: q?.stem ?? '',
@@ -299,7 +314,7 @@ export function ResultPage({ result, onGoHome, onRetry }: ResultPageProps) {
 
           <div className="wrong-list">
             {wrongAnswers.map((answer, index) => {
-              const question = getQuestionById(answer.questionId);
+              const question = lookupQuestion(answer.questionId);
               if (!question) return null;
 
               const qid = question.id;
@@ -344,6 +359,25 @@ export function ResultPage({ result, onGoHome, onRetry }: ResultPageProps) {
                         <strong className="text-success">{answer.correctAnswer}</strong>
                       </span>
                     </div>
+
+                    {question.explanation && (
+                      <section className="wrong-explanation" aria-label="題庫解析">
+                        <div className="wrong-explanation__header">
+                          <span className="material-icons sm" aria-hidden="true">
+                            menu_book
+                          </span>
+                          <span>題庫解析</span>
+                        </div>
+                        {question.explanation
+                          .split(PARAGRAPH_BREAK)
+                          .filter((para) => para.trim())
+                          .map((para, i) => (
+                            <p key={i} className="wrong-explanation__body">
+                              {para}
+                            </p>
+                          ))}
+                      </section>
+                    )}
 
                     <AnswerEvidence evidence={question.evidence} compact />
 

--- a/quiz-app/src/pages/ResultPage.tsx
+++ b/quiz-app/src/pages/ResultPage.tsx
@@ -400,11 +400,8 @@ export function ResultPage({ result, onGoHome, onRetry }: ResultPageProps) {
                           <div className="ai-response-header-inline">
                             <span className="material-icons sm">smart_toy</span>
                             <span>AI 解析</span>
-                            {aiResponse.confidence > 0 && (
-                              <span className="confidence-inline">
-                                信心度 {Math.round(aiResponse.confidence * 100)}%
-                              </span>
-                            )}
+                            {/* 不再顯示憑空生成的信心度百分比（見 ai-helper 的 AIResponse 註解） */}
+                            <span className="confidence-inline">未經人工審核</span>
                           </div>
                           {aiResponse.success ? (
                             <div className="ai-content">

--- a/quiz-app/src/pages/ResultPage.tsx
+++ b/quiz-app/src/pages/ResultPage.tsx
@@ -473,9 +473,12 @@ export function ResultPage({ result, onGoHome, onRetry }: ResultPageProps) {
                           <div className="ai-response-header-inline">
                             <span className="material-icons sm">auto_awesome</span>
                             <span>AI 生成的相似題</span>
-                            {generatedQ.confidence > 0 && generatedQ.confidence < 0.7 && (
-                              <span className="confidence-warning">低信心度</span>
-                            )}
+                            {/* 先前這裡用 confidence < 0.7 條件式顯示「低信心度」。
+                                那個分數是 estimateConfidence() 依回覆長度與關鍵詞加減出來的，
+                                與答案對不對無關（ai-helper 的 AIResponse 註解已寫明不對使用者
+                                呈現）。條件式顯示更糟：沒出現徽章等於暗示「這題信心高」，
+                                而我們沒有任何依據講這句話。改為與 AI 解析路徑一致的無條件揭露。 */}
+                            <span className="confidence-inline">未經人工審核</span>
                           </div>
                           {generatedQ.success ? (
                             <div className="ai-content generated-content">

--- a/quiz-app/src/types/quiz.ts
+++ b/quiz-app/src/types/quiz.ts
@@ -241,6 +241,15 @@ export interface QuizResult {
   endTime: number;
   totalTime: number;
   answers: AnswerRecord[];
+  /**
+   * 當次測驗實際出過的題目快照。
+   *
+   * 為什麼要帶：結果頁原本用 getQuestionById() 反查，而那個索引只由**主題庫**組成 ——
+   * 練習池題查不到就整張錯題卡 `return null`，題幹、正解、解析、來源、回報連結全部消失，
+   * 匯出的 stem 也會是空字串。帶快照同時解決另一個問題：部署後題庫內容若變動，
+   * 結果頁顯示的仍是作答當下那一版。
+   */
+  questions: QuizQuestion[];
   score: number;
   totalAnswerable: number;
   correctCount: number;

--- a/quiz-app/src/types/quiz.ts
+++ b/quiz-app/src/types/quiz.ts
@@ -140,7 +140,14 @@ export interface QuizQuestion {
   stem: string;
   options: QuizOption[];
   answer: string | null;
-  subject: ExamSubject;
+  /**
+   * 未能對應到考科時為 null。
+   *
+   * 這裡刻意允許 null：先前為了滿足 strict type 而 fallback 成 '考科2'，
+   * 結果 154 題練習池裡有 83 題 subject 是 null，全部被靜默算進考科二 ——
+   * 抽題池與備考統計都會被污染。單科篩選用 === 比較，null 自然被排除。
+   */
+  subject: ExamSubject | null;
   sourceType: 'gist' | 'unique' | 'practice_pool';
   year?: number | null;
   hasAnswer: boolean;

--- a/quiz-app/src/utils/ai-helper.ts
+++ b/quiz-app/src/utils/ai-helper.ts
@@ -292,6 +292,14 @@ async function runPuterAuth(): Promise<PuterAuthResult> {
 export interface AIResponse {
   success: boolean;
   content: string;
+  /**
+   * **這不是校準過的信心度，不要顯示成百分比。**
+   *
+   * 它是 estimateConfidence() 依「回覆長度、有沒有出現 A/B、命中幾個關鍵詞」加減出來的
+   * 啟發式分數 —— 與答案是否正確、是否符合一手來源、有沒有捏造條號，全都沒有關係。
+   * 先前 UI 把它渲染成「信心度 85%」，那是一個看起來精確、實際上憑空生成的數字。
+   * 現在只保留作為內部門檻（低於門檻時在內容尾端附上提醒），不對使用者呈現數值。
+   */
   confidence: number;
   error?: string;
 }

--- a/quiz-app/src/utils/practice-pool.test.ts
+++ b/quiz-app/src/utils/practice-pool.test.ts
@@ -176,3 +176,41 @@ describe('loadPracticePool (lazy)', () => {
     }
   });
 });
+
+describe('adapter 不得竄改或丟棄資料', () => {
+  it('subject 無法對應時維持 null，不冒充考科二', () => {
+    // 實際資料裡 154 題練習池有 83 題 subject 是 null；
+    // 先前為了滿足 strict type 而 fallback 成 '考科2'，等於把「不知道」寫成「考科二」，
+    // 抽題池與備考統計都會被污染。
+    const q = toQuizQuestion(baseItem({ subject: null }));
+    expect(q.subject).toBeNull();
+    expect(q.qualityFlags).toContain('unmapped_subject');
+  });
+
+  it('無法辨識的自由字串也不冒充考科二', () => {
+    const q = toQuizQuestion(baseItem({ subject: '未分類' }));
+    expect(q.subject).toBeNull();
+    expect(q.qualityFlags).toContain('unmapped_subject');
+  });
+
+  it('null subject 不會被算進任何單科池', () => {
+    const items = [
+      toQuizQuestion(baseItem({ id: 'a', subject: null })),
+      toQuizQuestion(baseItem({ id: 'b', subject: '考科2' })),
+    ];
+    expect(items.filter((q) => q.subject === '考科2').map((q) => q.id)).toEqual(['b']);
+    expect(items.filter((q) => q.subject === '考科1')).toHaveLength(0);
+  });
+
+  it('人工審核過的解析必須帶得出來', () => {
+    // 154 題練習池全部有解析，先前在 adapter 被丟掉，
+    // 使用者只能改按 AI 重猜一次。
+    const q = toQuizQuestion(baseItem({ explanation: '人工審核解析' }));
+    expect(q.explanation).toBe('人工審核解析');
+  });
+
+  it('沒有解析時為 null，不是 undefined', () => {
+    const q = toQuizQuestion(baseItem({ explanation: undefined }));
+    expect(q.explanation).toBeNull();
+  });
+});

--- a/quiz-app/src/utils/practice-pool.test.ts
+++ b/quiz-app/src/utils/practice-pool.test.ts
@@ -178,6 +178,30 @@ describe('loadPracticePool (lazy)', () => {
 });
 
 describe('adapter 不得竄改或丟棄資料', () => {
+  // 這個題庫滿是 ISO 14064-1 / 14068-1，而 subject 值本來就是「考科X：<主題敘述>」的形狀。
+  // 舊解析是 raw.includes('1')，於是標準編號裡的 1 會蓋掉「考科二」——
+  // 而且分類錯的題照樣出得來，沒有任何人會發現。
+  it('標準編號裡的數字不會蓋掉考科（考科二：ISO 14064-1 …）', () => {
+    const q = toQuizQuestion(baseItem({ subject: '考科二：ISO 14064-1 盤查規範' }));
+    expect(q.subject).toBe('考科2');
+  });
+
+  it('考科一：ISO 14068-2 之類反向情形也不會被吃掉', () => {
+    const q = toQuizQuestion(baseItem({ subject: '考科一：ISO 14068-2 概論' }));
+    expect(q.subject).toBe('考科1');
+  });
+
+  it('不存在的考科編號不亂猜（考科10 → null + unmapped_subject）', () => {
+    const q = toQuizQuestion(baseItem({ subject: '考科10' }));
+    expect(q.subject).toBeNull();
+    expect(q.qualityFlags).toContain('unmapped_subject');
+  });
+
+  it('英文寫法 Subject 2 仍可辨識', () => {
+    const q = toQuizQuestion(baseItem({ subject: 'Subject 2 — inventory' }));
+    expect(q.subject).toBe('考科2');
+  });
+
   it('subject 無法對應時維持 null，不冒充考科二', () => {
     // 實際資料裡 154 題練習池有 83 題 subject 是 null；
     // 先前為了滿足 strict type 而 fallback 成 '考科2'，等於把「不知道」寫成「考科二」，

--- a/quiz-app/src/utils/practice-pool.ts
+++ b/quiz-app/src/utils/practice-pool.ts
@@ -101,6 +101,27 @@ export function randomSample<T>(items: T[], n: number, rng?: () => number): T[] 
   return shuffle(items, rng).slice(0, n);
 }
 
+/**
+ * 從自由字串解析考科。只認「考科」後面緊跟的那一個字，不掃整串。
+ *
+ * 先前是 `raw.includes('1')`：只要字串裡任何位置出現 1 就判考科一。
+ * 這個題庫滿是 ISO 14064-1 / 14068-1，而現有的 subject 值本來就長成
+ * 「考科二：淨零碳盤查規範與程序概要」這種「考科X：<主題敘述>」的形狀 ——
+ * 於是「考科二：ISO 14064-1 盤查」會被判成考科一。今天的資料剛好沒有這種值，
+ * 但寫成這樣等於在等它發生，而且錯了不會有人發現（分類錯的題照樣出得來）。
+ *
+ * 認不出來時回 null（呼叫端會標 unmapped_subject），不猜 —— 明說「不知道」
+ * 比猜錯好，這也是先前拿掉 `?? '考科2'` fallback 的同一個判準。
+ */
+function parseSubject(raw: string): QuizQuestion['subject'] | null {
+  // 後面不接數字：擋掉「考科10」被前綴比對吃成考科一
+  const zh = raw.match(/考科\s*[:：]?\s*([12一二])(?![0-9])/);
+  if (zh) return /[1一]/.test(zh[1]) ? '考科1' : '考科2';
+  const en = raw.toLowerCase().match(/subject\s*([12])(?![0-9])/);
+  if (en) return en[1] === '1' ? '考科1' : '考科2';
+  return null;
+}
+
 /** 把 PracticePoolItem 轉成 QuizQuestion 形狀 */
 export function toQuizQuestion(item: PracticePoolItem): QuizQuestion & {
   provenance: PracticePoolItem['provenance'];
@@ -108,12 +129,7 @@ export function toQuizQuestion(item: PracticePoolItem): QuizQuestion & {
   sources: string[];
 } {
   const raw = typeof item.subject === 'string' ? item.subject : '';
-  let subject: QuizQuestion['subject'] | null = null;
-  if (raw.includes('1') || raw.includes('一') || raw.toLowerCase().includes('subject 1')) {
-    subject = '考科1';
-  } else if (raw.includes('2') || raw.includes('二') || raw.toLowerCase().includes('subject 2')) {
-    subject = '考科2';
-  }
+  const subject = parseSubject(raw);
 
   // subject 無法映射時加 quality flag，並讓 subject 維持 null。
   // 先前為了滿足 strict type 而 fallback 成 '考科2'，等於把「不知道」寫成「考科二」。

--- a/quiz-app/src/utils/practice-pool.ts
+++ b/quiz-app/src/utils/practice-pool.ts
@@ -115,9 +115,8 @@ export function toQuizQuestion(item: PracticePoolItem): QuizQuestion & {
     subject = '考科2';
   }
 
-  // subject 無法映射時加 quality flag — caller 可在 subject 篩選排除
-  // 預設 fallback 為 '考科2' 純為滿足 QuizQuestion strict subject type；
-  // 真正的「未分類」資訊在 qualityFlags 中
+  // subject 無法映射時加 quality flag，並讓 subject 維持 null。
+  // 先前為了滿足 strict type 而 fallback 成 '考科2'，等於把「不知道」寫成「考科二」。
   const qualityFlags = subject === null
     ? [...(item.quality_flags ?? []), 'unmapped_subject' as const]
     : item.quality_flags;
@@ -131,7 +130,10 @@ export function toQuizQuestion(item: PracticePoolItem): QuizQuestion & {
     stem: item.stem,
     options: item.options,
     answer: item.answer,
-    subject: subject ?? '考科2',
+    // 人工審核過的解析先前在這裡被丟掉：154 題練習池全部有解析，卻一則都傳不出去，
+    // 使用者只能改按 AI 重猜一次。
+    explanation: item.explanation ?? null,
+    subject,
     sourceType: 'practice_pool',
     year: null,
     hasAnswer: item.answer != null,

--- a/quiz-app/src/utils/subject-label.test.ts
+++ b/quiz-app/src/utils/subject-label.test.ts
@@ -1,0 +1,30 @@
+// 未分類就顯示「待分類」——先前 UI 一律 `=== '考科1' ? '考科一' : '考科二'`，
+// 於是練習池 154 題裡的 83 題 null 全被顯示成考科二。
+import { describe, it, expect } from 'vitest';
+import { subjectClass, subjectLabel } from './subject-label';
+
+describe('subjectLabel', () => {
+  it.each([
+    ['考科1', '考科一'],
+    ['考科2', '考科二'],
+  ] as const)('%s → %s', (input, expected) => {
+    expect(subjectLabel(input)).toBe(expected);
+  });
+
+  it.each([null, undefined])('未分類（%s）不冒充任何一科', (input) => {
+    expect(subjectLabel(input)).toBe('待分類');
+  });
+});
+
+describe('subjectClass', () => {
+  it.each([
+    ['考科1', 'subject-1'],
+    ['考科2', 'subject-2'],
+  ] as const)('%s → %s', (input, expected) => {
+    expect(subjectClass(input)).toBe(expected);
+  });
+
+  it.each([null, undefined])('未分類（%s）有自己的 class，不套用任一科的配色', (input) => {
+    expect(subjectClass(input)).toBe('subject-unmapped');
+  });
+});

--- a/quiz-app/src/utils/subject-label.ts
+++ b/quiz-app/src/utils/subject-label.ts
@@ -1,0 +1,17 @@
+// 考科標籤：未分類就顯示「待分類」，不要冒充考科二。
+//
+// 這支存在的原因：先前 UI 一律寫 `subject === '考科1' ? '考科一' : '考科二'`，
+// 於是所有 null 與無法辨識的值都被顯示成考科二 —— 而練習池 154 題裡有 83 題是 null。
+import type { ExamSubject } from '../types/quiz';
+
+export function subjectLabel(subject: ExamSubject | null | undefined): string {
+  if (subject === '考科1') return '考科一';
+  if (subject === '考科2') return '考科二';
+  return '待分類';
+}
+
+export function subjectClass(subject: ExamSubject | null | undefined): string {
+  if (subject === '考科1') return 'subject-1';
+  if (subject === '考科2') return 'subject-2';
+  return 'subject-unmapped';
+}

--- a/quiz-app/tests/e2e/ai-feature.spec.ts
+++ b/quiz-app/tests/e2e/ai-feature.spec.ts
@@ -44,7 +44,10 @@ test.describe('AI 解析功能', () => {
     // 應看到 AI 解析按鈕
     const aiButton = page.locator('.ai-explain-btn');
     await expect(aiButton).toBeVisible({ timeout: 5000 });
-    await expect(aiButton).toContainText('AI 解析');
+    // 按鈕文字刻意標明未經人工審核（見 PR #120）：人工解析已直接顯示在題目下方，
+    // AI 只是延伸說明，不該讓使用者以為它跟題庫解析同等份量。
+    await expect(aiButton).toContainText('AI 延伸說明');
+    await expect(aiButton).toContainText('未經人工審核');
   });
 
   test('點擊 AI 解析後應顯示載入狀態', async ({ page }) => {


### PR DESCRIPTION
外部複審指出的執行期問題，四項**全部查證屬實**，而且影響比描述的更大。

## 1. AI 回覆可造成 DOM XSS（安全性）

`renderMarkdown()` **完全沒有 escape**，輸出卻直接進 `dangerouslySetInnerHTML`，而輸入來自**第三方 AI 服務**。模型只要回 `<img src=x onerror=...>`，那段 HTML 就會被瀏覽器當成標籤執行。

修法：先做 HTML 實體逸出再套 markdown。逸出後唯一會出現在輸出裡的標籤，只有本函式自己插入的 `strong`／`em`／`code`，粗體與行內程式碼功能不受影響。

**mutation 驗過**：拿掉 escape，四個惡意輸入（`img/onerror`、`script`、`javascript:` 連結、`onclick`）全部失守。

## 2. 918 則人工解析從未顯示

| 題庫 | 有解析 | 先前顯示 |
|---|---:|---|
| 主題庫 | 764 / 781 | 從未 |
| 練習池 | 154 / 154 | 從未 |

畫面上只有一顆「AI 解析」按鈕——**等於讓未經審核的生成內容，取代通過反捏造閘門的內容**。

修法：新增「題庫解析」區塊，順序固定為 **答案 → 題庫解析 → 答案依據 → 參考來源 → AI 延伸說明**；AI 按鈕改標「AI 延伸說明（未經人工審核）」。

搬動時我的測試當場抓到一個自造缺陷：把答案依據移出 `showAnswer` 後會在**作答前劇透**，已修正並保留該測試。

## 3. `subject` 為 null 被冒充成考科二

`toQuizQuestion()` 為了滿足 strict type 寫 `subject ?? '考科2'`。實測：**練習池 154 題裡有 83 題 `subject` 是 null**，全部被靜默算進考科二——抽題池與備考統計都被污染。

修法：`QuizQuestion.subject` 型別改為 `ExamSubject | null`，未對應就維持 null 並標 `unmapped_subject`；UI 顯示「**待分類**」而非冒充任何一科。單科篩選用 `===` 比較，null 自然被排除。

## 4. 練習池人工解析在 adapter 被丟掉

`PracticePoolItem` 有 `explanation`，`toQuizQuestion()` 卻沒帶出來，使用者只能改按 AI 重猜一次。一行修好，並補測試釘住。

## 驗證

- 新增 `security-and-explanation.test.tsx` 十條、`practice-pool.test.ts` 補五條。
- **851 測試綠**、build 綠、tsc 綠、lint 乾淨、a11y-contrast e2e 綠。
- rendered 驗證：作答前不顯示任何依據；作答後 DOM 順序為 `curated-explanation → answer-evidence → question-sources → ai-section`，對比 7.03／18.75。

## 這份複審的其他部分

複審以 `8be3195` 為準、稱「PR #118 尚未合併」，但 **#118／#119 已於稍早合併**（main 現為 `b2046af`），因此其 P0-1（`gist[64]` CBAM）與 P0-2（`S_VOCUS_03-q004` 精密度）**已完成**。

其餘題目層級的指控（`gist[301]` 太陽 CO₂、`gist[140]`／`gist[296]` CCTS/CORSIA 雙正解、`gist[489]` GWP 25 版本、`S_CHU_06-q094` 答案卡衝突等）尚未逐題查證，屬另一批工作。
