### PR TITLE
把「這題能不能計分」收斂成單一判斷，並釘住兩個不變量

### DIFF
--- a/quiz-app/src/components/SourceBadge/SourceBadge.tsx
+++ b/quiz-app/src/components/SourceBadge/SourceBadge.tsx
@@ -18,7 +18,11 @@
 // 而 EU AI Act Art.50 的立法目的正好相反。
 // 文案改成：說清楚「哪些是機器可驗證的」「哪些不是」。
 import './SourceBadge.css';
-import type { PracticePoolSourceType, PracticePoolQualityFlag } from '../../types/practicePool';
+import type {
+  PracticePoolSourceType,
+  PracticePoolQualityFlag,
+  DataQualityFlag,
+} from '../../types/practicePool';
 
 interface SourceBadgeProps {
   sourceType: PracticePoolSourceType;
@@ -32,10 +36,22 @@ const SOURCE_LABEL: Record<PracticePoolSourceType, { text: string; icon: string;
   ai_generated: { text: 'AI 產題', icon: 'auto_awesome', tone: 'ai' },
 };
 
-const FLAG_LABEL: Partial<Record<PracticePoolQualityFlag, string>> = {
+// 對**資料層詞彙**窮舉（Record 而非 Partial<Record>）—— 這是刻意的：
+// 詞彙新增一個旗標卻忘了給說明，tsc 會當場擋下，而不是讓它在畫面上安靜消失。
+// 先前是 Partial 且只寫了三個，於是 duplicate_topic 與所有失效型旗標
+// （disputed / retired 等）標了等於沒標：題目離開計分池，使用者卻看不到任何說明。
+// runtime-only 的 unmapped_subject 刻意不在這裡 —— 它是內部推導的分類狀態，
+// 不是題目品質問題，不該對使用者出徽章。
+const FLAG_LABEL: Record<DataQualityFlag, string> = {
   time_sensitive: '時效',
-  ambiguous: '爭議',
   low_confidence: '低信心',
+  duplicate_topic: '主題重複',
+  ambiguous: '爭議',
+  disputed: '題目有爭議',
+  disputed_answer: '答案有爭議',
+  multiple_correct: '多重正解',
+  unverifiable_evidence: '依據待查證',
+  retired: '已退場',
 };
 
 export function SourceBadge({ sourceType, qualityFlags = [], compact = false }: SourceBadgeProps) {

--- a/quiz-app/src/components/SourceBanner/SourceBanner.tsx
+++ b/quiz-app/src/components/SourceBanner/SourceBanner.tsx
@@ -11,7 +11,11 @@
 //    2026-07 拿法條逐字比對，找到 13 個實質缺陷，**13 個當初全都被判 CONFIRMED**。
 //    一句假的保證比沒有保證更糟。詳見 SourceBadge.tsx 開頭。
 // - 帶 quality_flag：紅邊警示
-import type { PracticePoolSourceType, PracticePoolQualityFlag } from '../../types/practicePool';
+import type {
+  PracticePoolSourceType,
+  PracticePoolQualityFlag,
+  DataQualityFlag,
+} from '../../types/practicePool';
 import './SourceBanner.css';
 
 interface SourceBannerProps {
@@ -42,10 +46,19 @@ const SOURCE_META: Record<
   },
 };
 
-const FLAG_HINT: Partial<Record<PracticePoolQualityFlag, string>> = {
+// 同 SourceBadge：對資料層詞彙窮舉，漏掉一個就編不過。
+// 失效型旗標一律說明「已不列入計分」—— 使用者看到一題沒有標準答案時，
+// 至少知道那是我們刻意撤下的，而不是壞掉。
+const FLAG_HINT: Record<DataQualityFlag, string> = {
   time_sensitive: '時效性 — 答案會隨時間變動（如 RE100 名單），建議查最新官方資料',
-  ambiguous: '爭議 — 不同教材可能給出不同答案，請參考多方來源',
   low_confidence: '低信心 — 產題當下自評信心較低，務必自行查證',
+  duplicate_topic: '主題重複 — 與其他題目考點重疊，僅供多練一次',
+  ambiguous: '爭議 — 不同教材可能給出不同答案，本題已不列入計分',
+  disputed: '題目有爭議 — 題目本身的成立性有疑義，本題已不列入計分',
+  disputed_answer: '答案有爭議 — 各來源對正解不一致，本題已不列入計分',
+  multiple_correct: '多重正解 — 不只一個選項成立，本題已不列入計分',
+  unverifiable_evidence: '依據待查證 — 目前找不到站得住的一手依據，本題已不列入計分',
+  retired: '已退場 — 題目已過時或被取代，本題已不列入計分',
 };
 
 export function SourceBanner({

--- a/quiz-app/src/data/questions.test.ts
+++ b/quiz-app/src/data/questions.test.ts
@@ -1,5 +1,6 @@
 // 題庫資料模組測試
 import { describe, it, expect } from 'vitest';
+import { isQuestionScorable } from '../utils/scorable';
 import {
   stats,
   allQuestions,
@@ -119,8 +120,22 @@ describe('題庫資料模組', () => {
   });
 
   describe('questionsWithAnswer', () => {
-    it('有答案題目數應等於 stats.withAnswer', () => {
-      expect(questionsWithAnswer.length).toBe(stats.withAnswer);
+    // meta.with_answer 的定義是「有答案」（tools/sync_derived_counts.py 只看 answer 真值），
+    // 而 questionsWithAnswer 現在的定義是「可計分」＝有答案且不帶阻斷旗標。
+    // 今天兩者相等（主題庫無阻斷旗標），但直接斷言相等，會在有人第一次把某題標成
+    // disputed 時炸出一條看不懂的失敗 —— 而且他重跑 sync_derived_counts.py 也修不好，
+    // 因為那支工具算的是另一個量。所以把兩者的關係寫明白。
+    it('可計分題數 = 有答案題數 − 帶阻斷旗標的題數', () => {
+      // 刻意跟「實算」對，不跟 meta.with_answer 對：meta 是由 sync_derived_counts.py
+      // 產生的，資料剛改完但還沒重跑時它是舊的 —— 拿它當基準會讓這條測試在
+      // 「你只是還沒 sync」的時候紅，訊息卻在講可計分數，把人指向錯的地方。
+      // meta 與資料的對帳由 dataset-integrity 的 meta.with_answer 那條負責。
+      const answered = allQuestions.filter((q) => q.answer).length;
+      const blockedButAnswered = allQuestions.filter(
+        (q) => q.answer && !isQuestionScorable(q)
+      );
+      expect(questionsWithAnswer.length).toBe(answered - blockedButAnswered.length);
+      expect(questionsWithAnswer.length).toBeLessThanOrEqual(answered);
     });
 
     it('所有有答案的題目 hasAnswer 應為 true', () => {

--- a/quiz-app/src/data/questions.ts
+++ b/quiz-app/src/data/questions.ts
@@ -9,6 +9,7 @@ import type {
   UniqueQuestion,
   ExamSubject,
 } from '../types/quiz';
+import { isQuestionScorable } from '../utils/scorable';
 
 // 載入原始資料（build 時會被 Vite 處理）
 import rawData from './integrated_dataset.json';
@@ -115,6 +116,9 @@ function convertGistQuestion(q: GistQuestion): QuizQuestion {
     sourceType: 'gist',
     year: null,
     hasAnswer: q.answer !== null,
+    // 主題庫 raw data 有 quality_flags，先前沒帶進 runtime ——
+    // 於是題目標了 ambiguous 也永遠到不了 isQuestionScorable()。
+    qualityFlags: q.quality_flags ?? [],
     sources: collectSources(q),
     evidence: pickEvidence(q),
     explanation: q.explanation,
@@ -134,6 +138,9 @@ function convertUniqueQuestion(q: UniqueQuestion): QuizQuestion {
     sourceType: 'unique',
     year: q.year,
     hasAnswer: q.answer !== null,
+    // 主題庫 raw data 有 quality_flags，先前沒帶進 runtime ——
+    // 於是題目標了 ambiguous 也永遠到不了 isQuestionScorable()。
+    qualityFlags: q.quality_flags ?? [],
     sources: collectSources(q),
     evidence: pickEvidence(q),
     explanation: q.explanation ?? undefined,
@@ -157,7 +164,7 @@ export const subject2Questions = allQuestions.filter(
 );
 
 /** 有答案的題目 */
-export const questionsWithAnswer = allQuestions.filter((q) => q.hasAnswer);
+export const questionsWithAnswer = allQuestions.filter((q) => isQuestionScorable(q));
 
 /**
  * 依據考科取得題目
@@ -199,7 +206,7 @@ export function getRandomQuestions(
 ): QuizQuestion[] {
   let pool = dedupeByContent(getQuestionsBySubject(subject));
   if (onlyWithAnswer) {
-    pool = pool.filter((q) => q.hasAnswer);
+    pool = pool.filter((q) => isQuestionScorable(q));
   }
 
   // Fisher-Yates 洗牌演算法
@@ -223,7 +230,7 @@ export function getRandomQuestionsFromPool(
   let filtered = dedupeByContent(
     subject === 'all' ? pool : pool.filter((q) => q.subject === subject)
   );
-  if (onlyWithAnswer) filtered = filtered.filter((q) => q.hasAnswer);
+  if (onlyWithAnswer) filtered = filtered.filter((q) => isQuestionScorable(q));
   const shuffled = [...filtered];
   for (let i = shuffled.length - 1; i > 0; i--) {
     const j = Math.floor(Math.random() * (i + 1));
@@ -279,7 +286,7 @@ export function getSimilarQuestions(
   // 排除無標準答案的題（answer=null，已排除計分）—— 相似題是給使用者對照作答用的，
   // 出一題「沒有正解可對」的相似題只會困惑（同 useQuiz 抽題層的處理，Refs #93/#94/#95）。
   const scored = allQuestions
-    .filter((q) => q.id !== questionId && q.hasAnswer)
+    .filter((q) => q.id !== questionId && isQuestionScorable(q))
     .map((q) => {
       let score = 0;
       // 同考科加分

--- a/quiz-app/src/hooks/useQuiz.ts
+++ b/quiz-app/src/hooks/useQuiz.ts
@@ -1,5 +1,6 @@
 // 測驗邏輯 Hook
 import { useState, useCallback, useMemo, useEffect } from 'react';
+import { isQuestionScorable } from '../utils/scorable';
 import type {
   QuizQuestion,
   QuizConfig,
@@ -83,7 +84,7 @@ export function useQuiz() {
       // 順序取題（同樣依內容去重：跨科重複在 'all' 模式下會同時落進池子）
       // 同樣濾掉無答案題。
       const pool = dedupeByContent(getQuestionsBySubject(config.subject)).filter(
-        (q) => q.hasAnswer
+        (q) => isQuestionScorable(q)
       );
       questions = pool.slice(0, config.questionCount);
     }
@@ -131,7 +132,7 @@ export function useQuiz() {
               config.subject === 'all'
                 ? combined
                 : combined.filter((q) => q.subject === config.subject);
-            const answerFiltered = subjectFiltered.filter((q) => q.hasAnswer);
+            const answerFiltered = subjectFiltered.filter((q) => isQuestionScorable(q));
             return answerFiltered.slice(0, config.questionCount);
           })();
     } else {
@@ -145,7 +146,7 @@ export function useQuiz() {
       } else {
         const subjectFiltered = dedupeByContent(
           getQuestionsBySubject(config.subject)
-        ).filter((q) => q.hasAnswer);
+        ).filter((q) => isQuestionScorable(q));
         questions = subjectFiltered.slice(0, config.questionCount);
       }
     }
@@ -267,7 +268,7 @@ export function useQuiz() {
     const wrongCount = answeredWithCorrectAnswer.filter(
       (a) => a.isCorrect === false
     ).length;
-    const totalAnswerable = questions.filter((q) => q.hasAnswer).length;
+    const totalAnswerable = questions.filter((q) => isQuestionScorable(q)).length;
 
     const result: QuizResult = {
       config,
@@ -330,7 +331,7 @@ export function useQuiz() {
     // 本次修正前存下的進度可能含無答案題（answer=null，排除計分），而進度永不過期，
     // 之後任何時間續作都會遇到。續作時一併濾掉，讓「使用者不遇到無答案題」的保證
     // 對舊進度也成立（Refs #93/#94/#95）。
-    const answerable = s.questions.filter((q) => q.hasAnswer);
+    const answerable = s.questions.filter((q) => isQuestionScorable(q));
     if (answerable.length === 0) {
       // 整份都是無答案題（極端）→ 沒有可續的題目，清掉舊進度、不續作。
       clearProgress();

--- a/quiz-app/src/types/practicePool.ts
+++ b/quiz-app/src/types/practicePool.ts
@@ -57,14 +57,46 @@ export type PracticePoolProvenance =
       ai_metadata: AIMetadata;
     });
 
-/** UI 渲染徽章用的 quality flags */
-export type PracticePoolQualityFlag =
-  | 'time_sensitive'
-  | 'ambiguous'
-  | 'low_confidence'
-  | 'duplicate_topic'
-  /** subject 無法明確映射時設此 flag；filter 時可排除 */
-  | 'unmapped_subject';
+/**
+ * 提示型旗標：內容有需要留意之處，但答案仍站得住 —— **照常計分**，UI 出徽章提醒。
+ */
+export const ADVISORY_QUALITY_FLAGS = [
+  'time_sensitive',
+  'low_confidence',
+  'duplicate_topic',
+] as const;
+
+/**
+ * 失效型旗標：這題目前給不出唯一且站得住的答案 —— **一律不計分**（見 utils/scorable.ts）。
+ *
+ * 這份清單同時是資料檔的合法值與計分的阻斷條件，兩者必須是同一份 ——
+ * 先前 schema 白名單只認 4 個旗標，而 scorable 阻斷 6 個，交集只有 ambiguous。
+ * 結果是：照著「標上旗標就自動離開計分池」去標 disputed，schema 會判該題非法、CI 直接紅。
+ */
+export const BLOCKING_QUALITY_FLAGS = [
+  'ambiguous',
+  'disputed',
+  'disputed_answer',
+  'multiple_correct',
+  'unverifiable_evidence',
+  'retired',
+] as const;
+
+/** 資料檔（practice_pool.json / integrated_dataset.json）裡可以出現的旗標 */
+export const DATA_QUALITY_FLAGS = [
+  ...ADVISORY_QUALITY_FLAGS,
+  ...BLOCKING_QUALITY_FLAGS,
+] as const;
+export type DataQualityFlag = (typeof DATA_QUALITY_FLAGS)[number];
+
+/**
+ * 只在 runtime 產生、資料檔不會有的旗標。
+ * subject 無法明確映射時由 toQuizQuestion 注入；filter 時可排除。
+ */
+export type RuntimeOnlyQualityFlag = 'unmapped_subject';
+
+/** UI 渲染徽章用的 quality flags（資料檔的 + runtime 才有的） */
+export type PracticePoolQualityFlag = DataQualityFlag | RuntimeOnlyQualityFlag;
 
 /** 練習池 subject 可能值：official ExamSubject、自由字串（如 vocus 講師原文「考科一：…」）、或 null（無分類） */
 export type PracticePoolSubject = ExamSubject | string | null;
@@ -83,7 +115,8 @@ export interface PracticePoolItem {
   provenance: PracticePoolProvenance;
   /** Curl 實測通過的引用 URL */
   sources: string[];
-  quality_flags: PracticePoolQualityFlag[];
+  /** 資料檔旗標；runtime-only 的 unmapped_subject 不會出現在這裡 */
+  quality_flags: DataQualityFlag[];
 }
 
 /** 練習池檔案頂層 */

--- a/quiz-app/src/utils/__fixtures__/practice-pool-fixture.ts
+++ b/quiz-app/src/utils/__fixtures__/practice-pool-fixture.ts
@@ -104,10 +104,11 @@ export function buildFixturePool(): PracticePool {
         ai_metadata: aiMeta,
       },
     }),
-    // unmapped subject → 取得 unmapped_subject flag
+    // unmapped subject → toQuizQuestion 注入 unmapped_subject flag。
+    // 這裡刻意不預先寫進 quality_flags：那個旗標是 runtime 推導出來的，
+    // 資料檔不存（practice-pool-counts.ts 的註解亦如此聲明），預寫等於在測一個不存在的輸入。
     item(5, {
       subject: null,
-      quality_flags: ['unmapped_subject'],
     }),
     // 無答案題 —— 模擬真實資料中「來源互相矛盾、刻意排除計分」的題目
     // （例：PAS 2060 撤回日期）。answer=null 必須同時標 ambiguous，

--- a/quiz-app/src/utils/practice-pool-schema.ts
+++ b/quiz-app/src/utils/practice-pool-schema.ts
@@ -8,8 +8,9 @@ import type {
   PracticePoolSourceType,
   PracticePoolDifficulty,
   PracticePoolVerdict,
-  PracticePoolQualityFlag,
+  DataQualityFlag,
 } from '../types/practicePool';
+import { DATA_QUALITY_FLAGS } from '../types/practicePool';
 // 與主題庫共用的完整性規則（四選一 A–D、答案存在且在選項內、無換行/PDF 頁首頁尾、
 // time_sensitive 必須有可驗證來源）。抽出來共用，兩個題庫才是同一把尺。
 import { checkQuestion } from './question-integrity';
@@ -25,12 +26,9 @@ const VERDICTS: ReadonlyArray<PracticePoolVerdict> = [
   'REFUTED',
   'DUPLICATE',
 ];
-const QUALITY_FLAGS: ReadonlyArray<PracticePoolQualityFlag> = [
-  'time_sensitive',
-  'ambiguous',
-  'low_confidence',
-  'duplicate_topic',
-];
+// 不再手抄一份 —— 白名單就是資料層詞彙本身（types/practicePool.ts）。
+// 手抄的那份漏了失效型旗標，等於資料檔不准標 disputed / retired 等。
+const QUALITY_FLAGS: ReadonlyArray<DataQualityFlag> = DATA_QUALITY_FLAGS;
 
 export interface ValidationError {
   path: string;

--- a/quiz-app/src/utils/practice-pool.ts
+++ b/quiz-app/src/utils/practice-pool.ts
@@ -6,6 +6,7 @@ import type {
   PracticePoolItem,
   PracticePoolSourceType,
   PracticePoolDifficulty,
+  PracticePoolQualityFlag,
 } from '../types/practicePool';
 import type { QuizQuestion } from '../types/quiz';
 
@@ -104,7 +105,8 @@ export function randomSample<T>(items: T[], n: number, rng?: () => number): T[] 
 /** 把 PracticePoolItem 轉成 QuizQuestion 形狀 */
 export function toQuizQuestion(item: PracticePoolItem): QuizQuestion & {
   provenance: PracticePoolItem['provenance'];
-  qualityFlags: PracticePoolItem['quality_flags'];
+  // runtime 形狀：除了資料檔旗標，還可能被注入 unmapped_subject
+  qualityFlags: PracticePoolQualityFlag[];
   sources: string[];
 } {
   const raw = typeof item.subject === 'string' ? item.subject : '';

--- a/quiz-app/src/utils/quality-flags.ts
+++ b/quiz-app/src/utils/quality-flags.ts
@@ -13,13 +13,11 @@
 // 「安靜地少報」。
 
 import { hasPrimarySource, hostOf } from './source-authority';
+import { DATA_QUALITY_FLAGS } from '../types/practicePool';
 
-export const KNOWN_FLAGS: ReadonlySet<string> = new Set([
-  'time_sensitive',
-  'ambiguous',
-  'low_confidence',
-  'duplicate_topic',
-]);
+// 詞彙不再手抄第四份 —— 這份原本漏了所有失效型旗標（disputed / retired 等），
+// 於是把某題標成 disputed 會被判「未知的 flag」，而不是離開計分池。
+export const KNOWN_FLAGS: ReadonlySet<string> = new Set(DATA_QUALITY_FLAGS);
 
 /** 兩個題庫都能映射到的最小形狀。 */
 export interface FlaggedItem {

--- a/quiz-app/src/utils/question-integrity.ts
+++ b/quiz-app/src/utils/question-integrity.ts
@@ -11,12 +11,14 @@
 // 這些規則對現有資料是零破壞的（主題庫 783 題 + 練習池 157 題全數通過），
 // 所以可以當成硬性 gate 而非警告。
 
+import { BLOCKING_QUALITY_FLAGS } from '../types/practicePool';
+
 /** 兩個題庫都能映射到的最小共同形狀 */
 export interface IntegrityQuestion {
   id: string;
   stem: string;
   options: { key: string; text: string }[];
-  /** null 代表刻意不給答案（必須同時標 'ambiguous'，見下方規則） */
+  /** null 代表刻意不給答案（必須同時標任一失效型旗標，見下方規則） */
   answer: string | null | undefined;
   qualityFlags: string[];
   /** 所有可驗證的來源 URL（主題庫取 source.url + metadata.sources；練習池取 sources） */
@@ -76,15 +78,25 @@ export function checkQuestion(q: IntegrityQuestion): Violation[] {
     push('options_shape', `期望 A,B,C,D，實際 [${keys.join(',')}]`);
   }
 
-  // 2) 答案必須落在選項裡。唯一例外：明確標 'ambiguous' 的題目「必須」沒有答案
+  // 2) 答案必須落在選項裡。唯一例外：標了失效型旗標的題目「必須」沒有答案
   //    —— 題庫不能對互斥命題同時給出確定答案；標了瑕疵卻照常計分是最糟的組合。
-  const ambiguous = q.qualityFlags.includes('ambiguous');
+  //
+  //    先前這裡只認 'ambiguous' 一個字面值，而失效型旗標有六個。後果是：
+  //    把一題標成 disputed 並撤下答案（完全正確的做法），會被判 missing_answer，
+  //    逼人再補標一個 ambiguous 才過關 —— 又一次「規則只守了一半」。
+  //    規則 id 維持不變（測試與文件引用它），只是把條件擴到整個失效型家族。
+  const blocking = q.qualityFlags.some((f) =>
+    (BLOCKING_QUALITY_FLAGS as readonly string[]).includes(f)
+  );
   const hasAnswer = q.answer !== null && q.answer !== undefined && q.answer !== '';
-  if (ambiguous && hasAnswer) {
-    push('ambiguous_must_have_no_answer', `標了 ambiguous 卻仍有答案 ${q.answer}`);
+  if (blocking && hasAnswer) {
+    push(
+      'ambiguous_must_have_no_answer',
+      `標了失效型旗標（${q.qualityFlags.join('、')}）卻仍有答案 ${q.answer}`
+    );
   }
-  if (!ambiguous && !hasAnswer) {
-    push('missing_answer', '沒有答案，且未標 ambiguous');
+  if (!blocking && !hasAnswer) {
+    push('missing_answer', '沒有答案，且未標任何失效型旗標');
   }
   if (hasAnswer && !keys.includes(q.answer as string)) {
     push('answer_not_in_options', `answer=${q.answer}，選項只有 [${keys.join(',')}]`);

--- a/quiz-app/src/utils/scorable.test.ts
+++ b/quiz-app/src/utils/scorable.test.ts
@@ -3,6 +3,11 @@ import { describe, it, expect } from 'vitest';
 import { isQuestionScorable, whyNotScorable, SCORE_BLOCKING_FLAGS } from './scorable';
 import dataset from '../data/integrated_dataset.json';
 import pool from '../data/practice_pool.json';
+import type { QuizQuestion } from '../types/quiz';
+import type { PracticePoolQualityFlag } from '../types/practicePool';
+import { ADVISORY_QUALITY_FLAGS } from '../types/practicePool';
+import { validatePracticePool } from './practice-pool-schema';
+import { toQuizQuestion } from './practice-pool';
 
 describe('isQuestionScorable', () => {
   it('有答案且無阻斷旗標 → 可計分', () => {
@@ -102,7 +107,8 @@ describe('抽題 helper 必須真的排除不可計分的題（行為測試）',
   // 一題 answer='A' + ambiguous 仍可能進考卷，而分母把它排除 → 分數可能超過 100。
   it('getRandomQuestionsFromPool 不會回傳「有答案但帶阻斷旗標」的題', async () => {
     const { getRandomQuestionsFromPool } = await import('../data/questions');
-    const mk = (id: string, flags: string[] = []) => ({
+    // 標註成 QuizQuestion：fixture 自己就受真型別檢查，避免造出一個現實中不存在的形狀
+    const mk = (id: string, flags: PracticePoolQualityFlag[] = []): QuizQuestion => ({
       id,
       stem: `題幹 ${id}`,
       options: [
@@ -149,5 +155,40 @@ describe('抽題 helper 必須真的排除不可計分的題（行為測試）',
     expect(questionsWithAnswer.every((q) => isQuestionScorable(q))).toBe(true);
     expect(questionsWithAnswer.length).toBeLessThanOrEqual(allQuestions.length);
     expect(questionsWithAnswer.length).toBeGreaterThan(700);
+  });
+});
+
+// 這一組是本檔最重要的守門：阻斷旗標必須「標得下去」，而且「標了真的會離開計分池」。
+//
+// 為什麼：SCORE_BLOCKING_FLAGS 原本是在 scorable.ts 手寫的第二份清單，而資料檔的合法值
+// 由 practice-pool-schema 的另一份白名單決定 —— 兩份的交集只有 ambiguous。
+// 也就是說，照本模組宣稱的用法把一題標成 disputed，schema 會判該題非法、CI 直接紅：
+// 這個承諾對 6 個旗標中的 5 個根本不成立。單測 isQuestionScorable() 永遠驗不到這件事，
+// 因為它只吃自己造的物件、繞過了資料層。
+describe('阻斷旗標必須在資料層可用（不是只有 predicate 認得）', () => {
+  const sample = (pool as { items: unknown[] }).items[0] as Record<string, unknown>;
+
+  it.each([...SCORE_BLOCKING_FLAGS])('practice_pool schema 接受阻斷旗標 %s', (flag) => {
+    const doc = { ...(pool as object), items: [{ ...sample, quality_flags: [flag] }] };
+    const flagErrors = validatePracticePool(doc).filter((e) =>
+      e.path.includes('quality_flags')
+    );
+    expect(
+      flagErrors,
+      `schema 不接受 ${flag} —— 標上它會讓該題被判非法，而不是離開計分池`
+    ).toEqual([]);
+  });
+
+  it.each([...SCORE_BLOCKING_FLAGS])(
+    '帶 %s 的池題經 toQuizQuestion 後不可計分',
+    (flag) => {
+      const item = { ...sample, quality_flags: [flag] } as Parameters<typeof toQuizQuestion>[0];
+      expect(isQuestionScorable(toQuizQuestion(item))).toBe(false);
+    }
+  );
+
+  it.each([...ADVISORY_QUALITY_FLAGS])('帶 %s 的池題仍可計分（提示型旗標不阻斷）', (flag) => {
+    const item = { ...sample, quality_flags: [flag] } as Parameters<typeof toQuizQuestion>[0];
+    expect(isQuestionScorable(toQuizQuestion(item))).toBe(true);
   });
 });

--- a/quiz-app/src/utils/scorable.test.ts
+++ b/quiz-app/src/utils/scorable.test.ts
@@ -94,3 +94,60 @@ describe('計分路徑必須走同一支判斷', () => {
     expect(src).toContain('isQuestionScorable');
   });
 });
+
+describe('抽題 helper 必須真的排除不可計分的題（行為測試）', () => {
+  // 先前只有一條掃 useQuiz.ts 原始碼的 static gate —— 它剛好漏掉真正做過濾的
+  // questions.ts helpers（#96 把 hasAnswer 邏輯集中到那裡）。
+  // 結果是 gate 全綠，但預設的隨機抽題路徑仍走舊判斷：
+  // 一題 answer='A' + ambiguous 仍可能進考卷，而分母把它排除 → 分數可能超過 100。
+  it('getRandomQuestionsFromPool 不會回傳「有答案但帶阻斷旗標」的題', async () => {
+    const { getRandomQuestionsFromPool } = await import('../data/questions');
+    const mk = (id: string, flags: string[] = []) => ({
+      id,
+      stem: `題幹 ${id}`,
+      options: [
+        { key: 'A', text: '甲' },
+        { key: 'B', text: '乙' },
+      ],
+      answer: 'A',
+      subject: '考科1' as const,
+      sourceType: 'gist' as const,
+      year: null,
+      hasAnswer: true,
+      qualityFlags: flags,
+    });
+    const pool = [
+      mk('ok-1'),
+      mk('ok-2'),
+      mk('blocked-1', ['ambiguous']),
+      mk('blocked-2', ['retired']),
+      mk('advisory', ['time_sensitive']),
+    ];
+    const picked = getRandomQuestionsFromPool(pool, 10, 'all', true);
+    const ids = picked.map((q) => q.id);
+    expect(ids).not.toContain('blocked-1');
+    expect(ids).not.toContain('blocked-2');
+    // time_sensitive 只是提醒，不該被排除
+    expect(ids).toContain('advisory');
+    expect(ids.length).toBe(3);
+  });
+
+  it('主題庫的 quality_flags 一路帶到 runtime（converter 先前把它丟掉）', async () => {
+    const { allQuestions } = await import('../data/questions');
+    const flagged = allQuestions.filter(
+      (q) => (q.qualityFlags ?? []).length > 0
+    );
+    expect(
+      flagged.length,
+      '主題庫 raw data 有 quality_flags，但 runtime 一題都沒有 —— converter 又把它丟了'
+    ).toBeGreaterThan(100);
+    expect(flagged.some((q) => (q.qualityFlags ?? []).includes('time_sensitive'))).toBe(true);
+  });
+
+  it('全庫的可計分題都通過 predicate（分母與抽題同一口徑）', async () => {
+    const { questionsWithAnswer, allQuestions } = await import('../data/questions');
+    expect(questionsWithAnswer.every((q) => isQuestionScorable(q))).toBe(true);
+    expect(questionsWithAnswer.length).toBeLessThanOrEqual(allQuestions.length);
+    expect(questionsWithAnswer.length).toBeGreaterThan(700);
+  });
+});

--- a/quiz-app/src/utils/scorable.test.ts
+++ b/quiz-app/src/utils/scorable.test.ts
@@ -1,0 +1,96 @@
+// 「能不能計分」的單一定義，以及全庫的不變量。
+import { describe, it, expect } from 'vitest';
+import { isQuestionScorable, whyNotScorable, SCORE_BLOCKING_FLAGS } from './scorable';
+import dataset from '../data/integrated_dataset.json';
+import pool from '../data/practice_pool.json';
+
+describe('isQuestionScorable', () => {
+  it('有答案且無阻斷旗標 → 可計分', () => {
+    expect(isQuestionScorable({ answer: 'A' })).toBe(true);
+    expect(isQuestionScorable({ answer: 'A', qualityFlags: ['time_sensitive'] })).toBe(true);
+    // low_confidence 是練習池的品質提示（UI 已有徽章），不是「答案失效」
+    expect(isQuestionScorable({ answer: 'A', qualityFlags: ['low_confidence'] })).toBe(true);
+  });
+
+  it('沒有答案 → 不可計分', () => {
+    expect(isQuestionScorable({ answer: null })).toBe(false);
+    expect(isQuestionScorable({ answer: undefined })).toBe(false);
+    expect(isQuestionScorable({ hasAnswer: false, answer: 'A' })).toBe(false);
+    expect(whyNotScorable({ answer: null })).toContain('沒有標準答案');
+  });
+
+  it.each(SCORE_BLOCKING_FLAGS)('帶 %s 旗標 → 即使有答案也不可計分', (flag) => {
+    expect(isQuestionScorable({ answer: 'A', qualityFlags: [flag] })).toBe(false);
+    expect(whyNotScorable({ answer: 'A', qualityFlags: [flag] })).toContain(flag);
+  });
+
+  it('多個旗標時，只要有一個是阻斷旗標就不可計分', () => {
+    expect(
+      isQuestionScorable({ answer: 'A', qualityFlags: ['time_sensitive', 'ambiguous'] })
+    ).toBe(false);
+  });
+});
+
+describe('全庫不變量：不得有「被判爭議卻仍可計分」的題目', () => {
+  interface Item {
+    index?: number;
+    item_id?: string;
+    id?: string;
+    answer?: string | null;
+    quality_flags?: string[];
+  }
+  const ds = dataset as unknown as { gist_items: Item[]; our_unique_items: Item[] };
+  const pp = pool as unknown as { items: Item[] };
+  const all: Item[] = [...ds.gist_items, ...ds.our_unique_items, ...pp.items];
+  const who = (it: Item) => it.item_id ?? it.id ?? `gist-${it.index}`;
+
+  it('母體夠大（這條 gate 不能空轉）', () => {
+    expect(all.length).toBeGreaterThan(900);
+  });
+
+  it('帶阻斷旗標的題目，答案必須已被撤下（answer=null）', () => {
+    // 先前這裡寫成「先用 isQuestionScorable 過濾、再看有沒有阻斷旗標」——
+    // 帶旗標的題早就被第一道過濾掉，bad 永遠是空陣列，是一條空轉的 gate。
+    // 真正該釘的是**資料層的一致性**：既然標了旗標代表我們無法背書這個答案，
+    // 答案就該被撤下；否則哪天有人改了 predicate，答案又會悄悄回到計分池。
+    const bad = all
+      .filter((it) =>
+        (it.quality_flags ?? []).some((f) =>
+          (SCORE_BLOCKING_FLAGS as readonly string[]).includes(f)
+        )
+      )
+      .filter((it) => it.answer !== null && it.answer !== undefined)
+      .map((it) => `${who(it)}（旗標：${(it.quality_flags ?? []).join('、')}，答案仍為 ${it.answer}）`);
+    expect(bad, '這些題目被標了爭議旗標，答案卻沒有撤下').toEqual([]);
+  });
+
+  it('沒有答案的題目一律不可計分', () => {
+    const bad = all
+      .filter((it) => it.answer === null || it.answer === undefined)
+      .filter((it) => isQuestionScorable({ answer: it.answer, qualityFlags: it.quality_flags }))
+      .map(who);
+    expect(bad).toEqual([]);
+  });
+});
+
+describe('計分路徑必須走同一支判斷', () => {
+  it('useQuiz 不得自己 inline 過濾 hasAnswer', async () => {
+    // 抽題、分母、統計散落五處。只要有人新增一種旗標卻漏改其中一處，
+    // 就會出現「考試模式排除了、練習模式卻出現」這種不一致。
+    const fs = await import('node:fs');
+    const path = await import('node:path');
+    const src = fs.readFileSync(
+      path.join(process.cwd(), 'src/hooks/useQuiz.ts'),
+      'utf8'
+    );
+    const inlined = src
+      .split('\n')
+      .map((line, i) => ({ line: line.trim(), no: i + 1 }))
+      .filter(({ line }) => /\.filter\([^)]*\.hasAnswer|=>\s*q\.hasAnswer/.test(line));
+    expect(
+      inlined.map(({ no, line }) => `useQuiz.ts:${no}  ${line}`),
+      '這些地方直接用 hasAnswer 過濾，請改用 isQuestionScorable()'
+    ).toEqual([]);
+    expect(src).toContain('isQuestionScorable');
+  });
+});

--- a/quiz-app/src/utils/scorable.test.tsx
+++ b/quiz-app/src/utils/scorable.test.tsx
@@ -192,3 +192,32 @@ describe('阻斷旗標必須在資料層可用（不是只有 predicate 認得�
     expect(isQuestionScorable(toQuizQuestion(item))).toBe(true);
   });
 });
+
+// 「離開計分池」如果使用者看不見，那只做完一半。
+//
+// 標了 disputed 的題目答案會被撤下（見上面的資料層不變量），於是畫面上會出現
+// 一題沒有標準答案的題目。若徽章與提示都不提它，使用者只會覺得「這題壞了」。
+// 兩張說明表都對資料層詞彙窮舉（Record 而非 Partial<Record>），tsc 會強制新旗標補說明；
+// 這裡再從**渲染結果**確認一次 —— 型別窮舉保證鍵存在，不保證它真的被畫出來。
+describe('失效型旗標必須在畫面上說得出來', () => {
+  it.each([...SCORE_BLOCKING_FLAGS])('SourceBadge 會顯示 %s 的徽章', async (flag) => {
+    const { render, screen, cleanup } = await import('@testing-library/react');
+    const { SourceBadge } = await import('../components/SourceBadge/SourceBadge');
+    cleanup();
+    render(
+      <SourceBadge sourceType="ai_generated" qualityFlags={[flag]} />
+    );
+    const chip = document.querySelector(`.flag-${flag}`);
+    expect(chip, `${flag} 沒有渲染出徽章 —— 題目離開計分池了，使用者卻看不到原因`).not.toBeNull();
+    expect(chip?.textContent?.trim().length ?? 0).toBeGreaterThan(0);
+    expect(screen).toBeTruthy();
+  });
+
+  it.each([...SCORE_BLOCKING_FLAGS])('SourceBanner 的 %s 提示會說明不列入計分', async (flag) => {
+    const { render, screen, cleanup } = await import('@testing-library/react');
+    const { SourceBanner } = await import('../components/SourceBanner/SourceBanner');
+    cleanup();
+    render(<SourceBanner sourceType="ai_generated" qualityFlags={[flag]} sourceCount={1} />);
+    expect(screen.getByText(/不列入計分/)).toBeInTheDocument();
+  });
+});

--- a/quiz-app/src/utils/scorable.ts
+++ b/quiz-app/src/utils/scorable.ts
@@ -36,18 +36,28 @@ export interface ScorableQuestion {
 
 /** 這題是否可以進入計分（抽題、分母、對錯判定都用這一支）。 */
 export function isQuestionScorable(question: ScorableQuestion): boolean {
-  const hasAnswer =
-    question.hasAnswer ?? (question.answer !== null && question.answer !== undefined);
-  if (!hasAnswer) return false;
-  return !(question.qualityFlags ?? []).some((flag) => BLOCKING.has(flag));
+  // 兩個方向的矛盾狀態都要擋掉：先前只擋 hasAnswer:false + answer:'A'，
+  // 卻放行 hasAnswer:true + answer:null —— 那種資料在舊 localStorage 很容易出現。
+  const hasUsableAnswer =
+    question.answer !== null &&
+    question.answer !== undefined &&
+    question.hasAnswer !== false;
+  if (!hasUsableAnswer) return false;
+  // 壞掉的儲存資料可能讓 qualityFlags 不是陣列（例如舊格式存成字串），
+  // 直接 .some() 會在 resume 時 throw。
+  const flags = Array.isArray(question.qualityFlags) ? question.qualityFlags : [];
+  return !flags.some((flag) => BLOCKING.has(flag));
 }
 
 /** 這題為什麼不能計分（給 gate 與除錯用的可讀理由）。 */
 export function whyNotScorable(question: ScorableQuestion): string | null {
   if (isQuestionScorable(question)) return null;
-  const hasAnswer =
-    question.hasAnswer ?? (question.answer !== null && question.answer !== undefined);
-  if (!hasAnswer) return '沒有標準答案';
-  const hit = (question.qualityFlags ?? []).filter((flag) => BLOCKING.has(flag));
+  const hasUsableAnswer =
+    question.answer !== null &&
+    question.answer !== undefined &&
+    question.hasAnswer !== false;
+  if (!hasUsableAnswer) return '沒有標準答案';
+  const flags = Array.isArray(question.qualityFlags) ? question.qualityFlags : [];
+  const hit = flags.filter((flag) => BLOCKING.has(flag));
   return `帶有不可計分旗標：${hit.join('、')}`;
 }

--- a/quiz-app/src/utils/scorable.ts
+++ b/quiz-app/src/utils/scorable.ts
@@ -1,0 +1,53 @@
+// 「這題能不能計分」只能有一個定義。
+//
+// 起因：抽題、作答、計分分母、錯題匯出、統計各自寫 `q.hasAnswer`。今天五處一致，
+// 但只要有人新增一種「這題有問題」的旗標而漏改其中一處，就會出現
+// 「考試模式排除了、練習模式卻出現」或「分母排除了、錯題匯出仍判錯」這種不一致。
+//
+// 現況（2026-08-27）：兩個題庫都沒有 answer=null，也沒有任何爭議類旗標 ——
+// 所以這支現在的行為與 `q.hasAnswer` 完全相同。它存在是為了讓**下一次**有題目被判爭議時，
+// 標上旗標就自動離開計分池，而不必依賴某個人記得同時把答案撤掉。
+
+/**
+ * 帶這些旗標的題目一律不計分。
+ *
+ * 判準：旗標代表「這題目前無法給出唯一且站得住的答案」。
+ * `time_sensitive`（內容會過期，但現在是對的）與 `low_confidence`
+ * （練習池的品質提示，UI 已有徽章）**不在此列** —— 它們是提醒，不是失效。
+ */
+export const SCORE_BLOCKING_FLAGS = [
+  'ambiguous',
+  'disputed',
+  'disputed_answer',
+  'multiple_correct',
+  'unverifiable_evidence',
+  'retired',
+] as const;
+
+export type ScoreBlockingFlag = (typeof SCORE_BLOCKING_FLAGS)[number];
+
+const BLOCKING = new Set<string>(SCORE_BLOCKING_FLAGS);
+
+export interface ScorableQuestion {
+  answer?: string | null;
+  hasAnswer?: boolean;
+  qualityFlags?: string[];
+}
+
+/** 這題是否可以進入計分（抽題、分母、對錯判定都用這一支）。 */
+export function isQuestionScorable(question: ScorableQuestion): boolean {
+  const hasAnswer =
+    question.hasAnswer ?? (question.answer !== null && question.answer !== undefined);
+  if (!hasAnswer) return false;
+  return !(question.qualityFlags ?? []).some((flag) => BLOCKING.has(flag));
+}
+
+/** 這題為什麼不能計分（給 gate 與除錯用的可讀理由）。 */
+export function whyNotScorable(question: ScorableQuestion): string | null {
+  if (isQuestionScorable(question)) return null;
+  const hasAnswer =
+    question.hasAnswer ?? (question.answer !== null && question.answer !== undefined);
+  if (!hasAnswer) return '沒有標準答案';
+  const hit = (question.qualityFlags ?? []).filter((flag) => BLOCKING.has(flag));
+  return `帶有不可計分旗標：${hit.join('、')}`;
+}

--- a/quiz-app/src/utils/scorable.ts
+++ b/quiz-app/src/utils/scorable.ts
@@ -8,6 +8,8 @@
 // 所以這支現在的行為與 `q.hasAnswer` 完全相同。它存在是為了讓**下一次**有題目被判爭議時，
 // 標上旗標就自動離開計分池，而不必依賴某個人記得同時把答案撤掉。
 
+import { BLOCKING_QUALITY_FLAGS } from '../types/practicePool';
+
 /**
  * 帶這些旗標的題目一律不計分。
  *
@@ -15,14 +17,7 @@
  * `time_sensitive`（內容會過期，但現在是對的）與 `low_confidence`
  * （練習池的品質提示，UI 已有徽章）**不在此列** —— 它們是提醒，不是失效。
  */
-export const SCORE_BLOCKING_FLAGS = [
-  'ambiguous',
-  'disputed',
-  'disputed_answer',
-  'multiple_correct',
-  'unverifiable_evidence',
-  'retired',
-] as const;
+export const SCORE_BLOCKING_FLAGS = BLOCKING_QUALITY_FLAGS;
 
 export type ScoreBlockingFlag = (typeof SCORE_BLOCKING_FLAGS)[number];
 


### PR DESCRIPTION
## 問題

抽題、分母、統計原本各自寫 `q.hasAnswer`（**五處**）。今天五處一致，但只要有人新增一種「這題有問題」的旗標而漏改其中一處，就會出現「考試模式排除了、練習模式卻出現」或「分母排除了、錯題匯出仍判錯」——而使用者看到的是**自己答對卻被判錯**。

## 做法

`utils/scorable.ts` 的 `isQuestionScorable()` 同時看兩件事：有沒有答案、有沒有阻斷旗標。

| 旗標 | 是否阻斷計分 | 理由 |
|---|---|---|
| `ambiguous`／`disputed`／`disputed_answer`／`multiple_correct`／`unverifiable_evidence`／`retired` | **是** | 代表我們無法背書這個答案 |
| `time_sensitive` | 否 | 內容會過期，但現在是對的 |
| `low_confidence`／`duplicate_topic` | 否 | 品質提示，UI 已有徽章 |

## 複審後追加：這個 PR 原本的核心宣稱是假的

CI 的 tsc 先擋下測試 fixture 的型別，順著追下去發現旗標詞彙散在**四份互不相干的手抄清單**：

| 位置 | 內容 | 用途 |
|---|---|---|
| `types/practicePool.ts` | 5 個（含 runtime-only） | 型別 union |
| `utils/practice-pool-schema.ts` | 4 個 | 資料檔白名單 |
| `utils/quality-flags.ts` | 4 個 | 兩庫共用的 flag 規則 |
| `utils/scorable.ts` | 6 個 | 計分阻斷 |

前三份與第四份的**交集只有 `ambiguous`**。也就是說本 PR 寫的「標上旗標就自動離開計分池」，對 6 個旗標中的 5 個根本不成立。實測把主題庫某題標成 `disputed`：

```
× 未知的 flag「disputed」                                         （quality-flags）
× must be array of time_sensitive|ambiguous|low_confidence|duplicate_topic （schema）
× missing_answer：沒有答案，且未標 ambiguous                      （question-integrity）
```

三條都在說「這個旗標不存在」，把人指向錯的方向。原本的單元測試驗不到，因為它只吃自己造的物件、繞過了資料層。

### 改法

詞彙只留一份，在 `types/practicePool.ts` 分成兩類：

- `ADVISORY_QUALITY_FLAGS` —— 提示型，照常計分
- `BLOCKING_QUALITY_FLAGS` —— 失效型，不計分
- `DATA_QUALITY_FLAGS` = 兩者聯集，即資料檔的合法值

schema 白名單、`KNOWN_FLAGS`、`SCORE_BLOCKING_FLAGS` 全部改為引用它。`question-integrity` 的 `missing_answer` / `ambiguous_must_have_no_answer` 條件擴到整個失效型家族（規則 id 不動，測試與文件引用它）。

順帶分清楚資料層與 runtime 兩種形狀：`unmapped_subject` 是 `toQuizQuestion` 推導出來的、資料檔不存，所以 `PracticePoolItem.quality_flags` 收斂為 `DataQualityFlag[]`，`QuizQuestion.qualityFlags` 才是含 runtime-only 的完整 union。

### 實測前後對照

同一個動作（主題庫某題標 `disputed` + 撤下答案 + 拆掉 `evidence.supports_option`）：

- **改前**：三條「這個旗標不存在」
- **改後**：只剩「meta 統計與實際題數一致」一條，指向 `tools/sync_derived_counts.py` —— 那正是該做的下一步

## 現況：零行為變更

兩個題庫**都沒有 `answer=null`，也沒有任何失效型旗標**（旗標分布只有 `time_sensitive` 196、`low_confidence` 3）。這支現在的行為與 `hasAnswer` 完全相同。

需要誠實說明的是：repo 既有慣例是「失效型旗標 ⇒ 答案必須撤下」（原本只對 `ambiguous` 成立，本 PR 擴到整個家族），所以資料層上旗標分支確實碰不到 —— 它真正守的是**不重讀 JSON 的路徑**，也就是舊 localStorage 進度快照裡那些「當初有答案、現在已被判爭議」的題目。

## Gate（皆經 mutation 驗證）

1. **資料層**：帶阻斷旗標的題目，答案必須已被撤下。
2. **原始碼層**：`useQuiz` 不得再自己 inline 過濾 `hasAnswer`。
3. **跨層**（本次追加）：每個阻斷旗標都必須被 practice_pool schema 接受；帶阻斷旗標的池題經 `toQuizQuestion` 後必不可計分；帶提示旗標的仍可計分。
   mutation：白名單改回手抄的 4 個 → 正好 5 條轉紅。
4. 可計分數不變量改成跟**實算**對，不跟 `meta.with_answer` 對 —— 後者是 `sync_derived_counts.py` 產生的，資料剛改完還沒重跑時它是舊值，會讓測試在「你只是還沒 sync」時轉紅、訊息卻在講可計分數。

> 第一版我把 gate 1 寫成「先用 `isQuestionScorable` 過濾、再看有沒有旗標」——帶旗標的題早就被第一道濾掉，`bad` 永遠是空陣列，**是一條空轉的 gate**。自我複審時抓到並改掉。

867 測試綠、build 綠、tsc 綠、lint 乾淨。
