### PR TITLE
標準改版監控：ISO/FDIS 14068 將取代 14068-1:2023，把 15 題納入季排程視野

### DIFF
--- a/CONTENT-CURRENCY.md
+++ b/CONTENT-CURRENCY.md
@@ -13,7 +13,7 @@
 - 每題 → `metadata.valid_as_of` + `metadata.sources[]`（一手來源，quarterly workflow 會 curl）
 
 > **`meta.content_review.last_review_date`（本輪窗口起點 `2026-07-13`）不代表「整份題庫已查證到那一天」。**
-> 本輪只實查了 **132 / 781** 題（含 **2026-07-20** 補查的 IFRS/ISSB/TCFD 那批；已查主題見 `meta.content_review.scope`），
+> 本輪只實查了 **133 / 781** 題（含 **2026-07-20** 補查的 IFRS/ISSB/TCFD 那批；已查主題見 `meta.content_review.scope`），
 > 未查題數記於 `not_reviewed_this_round_count`。這些數字皆由 `tools/sync_derived_counts.py` 依公式算、由 gate 釘死在資料上；
 > **這裡不再內嵌會漂的快照（原本的「12 題沿用 2026-01-23」「668 題未標」已刪）。**
 >
@@ -42,7 +42,7 @@
 | 碳費 | — | 2026-05 首徵；一般 300 元，優惠 A 50 / B 100；高碳洩漏係數 0.2 | 環境部 |
 
 一手來源已掛進 `metadata.sources[]`（EUR-Lex 合併版 `02023R0956-20251020`、Omnibus `32025R2083`、
-環境部氣候變遷署、全國法規資料庫、ISO）。**132 題**標記 `time_sensitive`，其中 **112 題**有 source URL
+環境部氣候變遷署、全國法規資料庫、ISO）。**133 題**標記 `time_sensitive`，其中 **112 題**有 source URL
 —— 這點很重要：quarterly workflow **只看得到有 URL 的題目**，修正前 569 題中有 535 題（94 %）對它完全隱形。
 
 ---
@@ -230,3 +230,26 @@ Art 22(1) 原文：
 
 舊版用 `*)` catch-all 把 400/401/408/451/5xx/TLS/逾時全寫成 DEAD，而 issue 文案卻宣稱「只有 404/410/DNS 才算失效」—— 程式與說明不一致，就是在製造下一輪的喊狼來了。
 但**「內容再驗證」仍然只能靠人**（或一輪像這次的 LLM + 一手來源查證）。**排進行事曆，別等 workflow 提醒你。**
+
+## 標準改版監控：ISO/FDIS 14068 將取代 ISO 14068-1:2023
+
+**查核日：2026-08-27。現行有效版本仍是 ISO 14068-1:2023，題庫答案未因此改動。**
+
+ISO 目錄顯示 **ISO/FDIS 14068《Climate change management — Carbon neutrality》** 已進入
+approval 階段（FDIS＝最終國際標準草案），並載明將取代 ISO 14068-1:2023。
+
+這與「連結還通」是兩件事：季排程只 curl URL 看是否 200，**偵測不到標準改版**。
+新版發布時，下列各題涉及的要求、條號與用語都需要重新確認（共 15 題，皆已標 `time_sensitive`）：
+
+- 主題庫：`gist[24]`、`gist[72]`、`gist[78]`、`gist[109]`、`gist[137]`、`gist[147]`、
+  `gist[302]`、`gist[421]`、`gist[422]`、`gist[452]`、`gist[463]`
+- 練習池：`mock-007`、`mock-047`、`intl-019`、`intl_round1_rescued-intl-018`
+
+其中 `gist[452]`、`mock-047`、`intl-019` 先前**沒有標時效**，本次補標。
+
+**觸發條件**：ISO/FDIS 14068 正式發布（狀態由 FDIS 轉為 published）。屆時應逐題重驗，
+而不是只更新日期 —— 條號與用語若變動，題幹與解析都要跟著改。
+
+**刻意不做的事**：沒有把 `valid_as_of` 設成今天。今天只查證了「標準改版狀態」，
+並沒有逐題重驗這 15 題的內容；把日期改成今天等於宣稱已重驗，那是假的。
+

--- a/README.md
+++ b/README.md
@@ -484,12 +484,12 @@ CBAM、ISO 14068-1 屬**科目一**；**科目二只涵蓋 ISO 14064-1 與 ISO 1
 
 ## 內容時效性
 
-題庫中有 **132 題**的答案會隨法規變動（CBAM、碳費、NDC、碳中和標準）。
+題庫中有 **133 題**的答案會隨法規變動（CBAM、碳費、NDC、碳中和標準）。
 [`CONTENT-CURRENCY.md`](CONTENT-CURRENCY.md) 記錄已查證到哪一天、**還有什麼沒確定**、
 以及下一個到期日（最近的是 **2026-12-15：ISAE 3410 撤回，由 ISSA 5000 取代**）。
 
 `meta.content_review.last_review_date` **不代表整份題庫都查證到那一天** ——
-本輪只實查 **132 / 781** 題。判斷單一題目請看該題的 `metadata.valid_as_of`。
+本輪只實查 **133 / 781** 題。判斷單一題目請看該題的 `metadata.valid_as_of`。
 
 季排程 `quarterly-time-sensitive-verify` 現在做兩件事，但**能力範圍差很多**：
 

--- a/quiz-app/src/data/integrated_dataset.json
+++ b/quiz-app/src/data/integrated_dataset.json
@@ -26,10 +26,10 @@
         "carbon_neutrality",
         "ISSB_IFRS_TCFD"
       ],
-      "reverified_count": 132,
+      "reverified_count": 133,
       "total_questions": 781,
-      "time_sensitive_count": 132,
-      "not_reviewed_this_round_count": 649,
+      "time_sensitive_count": 133,
+      "not_reviewed_this_round_count": 648,
       "carried_over_count": 0,
       "known_unresolved": [
         {
@@ -24349,8 +24349,14 @@
             "verified_on": "2026-07-16",
             "sem_reverify": "第十八輪語意複核（代理判定＋我逐批抽樣複核）：引文語意釘得住現行答案"
           }
-        ]
-      }
+        ],
+        "standard_replacement_watch": "ISO/FDIS 14068（Climate change management — Carbon neutrality）已進入 approval 階段，將取代 ISO 14068-1:2023。新版發布時，本題涉及的要求與條號需重新確認。註：現行有效版本仍是 ISO 14068-1:2023，本題答案未因此改動。",
+        "valid_as_of": "2026-07-16",
+        "valid_as_of_basis": "採用本題 evidence 的 verified_on（第十八輪語意複核）作為內容查證日，而不是補標旗標的今天 —— 今天只查證了 ISO 標準的改版狀態，並未重驗本題內容。"
+      },
+      "quality_flags": [
+        "time_sensitive"
+      ]
     },
     {
       "index": 453,

--- a/quiz-app/src/data/practice_pool.json
+++ b/quiz-app/src/data/practice_pool.json
@@ -2874,7 +2874,10 @@
         "https://vocus.cc/article/6903fd65fd89780001a80f8b",
         "https://www.iso.org/standard/43279.html"
       ],
-      "quality_flags": []
+      "quality_flags": [
+        "time_sensitive"
+      ],
+      "_standard_replacement_watch": "ISO/FDIS 14068 已進入 approval 階段、將取代 ISO 14068-1:2023；新版發布時需重驗本題。現行有效版本仍是 2023 版，答案未改動。"
     },
     {
       "id": "pool-em-ipas_vocus_mock-048",
@@ -6809,7 +6812,10 @@
         "https://www.iso.org/standard/43279.html",
         "https://committee.iso.org/sites/tc207sc7/home/projects/published/iso-14068-1.html"
       ],
-      "quality_flags": []
+      "quality_flags": [
+        "time_sensitive"
+      ],
+      "_standard_replacement_watch": "ISO/FDIS 14068 已進入 approval 階段、將取代 ISO 14068-1:2023；新版發布時需重驗本題。現行有效版本仍是 2023 版，答案未改動。"
     },
     {
       "id": "pool-aig-intl-020",

--- a/quiz-app/src/data/standard-replacement-watch.test.ts
+++ b/quiz-app/src/data/standard-replacement-watch.test.ts
@@ -1,0 +1,51 @@
+// 標準改版偵測不到，只能靠標記。
+//
+// 季排程只 curl source URL 看是否 200 —— 它偵測不到「ISO 把標準改版了」。
+// ISO/FDIS 14068 已進入 approval 階段並將取代 ISO 14068-1:2023；新版發布時，
+// 這些題涉及的要求、條號與用語都要重新確認。至少要確保它們全部在季排程的視野內。
+import { describe, it, expect } from 'vitest';
+import dataset from './integrated_dataset.json';
+import pool from './practice_pool.json';
+
+interface Item {
+  index?: number;
+  item_id?: string;
+  id?: string;
+  stem: string;
+  options: { text: string }[];
+  explanation?: string | null;
+  quality_flags?: string[];
+}
+
+const ds = dataset as unknown as { gist_items: Item[]; our_unique_items: Item[] };
+const pp = pool as unknown as { items: Item[] };
+const ALL: Item[] = [...ds.gist_items, ...ds.our_unique_items, ...pp.items];
+const who = (it: Item) => it.item_id ?? it.id ?? `gist-${it.index}`;
+
+const text = (it: Item) =>
+  [it.stem, ...it.options.map((o) => o.text), it.explanation ?? ''].join(' ');
+
+/** 已知有改版在途、必須進入季排程視野的標準 */
+const PENDING_REPLACEMENT = [
+  { name: 'ISO 14068', pattern: /14068/, note: 'ISO/FDIS 14068 將取代 ISO 14068-1:2023' },
+];
+
+describe('改版在途的標準，相關題目必須標 time_sensitive', () => {
+  for (const std of PENDING_REPLACEMENT) {
+    const affected = ALL.filter((it) => std.pattern.test(text(it)));
+
+    it(`${std.name}：確實有相關題目（gate 不能空轉）`, () => {
+      expect(affected.length).toBeGreaterThan(5);
+    });
+
+    it(`${std.name}：每一題都在季排程視野內（${std.note}）`, () => {
+      const unflagged = affected
+        .filter((it) => !(it.quality_flags ?? []).includes('time_sensitive'))
+        .map(who);
+      expect(
+        unflagged,
+        `這些題目涉及改版在途的標準，卻沒標 time_sensitive —— 新版發布時不會有人回來看它們`
+      ).toEqual([]);
+    });
+  }
+});


### PR DESCRIPTION
## 問題

季排程只 `curl` source URL 看是否 200 —— **它偵測不到「標準被改版」**。而 ISO 目錄顯示 **ISO/FDIS 14068《Climate change management — Carbon neutrality》已進入 approval 階段（FDIS），並載明將取代 ISO 14068-1:2023**。

## 答案沒有改動

現行有效版本仍是 **ISO 14068-1:2023**。這個 PR 做的是：讓新版發布時，有人會回來看這些題。

| | |
|---|---|
| 題庫提及 ISO 14068 | **15 題** |
| 先前沒標時效 | `gist[452]`、`mock-047`、`intl-019` → 本次補標 |
| 觸發條件 | ISO/FDIS 14068 狀態由 FDIS 轉 published |
| 屆時要做的 | **逐題重驗條號與用語**，不是只更新日期 |

`CONTENT-CURRENCY.md` 新增「標準改版監控」段落，列出全部 15 題與觸發條件。

新增 `standard-replacement-watch.test.ts`：改版在途的標準，相關題目必須標 `time_sensitive`。**mutation 驗過**——拿掉任一題的旗標，gate 立刻指名該題轉紅。

## 刻意不做的事

**沒有把 `valid_as_of` 設成今天。** 今天只查證了標準的改版狀態，並未逐題重驗這 15 題的內容；把日期改成今天等於宣稱已重驗。

`gist[452]` 因 gate 要求 `time_sensitive` 必須有 `valid_as_of`，採用其 evidence 既有的 `verified_on`（2026-07-16）並在 `valid_as_of_basis` 註明依據。

## 順帶查證、但**未發現變動**的

| 法規 | 現行版本 | 複審宣稱的新條文 |
|---|---|---|
| 《碳費收費辦法》(O0020139) | 民國 113/08/29 發布 | **無**「第 3 條之 1」 |
| 《自主減量計畫管理辦法》(O0020140) | 民國 113/08/29 發布 | **無**「第 11 條之 1」 |

外部複審提到的「2026-08-06 預告修正」，在全國法規資料庫與環境部官方網域上都查不到對應內容。因此**不**依據一份查不到的草案去標註題目——那正是本 repo 禁止的無中生有。若日後該預告確實發布，`碳費收費辦法` 的 sha256 會在季排程對不上，CI 自然轉紅。

838 測試綠、build 綠、衍生計數已同步（`time_sensitive` 132→133）。
